### PR TITLE
Clean up changes for 0.1.0 release

### DIFF
--- a/sdk/PrebidMobile/PBBidManager.m
+++ b/sdk/PrebidMobile/PBBidManager.m
@@ -185,10 +185,18 @@ static dispatch_once_t onceToken;
     if (adUnit.adSizes == nil && adUnit.adType == PBAdUnitTypeBanner) {
         @throw [PBException exceptionWithName:PBAdUnitNoSizeException];
     }
-    // Check if adunit already exists, if so remove it
-    if ([_adUnits containsObject:adUnit]) {
+    // Check if ad unit already exists, if so remove it
+    NSMutableArray *adUnitsToRemove = [[NSMutableArray alloc] init];
+    for (PBAdUnit *existingAdUnit in _adUnits) {
+        if ([existingAdUnit.identifier isEqualToString:adUnit.identifier]) {
+            [adUnitsToRemove addObject:existingAdUnit];
+        }
+    }
+    for (PBAdUnit *adUnit in adUnitsToRemove) {
         [_adUnits removeObject:adUnit];
     }
+
+    // Finish registration of ad unit by adding it to adUnits
     [_adUnits addObject:adUnit];
     PBLogDebug(@"AdUnit %@ is registered with Prebid Mobile", adUnit.identifier);
 }
@@ -249,8 +257,7 @@ static dispatch_once_t onceToken;
 }
 
 - (BOOL)isBidReady:(NSString *)identifier {
-    if ([[_bidsMap allKeys] containsObject:identifier] &&
-        [_bidsMap objectForKey:identifier] != nil &&
+    if ([_bidsMap objectForKey:identifier] != nil &&
         [[_bidsMap objectForKey:identifier] count] > 0) {
         PBLogDebug(@"Bid is ready for ad unit with identifier %@", identifier);
         return YES;

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
@@ -110,6 +110,20 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
     XCTAssertNil(returnedAdUnit);
 }
 
+- (void)testRegisterAdUnitWithSameIdentifier {
+    PBAdUnit *returnedUnit = nil;
+    PBAdUnit *bannerAdUnit1 = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"sameid" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
+    [bannerAdUnit1 addSize:CGSizeMake(320, 50)];
+    PBAdUnit *bannerAdUnit2 = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"sameid" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
+    [bannerAdUnit2 addSize:CGSizeMake(320, 50)];
+
+    [[PBBidManager sharedInstance] registerAdUnits:@[bannerAdUnit1, bannerAdUnit2] withAccountId:self.accountId];
+    returnedUnit = [[PBBidManager sharedInstance] adUnitByIdentifier:[bannerAdUnit1 identifier]];
+
+    XCTAssertNotNil(returnedUnit);
+    XCTAssertEqualObjects(returnedUnit.identifier, bannerAdUnit1.identifier);
+}
+
 #pragma mark - Test winning bid for ad unit
 
 - (void)testWinningBidForAdUnit {

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
@@ -122,7 +122,8 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
     returnedUnit = [[PBBidManager sharedInstance] adUnitByIdentifier:[bannerAdUnit1 identifier]];
 
     XCTAssertNotNil(returnedUnit);
-    XCTAssertEqualObjects(returnedUnit.identifier, bannerAdUnit1.identifier);
+    // Test that the second banner ad unit is the one that is registered, not the first banner ad unit
+    XCTAssertEqualObjects(returnedUnit, bannerAdUnit2);
 }
 
 #pragma mark - Test winning bid for ad unit

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
@@ -33,6 +33,7 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
 - (void)startNewAuction:(PBAdUnit *)adUnit;
 - (void)saveBidResponses:(nonnull NSArray<PBBidResponse *> *)bidResponse;
 - (void)checkForBidsExpired;
+- (void)registerAdUnit:(PBAdUnit *)adUnit;
 - (NSArray<PBBidResponse *> *)getBids:(PBAdUnit *)adUnit;
 
 @end
@@ -264,9 +265,16 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
 
 - (void)testCheckForBidsExpired {
     XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+    // This test is a bit confusing. The first ad unit is registered to initialize Prebid and the ad units set using the public API.
+    PBAdUnit *adUnitTest = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt21" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
+    [adUnitTest addSize:CGSizeMake(320, 50)];
+    [[PBBidManager sharedInstance] registerAdUnits:@[adUnitTest] withAccountId:self.accountId];
+
+    // We initialize this ad unit using the private function to ensure a request doesn't go out and the timeToExpireAfter doesn't get reset
+    // to 4 min and 30 seconds instead of 1 second for testing.
     PBAdUnit *adUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt12" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
     [adUnit addSize:CGSizeMake(320, 50)];
-    [[PBBidManager sharedInstance] registerAdUnits:@[adUnit] withAccountId:self.accountId];
+    [[PBBidManager sharedInstance] registerAdUnit:adUnit];
     
     NSDictionary *testAdServerTargeting = @{@"hb_pb":@"4.14", @"hb_cache_id":@"0000-0000-000-0000", @"hb_bidder": @"appnexus"};
     PBBidResponse *bidResponse = [PBBidResponse bidResponseWithAdUnitId:adUnit.identifier adServerTargeting:testAdServerTargeting];


### PR DESCRIPTION
Went through to make sure that code looked good. Found a couple of the changes below
- Fix removing duplicate ad units on registration to check against adunit identifier instead of adunit. add tests
- remove contains check on isBidReady, its redundant to the next check and takes O(n) time and risks iterating through unnecessarily
- Fix bids expired test 