### PR TITLE
Testing build on Travis CI with new Google framework

### DIFF
--- a/examples/PrebidMobileDemo/PrebidMobileDemo.xcodeproj/project.pbxproj
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo.xcodeproj/project.pbxproj
@@ -1814,10 +1814,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					arm64,
-					armv7,
-				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1867,10 +1863,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = (
-					arm64,
-					armv7,
-				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/examples/PrebidMobileDemo/PrebidMobileDemo.xcodeproj/project.pbxproj
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo.xcodeproj/project.pbxproj
@@ -1814,6 +1814,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					armv7,
+				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1863,6 +1867,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					arm64,
+					armv7,
+				);
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/examples/PrebidMobileDemo/bin/make/ipa.sh
+++ b/examples/PrebidMobileDemo/bin/make/ipa.sh
@@ -83,8 +83,8 @@ if [ -z "${CODE_SIGN_IDENTITY}" ]; then
     -scheme "${XC_TARGET}" \
     -configuration "${XC_CONFIG}" \
     -sdk iphoneos \
-    ARCHS="armv7 armv7s arm64" \
-    VALID_ARCHS="armv7 armv7s arm64" \
+    ARCHS="armv7 arm64" \
+    VALID_ARCHS="armv7 arm64" \
     ONLY_ACTIVE_ARCH=NO \
     build | $XC_PIPE
 else
@@ -96,8 +96,8 @@ else
     -scheme "${XC_TARGET}" \
     -configuration "${XC_CONFIG}" \
     -sdk iphoneos \
-    ARCHS="armv7 armv7s arm64" \
-    VALID_ARCHS="armv7 armv7s arm64" \
+    ARCHS="armv7 arm64" \
+    VALID_ARCHS="armv7 arm64" \
     ONLY_ACTIVE_ARCH=NO \
     build | $XC_PIPE
 fi


### PR DESCRIPTION
New version of the GoogleMobileAds framework won't build armv7s architecture so remove it from the build .ipa script.