### PR TITLE
Fix for manual addition framework, using Swift

### DIFF
--- a/sdk/PrebidMobile.xcodeproj/project.pbxproj
+++ b/sdk/PrebidMobile.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		C2B1747A1EE1E3C3006304C0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2B174791EE1E3C3006304C0 /* UIKit.framework */; };
 		C2B1747C1EE1E3C9006304C0 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2B1747B1EE1E3C9006304C0 /* SystemConfiguration.framework */; };
 		C2B1747E1EE1E3CE006304C0 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2B1747D1EE1E3CE006304C0 /* QuartzCore.framework */; };
+		E6BF995F1F7167B0001016FD /* PrebidMobile-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = E6BF995E1F7167B0001016FD /* PrebidMobile-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -150,6 +151,8 @@
 		C2B174791EE1E3C3006304C0 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		C2B1747B1EE1E3C9006304C0 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		C2B1747D1EE1E3CE006304C0 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		E62599751F716E4E008DA0A4 /* PrebidMobile.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = PrebidMobile.modulemap; sourceTree = "<group>"; };
+		E6BF995E1F7167B0001016FD /* PrebidMobile-umbrella.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PrebidMobile-umbrella.h"; sourceTree = "<group>"; };
 		EFD3C940519B957467FE94E6 /* libPods-PrebidMobile.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PrebidMobile.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -281,6 +284,7 @@
 				C2B16E321EE1BEA6006304C0 /* PBTargetingParams.m */,
 				C23386D01EE5DBFB002FD404 /* PrebidMobile.h */,
 				C23386D11EE5DBFB002FD404 /* PrebidMobile.m */,
+				E653A34F1F725B2800DE11DB /* Support */,
 			);
 			path = PrebidMobile;
 			sourceTree = "<group>";
@@ -354,6 +358,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		E653A34F1F725B2800DE11DB /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				E6BF995E1F7167B0001016FD /* PrebidMobile-umbrella.h */,
+				E62599751F716E4E008DA0A4 /* PrebidMobile.modulemap */,
+			);
+			name = Support;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -369,6 +382,7 @@
 				C23FCCEA1EE5E3F500CFFEF0 /* PBLogging.h in Headers */,
 				C2B16E3D1EE1BEA6006304C0 /* PBKeywordsManager.h in Headers */,
 				C23FCCEE1EE5E41E00CFFEF0 /* PBLogManager.h in Headers */,
+				E6BF995F1F7167B0001016FD /* PrebidMobile-umbrella.h in Headers */,
 				C23386DA1EE5DCDB002FD404 /* PBServerAdapter.h in Headers */,
 				C23386D61EE5DC95002FD404 /* PBAdUnit.h in Headers */,
 				C23386D21EE5DBFB002FD404 /* PrebidMobile.h in Headers */,
@@ -671,6 +685,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/lib/DFPSDK $(PROJECT_DIR)/lib/MoPubSDK";
 				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "$(PROJECT)/PrebidMobile.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = AppNexus.PrebidMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -693,6 +708,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks $(PROJECT_DIR)/lib/DFPSDK $(PROJECT_DIR)/lib/MoPubSDK";
 				MACH_O_TYPE = staticlib;
+				MODULEMAP_FILE = "$(PROJECT)/PrebidMobile.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = AppNexus.PrebidMobile;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/sdk/PrebidMobile/PrebidMobile-umbrella.h
+++ b/sdk/PrebidMobile/PrebidMobile-umbrella.h
@@ -1,0 +1,15 @@
+#import "PBLogManager.h"
+#import "PBLogging.h"
+
+#import "PrebidMobile.h"
+#import "PBAdUnit.h"
+#import "PBBannerAdUnit.h"
+#import "PBBidManager.h"
+#import "PBBidResponse.h"
+#import "PBBidResponseDelegate.h"
+#import "PBException.h"
+#import "PBInterstitialAdUnit.h"
+#import "PBKeywordsManager.h"
+#import "PBTargetingParams.h"
+
+#import "PBServerAdapter.h"

--- a/sdk/PrebidMobile/PrebidMobile.h
+++ b/sdk/PrebidMobile/PrebidMobile.h
@@ -13,8 +13,7 @@
  limitations under the License.
  */
 
-#import <UIKit/UIKit.h>
-#import "PBLogging.h"
+@import Foundation.NSString;
 
 @class PBAdUnit;
 

--- a/sdk/PrebidMobile/PrebidMobile.m
+++ b/sdk/PrebidMobile/PrebidMobile.m
@@ -15,6 +15,7 @@
 
 #import "PBBidManager.h"
 #import "PrebidMobile.h"
+#import "PBLogging.h"
 
 @implementation PrebidMobile
 

--- a/sdk/PrebidMobile/PrebidMobile.modulemap
+++ b/sdk/PrebidMobile/PrebidMobile.modulemap
@@ -1,0 +1,6 @@
+framework module PrebidMobile {
+    umbrella header "PrebidMobile-umbrella.h"
+    
+    export *
+    module * { export * }
+}


### PR DESCRIPTION
Add modulemap and umbrella header, in order to make objc classes available in swift context, when the framework is manually added to a project.