### PR TITLE
Remove unneeded libs from Prebid Mobile podspec & code

### DIFF
--- a/PrebidMobile.podspec
+++ b/PrebidMobile.podspec
@@ -40,6 +40,6 @@ Pod::Spec.new do |s|
 :HEADER_SEARCH_PATHS => '$(inherited)',
 :FRAMEWORK_SEARCH_PATHS => '$(inherited)'
 }
-  s.framework  = ['MediaPlayer', 'AVFoundation', 'EventKit', 'CoreTelephony', 'CoreData', 'SystemConfiguration', 'CoreGraphics', 'UIKit', 'Foundation', 'MessageUI', 'StoreKit']
+  s.framework  = ['CoreTelephony', 'SystemConfiguration', 'UIKit', 'Foundation']
 
 end

--- a/sdk/PrebidMobile/PBKeywordsManager.h
+++ b/sdk/PrebidMobile/PBKeywordsManager.h
@@ -13,7 +13,6 @@
  limitations under the License.
  */
 
-#import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 
 @class PBBidResponse;


### PR DESCRIPTION
Noticed that the podspec had unneeded dependencies and that we don't use CoreGraphics lib. This PR cleans this up for 0.1.0 release.