### PR TITLE
Bid expiry update alignment with Android

### DIFF
--- a/sdk/PrebidMobile/Categories/NSObject+Prebid.m
+++ b/sdk/PrebidMobile/Categories/NSObject+Prebid.m
@@ -69,19 +69,19 @@
 // dfp ad slot
 - (id)pb_requestParameters {
     __block id requestParameters = [self pb_requestParameters];
-    
+
     SEL adEventDelegateSel = NSSelectorFromString(@"adEventDelegate");
     if ([self respondsToSelector:adEventDelegateSel]) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-performSelector-leaks"
         id adEventDelegate = [self performSelector:adEventDelegateSel];
         NSDictionary<NSString *, NSString *> *keywordsPairs;
-        
+
         SEL getPb_identifier = NSSelectorFromString(@"pb_identifier");
         if ([adEventDelegate respondsToSelector:getPb_identifier]) {
             PBAdUnit *adUnit = (PBAdUnit *)[adEventDelegate performSelector:getPb_identifier];
 #pragma clang diagnostic pop
-            
+
             keywordsPairs = [[PBBidManager sharedInstance] keywordsForWinningBidForAdUnit:adUnit];
             requestParameters = [[PBBidManager sharedInstance] addPrebidParameters:requestParameters withKeywords:keywordsPairs];
         }

--- a/sdk/PrebidMobile/PBBidManager.m
+++ b/sdk/PrebidMobile/PBBidManager.m
@@ -114,7 +114,7 @@ static dispatch_once_t onceToken;
 }
 
 - (nullable NSDictionary<NSString *, NSString *> *)keywordsForWinningBidForAdUnit:(nonnull PBAdUnit *)adUnit {
-    NSArray *bids = [self getWinningBids:adUnit];
+    NSArray *bids = [self getBids:adUnit];
     [self startNewAuction:adUnit];
     if (bids) {
         PBLogDebug(@"Bid is available to create keywords");
@@ -244,7 +244,7 @@ static dispatch_once_t onceToken;
     }
 }
 
-- (nullable NSArray<PBBidResponse *> *)getWinningBids:(PBAdUnit *)adUnit {
+- (nullable NSArray<PBBidResponse *> *)getBids:(PBAdUnit *)adUnit {
     NSMutableArray *bids = [_bidsMap objectForKey:adUnit.identifier];
     if (bids && [bids count] > 0) {
         return bids;

--- a/sdk/PrebidMobile/PBBidManager.m
+++ b/sdk/PrebidMobile/PBBidManager.m
@@ -253,7 +253,9 @@ static dispatch_once_t onceToken;
 }
 
 - (BOOL)isBidReady:(NSString *)identifier {
-    if ([[_bidsMap allKeys] containsObject:identifier] && [_bidsMap objectForKey:identifier] != nil) {
+    if ([[_bidsMap allKeys] containsObject:identifier] &&
+        [_bidsMap objectForKey:identifier] != nil &&
+        [[_bidsMap objectForKey:identifier] count] > 0) {
         PBLogDebug(@"Bid is ready for ad unit with identifier %@", identifier);
         return YES;
     }

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
@@ -273,4 +273,16 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
     }];
 }
 
+- (void)testCheckForBidsExpiredNoBid {
+    PBAdUnit *adUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt13" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
+    [adUnit addSize:CGSizeMake(320, 50)];
+    [[PBBidManager sharedInstance] registerAdUnits:@[adUnit] withAccountId:self.accountId];
+
+    // On no bid response bids should not be considered expired
+    NSString *originalUUID = adUnit.uuid;
+
+    [[PBBidManager sharedInstance] checkForBidsExpired];
+    XCTAssertTrue([originalUUID isEqualToString:adUnit.uuid]);
+}
+
 @end

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
@@ -33,7 +33,7 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
 - (void)startNewAuction:(PBAdUnit *)adUnit;
 - (void)saveBidResponses:(nonnull NSArray<PBBidResponse *> *)bidResponse;
 - (void)checkForBidsExpired;
-- (PBBidResponse *)winningBidForAdUnit:(PBAdUnit *)adUnit;
+- (NSArray<PBBidResponse *> *)getBids:(PBAdUnit *)adUnit;
 
 @end
 
@@ -123,8 +123,10 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
     PBBidResponse *bidResponse2 = [PBBidResponse bidResponseWithAdUnitId:bannerAdUnit.identifier adServerTargeting:testAdServerTargeting2];
     [[PBBidManager sharedInstance] saveBidResponses:@[bidResponse, bidResponse2]];
 
-    PBBidResponse *winningBid = [[PBBidManager sharedInstance] winningBidForAdUnit:bannerAdUnit];
-    XCTAssertEqual(winningBid.customKeywords[@"hb_pb"], bidResponse.customKeywords[@"hb_pb"]);
+    NSArray *bids = [[PBBidManager sharedInstance] getBids:bannerAdUnit];
+    PBBidResponse *topBid = [bids firstObject];
+    XCTAssertEqual([bids count], 2);
+    XCTAssertEqual(topBid.customKeywords[@"hb_pb"], @"4.14");
 }
 
 #pragma mark - Test keywords for winning bid for ad unit tests


### PR DESCRIPTION
New expected behavior:
- When bid responses are saved, the expiry time on those bid responses is set to 4 minutes 30 seconds.
- Every 30 seconds poll will check all ad units for expired bids. 
- If there was a bid for that ad unit and that bid is expired, start a new auction in Prebid Server.
- On iOS, on MoPub or DFP autorefresh, send any cached bid to MoPub / DFP line items and start a new auction.
- On iOS, when setBidKeywords API is called set adUnit identifier to start a new auction on swizzled load ad method.
- On both platforms, a new auction is run every time the setBidKeywords API is called.