### PR TITLE
Add in separate env variables for integration tests 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: objective-c
 osx_image: xcode8
 env:
-- XAMARIN_DEVICES_ID_PR=9f82ba1c
-- XAMARIN_DEVICES_ID_CRON=67582786
+- XAMARIN_DEVICES_ID_PR=9f82ba1c XAMARIN_DEVICES_ID_CRON=67582786
 before_script: "./scripts/add-keys.sh"
 after_script: "./scripts/remove-key.sh"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: objective-c
 osx_image: xcode8
+env:
+- XAMARIN_DEVICES_ID_PR=9f82ba1c
+- XAMARIN_DEVICES_ID_CRON=67582786
 before_script: "./scripts/add-keys.sh"
 after_script: "./scripts/remove-key.sh"
 script:

--- a/scripts/testPrebidMobile.sh
+++ b/scripts/testPrebidMobile.sh
@@ -25,4 +25,9 @@ make ipa
 echo "Running integration tests"
 
 gem install xamarin-test-cloud
-test-cloud submit Products/ipa/PrebidMobileDemo.ipa 435c130f3f6ff5256d19a790c21dd653 --devices 9f82ba1c --series "master" --locale "en_US" --app-name "AppNexus.PrebidMobileDemo" --user nhedley@appnexus.com
+if [ "$TRAVIS_EVENT_TYPE" == "pull_request" ]; then
+test-cloud submit Products/ipa/PrebidMobileDemo.ipa 435c130f3f6ff5256d19a790c21dd653 --devices "$XAMARIN_DEVICES_ID_PR" --series "master" --locale "en_US" --app-name "AppNexus.PrebidMobileDemo" --user nhedley@appnexus.com
+fi
+if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+test-cloud submit Products/ipa/PrebidMobileDemo.ipa 435c130f3f6ff5256d19a790c21dd653 --devices "$XAMARIN_DEVICES_ID_CRON" --series "master" --locale "en_US" --app-name "AppNexus.PrebidMobileDemo" --user nhedley@appnexus.com
+fi


### PR DESCRIPTION
For PRs we want to run the integration tests only on one device to keep the build times at around 15 min. 

For cron jobs (run 1/week) we want to run on a larger suite of devices to test across OS versions
![screen shot 2017-08-16 at 12 20 17 pm](https://user-images.githubusercontent.com/21044586/29373800-4784cac6-827d-11e7-88e9-4722a0710b06.png)
