### PR TITLE
Add extra mobile parameters for Prebid Server to handle

### DIFF
--- a/sdk/PrebidMobile.xcodeproj/project.pbxproj
+++ b/sdk/PrebidMobile.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		C281E1AD1EE5F2DA00F2F4A9 /* ANHTTPStubURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = C281E1A61EE5F2DA00F2F4A9 /* ANHTTPStubURLProtocol.m */; };
 		C281E1AE1EE5F2DA00F2F4A9 /* ANURLConnectionStub.m in Sources */ = {isa = PBXBuildFile; fileRef = C281E1A81EE5F2DA00F2F4A9 /* ANURLConnectionStub.m */; };
 		C281E1B21EE5F2E500F2F4A9 /* PBMockServerAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = C281E1B11EE5F2E500F2F4A9 /* PBMockServerAdapter.m */; };
+		C29238D91F3E38D100217075 /* PBServerAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C29238D81F3E38D100217075 /* PBServerAdapterTests.m */; };
 		C2B16E341EE1BEA6006304C0 /* PBBannerAdUnit.h in Headers */ = {isa = PBXBuildFile; fileRef = C2B16E261EE1BEA6006304C0 /* PBBannerAdUnit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C2B16E351EE1BEA6006304C0 /* PBBannerAdUnit.m in Sources */ = {isa = PBXBuildFile; fileRef = C2B16E271EE1BEA6006304C0 /* PBBannerAdUnit.m */; };
 		C2B16E361EE1BEA6006304C0 /* PBBidManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C2B16E281EE1BEA6006304C0 /* PBBidManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -108,6 +109,7 @@
 		C281E1A81EE5F2DA00F2F4A9 /* ANURLConnectionStub.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ANURLConnectionStub.m; sourceTree = "<group>"; };
 		C281E1B01EE5F2E500F2F4A9 /* PBMockServerAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBMockServerAdapter.h; sourceTree = "<group>"; };
 		C281E1B11EE5F2E500F2F4A9 /* PBMockServerAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBMockServerAdapter.m; sourceTree = "<group>"; };
+		C29238D81F3E38D100217075 /* PBServerAdapterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBServerAdapterTests.m; sourceTree = "<group>"; };
 		C2B16E1B1EE1BE69006304C0 /* PrebidMobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PrebidMobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C2B16E1F1EE1BE69006304C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C2B16E261EE1BEA6006304C0 /* PBBannerAdUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBBannerAdUnit.h; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 				C281E1951EE5F2AD00F2F4A9 /* PBBidManagerTests.m */,
 				C281E1961EE5F2AD00F2F4A9 /* PBBidResponseTests.m */,
 				C281E1981EE5F2AD00F2F4A9 /* PBTargetingParamsTests.m */,
+				C29238D81F3E38D100217075 /* PBServerAdapterTests.m */,
 			);
 			path = PrebidMobileCoreTests;
 			sourceTree = "<group>";
@@ -486,6 +489,7 @@
 				C281E1AD1EE5F2DA00F2F4A9 /* ANHTTPStubURLProtocol.m in Sources */,
 				C281E1B21EE5F2E500F2F4A9 /* PBMockServerAdapter.m in Sources */,
 				C281E19B1EE5F2AD00F2F4A9 /* PBBidResponseTests.m in Sources */,
+				C29238D91F3E38D100217075 /* PBServerAdapterTests.m in Sources */,
 				C281E19D1EE5F2AD00F2F4A9 /* PBTargetingParamsTests.m in Sources */,
 				C281E1991EE5F2AD00F2F4A9 /* PBAdUnitTests.m in Sources */,
 				C281E19A1EE5F2AD00F2F4A9 /* PBBidManagerTests.m in Sources */,

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBServerAdapterTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBServerAdapterTests.m
@@ -1,0 +1,85 @@
+/*   Copyright 2017 APPNEXUS INC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "PBServerAdapter.h"
+
+static NSString *const kPrebidMobileVersion = @"0.0.2";
+
+@interface PBServerAdapter (Testing)
+
+- (NSURLRequest *)buildRequestForAdUnits:(NSArray<PBAdUnit *> *)adUnits;
+- (NSDictionary *)requestBodyForAdUnits:(NSArray<PBAdUnit *> *)adUnits;
+
+@end
+
+@interface PBServerAdapterTests : XCTestCase
+
+@end
+
+@implementation PBServerAdapterTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testRequestBodyForAdUnit {
+    PBAdUnit *adUnit = [[PBAdUnit alloc] initWithIdentifier:@"test_identifier" andAdType:PBAdUnitTypeBanner andConfigId:@"test_config_id"];
+    [adUnit addSize:CGSizeMake(250, 300)];
+    NSArray *adUnits = @[adUnit];
+
+    PBServerAdapter *serverAdapter = [[PBServerAdapter alloc] initWithAccountId:@"test_account_id"];
+
+    NSDictionary *requestBody = [serverAdapter requestBodyForAdUnits:adUnits];
+
+    XCTAssertEqualObjects(requestBody[@"account_id"], @"test_account_id");
+    XCTAssertEqualObjects(requestBody[@"max_key_length"], @(20));
+    XCTAssertEqualObjects(requestBody[@"sort_bids"], @(1));
+    XCTAssertEqualObjects(requestBody[@"cache_markup"], @(1));
+
+    NSDictionary *app = requestBody[@"app"];
+    XCTAssertEqualObjects(app[@"ver"], kPrebidMobileVersion);
+
+    NSDictionary *sdk = requestBody[@"sdk"];
+    XCTAssertEqualObjects(sdk[@"version"], kPrebidMobileVersion);
+    XCTAssertEqualObjects(sdk[@"platform"], @"iOS");
+    XCTAssertEqualObjects(sdk[@"source"], @"prebid-mobile");
+
+    NSDictionary *device = requestBody[@"device"];
+    XCTAssertEqualObjects(device[@"os"], @"iOS");
+    XCTAssertEqualObjects(device[@"make"], @"Apple");
+
+    NSArray *requestAdUnits = requestBody[@"ad_units"];
+    NSDictionary *jsonAdUnit = (NSDictionary *)[requestAdUnits firstObject];
+    XCTAssertEqualObjects(jsonAdUnit[@"config_id"], @"test_config_id");
+    XCTAssertEqualObjects(jsonAdUnit[@"code"], @"test_identifier");
+    NSArray *sizesArray = jsonAdUnit[@"sizes"];
+    XCTAssertTrue([sizesArray count] == 1);
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end

--- a/sdk/PrebidServerAdapter/PBServerAdapter.m
+++ b/sdk/PrebidServerAdapter/PBServerAdapter.m
@@ -158,7 +158,7 @@ static NSString *const kPrebidMobileVersion = @"0.0.2";
             gender = @"F";
             break;
         default:
-            gender = @"0";
+            gender = @"O";
             break;
     }
     userDict[@"gender"] = gender;

--- a/sdk/PrebidServerAdapter/PBServerAdapter.m
+++ b/sdk/PrebidServerAdapter/PBServerAdapter.m
@@ -13,6 +13,12 @@
  limitations under the License.
  */
 
+#import <AdSupport/AdSupport.h>
+#import <CoreTelephony/CTCarrier.h>
+#import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#import <sys/utsname.h>
+#import <UIKit/UIKit.h>
+
 #import "PBBidResponse.h"
 #import "PBBidResponseDelegate.h"
 #import "PBLogging.h"
@@ -22,15 +28,10 @@
 #import "PBServerLocation.h"
 #import "PBServerReachability.h"
 #import "PBTargetingParams.h"
-#import <AdSupport/AdSupport.h>
-#import <CoreTelephony/CTCarrier.h>
-#import <CoreTelephony/CTTelephonyNetworkInfo.h>
-#import <UIKit/UIKit.h>
-#import <sys/utsname.h>
 
 static NSString *const kAPNAdServerResponseKeyNoBid = @"nobid";
 static NSString *const kAPNAdServerResponseKeyUUID = @"uuid";
-static NSString *const kPrebidMobileVersion = @"0.0.1";
+static NSString *const kPrebidMobileVersion = @"0.0.2";
 
 @interface PBServerAdapter ()
 
@@ -148,19 +149,19 @@ static NSString *const kPrebidMobileVersion = @"0.0.1";
     }
     
     PBTargetingParamsGender genderValue = [[PBTargetingParams sharedInstance] gender];
-    NSUInteger gender;
+    NSString *gender;
     switch (genderValue) {
         case PBTargetingParamsGenderMale:
-            gender = 1;
+            gender = @"M";
             break;
         case PBTargetingParamsGenderFemale:
-            gender = 2;
+            gender = @"F";
             break;
         default:
-            gender = 0;
+            gender = @"0";
             break;
     }
-    userDict[@"gender"] = @(gender);
+    userDict[@"gender"] = gender;
     
     NSString *language = [NSLocale preferredLanguages][0];
     if (language.length) {
@@ -203,6 +204,10 @@ static NSString *const kPrebidMobileVersion = @"0.0.1";
     }
     
     deviceDict[@"make"] = @"Apple";
+    deviceDict[@"os"] = @"iOS";
+    deviceDict[@"osv"] = [[UIDevice currentDevice] systemVersion];
+    deviceDict[@"h"] = @([[UIScreen mainScreen] bounds].size.height);
+    deviceDict[@"w"] = @([[UIScreen mainScreen] bounds].size.width);
     
     NSString *deviceModel = PBSDeviceModel();
     if (deviceModel) {
@@ -285,13 +290,13 @@ static NSString *const kPrebidMobileVersion = @"0.0.1";
 - (NSDictionary *)app {
     if ([[PBTargetingParams sharedInstance] itunesID] != nil) {
         NSString *itunesid = [[PBTargetingParams sharedInstance] itunesID];
-        return @{ @"appid": itunesid };
+        return @{ @"appid": itunesid, @"ver": kPrebidMobileVersion };
     } else {
         NSString *appId = [[NSBundle mainBundle] bundleIdentifier];
         if (appId == nil) {
             appId = @"";
         }
-        return @{ @"bundle": appId };
+        return @{ @"bundle": appId, @"ver": kPrebidMobileVersion };
     }
 }
 


### PR DESCRIPTION
This PR adds in device params and edits the user params to be OpenRTB compatible. It also updates the version for Prebid to be 0.0.2, which will be the version for release on Wednesday 8/16.

Unit tests included.

@anwzhang For Android, if we don't already pass strings for user gender, we need to edit the params to do so before release to be Open RTB compatible with the Prebid Server changes.