### PR TITLE
Update Xamarin device ids for integration testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 osx_image: xcode8
 env:
-- XAMARIN_DEVICES_ID_PR=9f82ba1c XAMARIN_DEVICES_ID_CRON=67582786
+- XAMARIN_DEVICES_ID_PR=92132fb4 XAMARIN_DEVICES_ID_CRON=a3dab23a
 before_script: "./scripts/add-keys.sh"
 after_script: "./scripts/remove-key.sh"
 script:


### PR DESCRIPTION
New devices ids are pull request uses a 10.2 iPhone 7 Plus and Cron to include a device on iOS 11