### PR TITLE
Add extra synchronized block just to be safe

### DIFF
--- a/sdk/PrebidServerAdapter/PrebidServerModule/PBServerFetcher.m
+++ b/sdk/PrebidServerAdapter/PrebidServerModule/PBServerFetcher.m
@@ -46,7 +46,9 @@
     if (self.requestTIDs == nil) {
         self.requestTIDs = [[NSMutableArray alloc] init];
     }
-    [self.requestTIDs addObject:params[@"tid"]];
+    @synchronized(self.requestTIDs) {
+        [self.requestTIDs addObject:params[@"tid"]];
+    }
 
     [NSURLConnection sendAsynchronousRequest:request
                                        queue:[[NSOperationQueue alloc] init]


### PR DESCRIPTION
Not seeing any crashes but want to make sure requestTIDs isn't accessed without synchronization.