### PR TITLE
Use local storage to cache ads instead of Prebid Cache

### DIFF
--- a/examples/PrebidMobileDemo/PrebidMobileDemo/AppDelegate.m
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo/AppDelegate.m
@@ -64,7 +64,7 @@
 
         [self setPrebidTargetingParams];
 
-        [PrebidMobile registerAdUnits:@[adUnit1, adUnit2] withAccountId:kAccountId];
+        [PrebidMobile registerAdUnits:@[adUnit1, adUnit2] withAccountId:kAccountId andPrimaryAdServer:PBPrimaryAdServerDFP];
     } @catch (PBException *ex) {
         NSLog(@"%@",[ex reason]);
     } @finally {

--- a/examples/PrebidMobileDemo/PrebidMobileDemo/SettingsViewController.m
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo/SettingsViewController.m
@@ -19,6 +19,11 @@
 #import "SettingsViewController.h"
 #import "VideoTestsViewController.h"
 
+#import <PrebidMobile/PBBannerAdUnit.h>
+#import <PrebidMobile/PBException.h>
+#import <PrebidMobile/PBInterstitialAdUnit.h>
+#import <PrebidMobile/PrebidMobile.h>
+
 static NSString *const kSeeAdButtonTitle = @"See Ad";
 static NSString *const kAdSettingsTableViewReuseId = @"AdSettingsTableItem";
 static CGFloat const kRightMargin = 15;
@@ -61,6 +66,9 @@ static CGFloat const kRightMargin = 15;
 
     UISegmentedControl *adServerSegControl = [[UISegmentedControl alloc] initWithItems:@[kDFPAdServer, kMoPubAdServer]];
     adServerSegControl.selectedSegmentIndex = 0;
+    [adServerSegControl addTarget:self
+                           action:@selector(adServerClicked:)
+                 forControlEvents:UIControlEventValueChanged];
     UISegmentedControl *adTypeSegControl = [[UISegmentedControl alloc] initWithItems:@[kBanner, kInterstitial]];
     adTypeSegControl.selectedSegmentIndex = 0;
 
@@ -108,7 +116,29 @@ static CGFloat const kRightMargin = 15;
 }
 
 - (void)adServerClicked:(id)sender {
-    
+    UISegmentedControl *adServerSegControl = (UISegmentedControl *)sender;
+    NSString *adServer = [adServerSegControl titleForSegmentAtIndex:[adServerSegControl selectedSegmentIndex]];
+    PBPrimaryAdServerType primaryAdServer = PBPrimaryAdServerUnknown;
+    if ([adServer isEqualToString:kDFPAdServer]) {
+        primaryAdServer = PBPrimaryAdServerDFP;
+    } else if ([adServer isEqualToString:kMoPubAdServer]) {
+        primaryAdServer = PBPrimaryAdServerMoPub;
+    }
+    [self setupPrebidAndRegisterAdUnitsWithAdServer:primaryAdServer];
+}
+
+- (BOOL)setupPrebidAndRegisterAdUnitsWithAdServer:(PBPrimaryAdServerType)adServer {
+    @try {
+        PBBannerAdUnit *__nullable adUnit1 = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:kAdUnit1Id andConfigId:kAdUnit1ConfigId];
+        PBInterstitialAdUnit *__nullable adUnit2 = [[PBInterstitialAdUnit alloc] initWithAdUnitIdentifier:kAdUnit2Id andConfigId:kAdUnit2ConfigId];
+        [adUnit1 addSize:CGSizeMake(300, 250)];
+
+        [PrebidMobile registerAdUnits:@[adUnit1, adUnit2] withAccountId:kAccountId andPrimaryAdServer:adServer];
+    } @catch (PBException *ex) {
+        NSLog(@"%@",[ex reason]);
+    } @finally {
+        return YES;
+    }
 }
 
 #pragma mark UITableViewDataSource methods

--- a/sdk/PrebidMobile.xcodeproj/project.pbxproj
+++ b/sdk/PrebidMobile.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		C210FE321FBDF0440010B588 /* PrebidURLProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C210FE301FBDF0440010B588 /* PrebidURLProtocol.h */; };
 		C210FE331FBDF0440010B588 /* PrebidURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = C210FE311FBDF0440010B588 /* PrebidURLProtocol.m */; };
+		C210FE381FC3375D0010B588 /* EGOCache.h in Headers */ = {isa = PBXBuildFile; fileRef = C210FE361FC3375D0010B588 /* EGOCache.h */; };
+		C210FE391FC3375D0010B588 /* EGOCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C210FE371FC3375D0010B588 /* EGOCache.m */; };
 		C22E7CE61EE70E19007B31F4 /* NSTimer+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = C2B16E501EE1BEC4006304C0 /* NSTimer+Extension.m */; };
 		C23386D21EE5DBFB002FD404 /* PrebidMobile.h in Headers */ = {isa = PBXBuildFile; fileRef = C23386D01EE5DBFB002FD404 /* PrebidMobile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C23386D31EE5DBFB002FD404 /* PrebidMobile.m in Sources */ = {isa = PBXBuildFile; fileRef = C23386D11EE5DBFB002FD404 /* PrebidMobile.m */; };
@@ -84,6 +86,8 @@
 /* Begin PBXFileReference section */
 		C210FE301FBDF0440010B588 /* PrebidURLProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrebidURLProtocol.h; sourceTree = "<group>"; };
 		C210FE311FBDF0440010B588 /* PrebidURLProtocol.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PrebidURLProtocol.m; sourceTree = "<group>"; };
+		C210FE361FC3375D0010B588 /* EGOCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EGOCache.h; sourceTree = "<group>"; };
+		C210FE371FC3375D0010B588 /* EGOCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = EGOCache.m; sourceTree = "<group>"; };
 		C23386D01EE5DBFB002FD404 /* PrebidMobile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrebidMobile.h; sourceTree = "<group>"; };
 		C23386D11EE5DBFB002FD404 /* PrebidMobile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PrebidMobile.m; sourceTree = "<group>"; };
 		C23386D41EE5DC95002FD404 /* PBAdUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBAdUnit.h; sourceTree = "<group>"; };
@@ -287,6 +291,8 @@
 				C210FE311FBDF0440010B588 /* PrebidURLProtocol.m */,
 				C23386D01EE5DBFB002FD404 /* PrebidMobile.h */,
 				C23386D11EE5DBFB002FD404 /* PrebidMobile.m */,
+				C210FE361FC3375D0010B588 /* EGOCache.h */,
+				C210FE371FC3375D0010B588 /* EGOCache.m */,
 			);
 			path = PrebidMobile;
 			sourceTree = "<group>";
@@ -386,6 +392,7 @@
 				C2B16E9D1EE1BF1A006304C0 /* PBServerLocation.h in Headers */,
 				C210FE321FBDF0440010B588 /* PrebidURLProtocol.h in Headers */,
 				C2B16E981EE1BF1A006304C0 /* PBServerFetcher.h in Headers */,
+				C210FE381FC3375D0010B588 /* EGOCache.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -516,6 +523,7 @@
 				C2B16E9C1EE1BF1A006304C0 /* PBServerGlobal.m in Sources */,
 				C2B16E3C1EE1BEA6006304C0 /* PBInterstitialAdUnit.m in Sources */,
 				C23FCCEB1EE5E3F500CFFEF0 /* PBLogging.m in Sources */,
+				C210FE391FC3375D0010B588 /* EGOCache.m in Sources */,
 				C2B16E401EE1BEA6006304C0 /* PBTargetingParams.m in Sources */,
 				C2B16E9E1EE1BF1A006304C0 /* PBServerLocation.m in Sources */,
 				C2B16E351EE1BEA6006304C0 /* PBBannerAdUnit.m in Sources */,

--- a/sdk/PrebidMobile.xcodeproj/project.pbxproj
+++ b/sdk/PrebidMobile.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C210FE321FBDF0440010B588 /* PrebidURLProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = C210FE301FBDF0440010B588 /* PrebidURLProtocol.h */; };
+		C210FE331FBDF0440010B588 /* PrebidURLProtocol.m in Sources */ = {isa = PBXBuildFile; fileRef = C210FE311FBDF0440010B588 /* PrebidURLProtocol.m */; };
 		C22E7CE61EE70E19007B31F4 /* NSTimer+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = C2B16E501EE1BEC4006304C0 /* NSTimer+Extension.m */; };
 		C23386D21EE5DBFB002FD404 /* PrebidMobile.h in Headers */ = {isa = PBXBuildFile; fileRef = C23386D01EE5DBFB002FD404 /* PrebidMobile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C23386D31EE5DBFB002FD404 /* PrebidMobile.m in Sources */ = {isa = PBXBuildFile; fileRef = C23386D11EE5DBFB002FD404 /* PrebidMobile.m */; };
@@ -80,6 +82,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		C210FE301FBDF0440010B588 /* PrebidURLProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PrebidURLProtocol.h; sourceTree = "<group>"; };
+		C210FE311FBDF0440010B588 /* PrebidURLProtocol.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PrebidURLProtocol.m; sourceTree = "<group>"; };
 		C23386D01EE5DBFB002FD404 /* PrebidMobile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PrebidMobile.h; sourceTree = "<group>"; };
 		C23386D11EE5DBFB002FD404 /* PrebidMobile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PrebidMobile.m; sourceTree = "<group>"; };
 		C23386D41EE5DC95002FD404 /* PBAdUnit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBAdUnit.h; sourceTree = "<group>"; };
@@ -279,6 +283,8 @@
 				C2B16E301EE1BEA6006304C0 /* PBKeywordsManager.m */,
 				C2B16E311EE1BEA6006304C0 /* PBTargetingParams.h */,
 				C2B16E321EE1BEA6006304C0 /* PBTargetingParams.m */,
+				C210FE301FBDF0440010B588 /* PrebidURLProtocol.h */,
+				C210FE311FBDF0440010B588 /* PrebidURLProtocol.m */,
 				C23386D01EE5DBFB002FD404 /* PrebidMobile.h */,
 				C23386D11EE5DBFB002FD404 /* PrebidMobile.m */,
 			);
@@ -378,6 +384,7 @@
 				C2B16E9B1EE1BF1A006304C0 /* PBServerGlobal.h in Headers */,
 				C2B16E9F1EE1BF1A006304C0 /* PBServerReachability.h in Headers */,
 				C2B16E9D1EE1BF1A006304C0 /* PBServerLocation.h in Headers */,
+				C210FE321FBDF0440010B588 /* PrebidURLProtocol.h in Headers */,
 				C2B16E981EE1BF1A006304C0 /* PBServerFetcher.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -512,6 +519,7 @@
 				C2B16E401EE1BEA6006304C0 /* PBTargetingParams.m in Sources */,
 				C2B16E9E1EE1BF1A006304C0 /* PBServerLocation.m in Sources */,
 				C2B16E351EE1BEA6006304C0 /* PBBannerAdUnit.m in Sources */,
+				C210FE331FBDF0440010B588 /* PrebidURLProtocol.m in Sources */,
 				C23386D71EE5DC95002FD404 /* PBAdUnit.m in Sources */,
 				C24B78C51EE7467E0045B454 /* NSObject+Prebid.m in Sources */,
 				C2B16E581EE1BEC4006304C0 /* NSString+Extension.m in Sources */,

--- a/sdk/PrebidMobile/EGOCache.h
+++ b/sdk/PrebidMobile/EGOCache.h
@@ -1,0 +1,96 @@
+//
+//  EGOCache.h
+//  enormego
+//
+//  Created by Shaun Harrison.
+//  Copyright (c) 2009-2017 enormego.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#endif
+
+#if TARGET_OS_OSX
+#import <AppKit/AppKit.h>
+#endif
+
+//! Project version number for EGOCache.
+FOUNDATION_EXPORT double EGOCacheVersionNumber;
+
+//! Project version string for EGOCache.
+FOUNDATION_EXPORT const unsigned char EGOCacheVersionString[];
+
+#if !__has_feature(nullability)
+#    define nullable
+#    define nonnull
+#    define __nullable
+#    define __nonnull
+#endif
+
+@interface EGOCache : NSObject
+
+// Global cache for easy use
++ (nonnull instancetype)globalCache;
+
+// Opitionally create a different EGOCache instance with it's own cache directory
+- (nonnull instancetype)initWithCacheDirectory:(NSString* __nonnull)cacheDirectory;
+
+- (void)clearCache;
+- (void)removeCacheForKey:(NSString* __nonnull)key;
+
+- (BOOL)hasCacheForKey:(NSString* __nonnull)key;
+
+- (NSData* __nullable)dataForKey:(NSString* __nonnull)key;
+- (void)setData:(NSData* __nonnull)data forKey:(NSString* __nonnull)key;
+- (void)setData:(NSData* __nonnull)data forKey:(NSString* __nonnull)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
+
+- (NSString* __nullable)stringForKey:(NSString* __nonnull)key;
+- (void)setString:(NSString* __nonnull)aString forKey:(NSString* __nonnull)key;
+- (void)setString:(NSString* __nonnull)aString forKey:(NSString* __nonnull)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
+
+- (NSDate* __nullable)dateForKey:(NSString* __nonnull)key;
+- (NSArray* __nonnull)allKeys;
+
+#if TARGET_OS_IPHONE
+- (UIImage* __nullable)imageForKey:(NSString* __nonnull)key;
+- (void)setImage:(UIImage* __nonnull)anImage forKey:(NSString* __nonnull)key;
+- (void)setImage:(UIImage* __nonnull)anImage forKey:(NSString* __nonnull)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
+#else
+- (NSImage* __nullable)imageForKey:(NSString* __nonnull)key;
+- (void)setImage:(NSImage* __nonnull)anImage forKey:(NSString* __nonnull)key;
+- (void)setImage:(NSImage* __nonnull)anImage forKey:(NSString* __nonnull)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
+#endif
+
+- (NSData* __nullable)plistForKey:(NSString* __nonnull)key;
+- (void)setPlist:(nonnull id)plistObject forKey:(NSString* __nonnull)key;
+- (void)setPlist:(nonnull id)plistObject forKey:(NSString* __nonnull)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
+
+- (void)copyFilePath:(NSString* __nonnull)filePath asKey:(NSString* __nonnull)key;
+- (void)copyFilePath:(NSString* __nonnull)filePath asKey:(NSString* __nonnull)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
+
+- (nullable id<NSCoding>)objectForKey:(NSString* __nonnull)key;
+- (void)setObject:(nonnull id<NSCoding>)anObject forKey:(NSString* __nonnull)key;
+- (void)setObject:(nonnull id<NSCoding>)anObject forKey:(NSString* __nonnull)key withTimeoutInterval:(NSTimeInterval)timeoutInterval;
+
+@property(nonatomic) NSTimeInterval defaultTimeoutInterval; // Default is 1 day
+@end

--- a/sdk/PrebidMobile/EGOCache.m
+++ b/sdk/PrebidMobile/EGOCache.m
@@ -1,0 +1,368 @@
+//
+//  EGOCache.m
+//  enormego
+//
+//  Created by Shaun Harrison.
+//  Copyright (c) 2009-2017 enormego.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "EGOCache.h"
+
+#if DEBUG
+#    define CHECK_FOR_EGOCACHE_PLIST() if([key isEqualToString:@"EGOCache.plist"]) { \
+NSLog(@"EGOCache.plist is a reserved key and can not be modified."); \
+return; }
+#else
+#    define CHECK_FOR_EGOCACHE_PLIST() if([key isEqualToString:@"EGOCache.plist"]) return;
+#endif
+
+static inline NSString* cachePathForKey(NSString* directory, NSString* key) {
+    key = [key stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
+    return [directory stringByAppendingPathComponent:key];
+}
+
+#pragma mark -
+
+@interface EGOCache () {
+    dispatch_queue_t _cacheInfoQueue;
+    dispatch_queue_t _frozenCacheInfoQueue;
+    dispatch_queue_t _diskQueue;
+    NSMutableDictionary* _cacheInfo;
+    NSString* _directory;
+    BOOL _needsSave;
+}
+
+@property(nonatomic,copy) NSDictionary* frozenCacheInfo;
+@end
+
+@implementation EGOCache
+
++ (instancetype)globalCache {
+    static id instance;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[[self class] alloc] init];
+    });
+    
+    return instance;
+}
+
+- (instancetype)init {
+    NSString* cachesDirectory = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)[0];
+    NSString* oldCachesDirectory = [[[cachesDirectory stringByAppendingPathComponent:[[NSProcessInfo processInfo] processName]] stringByAppendingPathComponent:@"EGOCache"] copy];
+    
+    if([[NSFileManager defaultManager] fileExistsAtPath:oldCachesDirectory]) {
+        [[NSFileManager defaultManager] removeItemAtPath:oldCachesDirectory error:NULL];
+    }
+    
+    cachesDirectory = [[[cachesDirectory stringByAppendingPathComponent:[[NSBundle mainBundle] bundleIdentifier]] stringByAppendingPathComponent:@"EGOCache"] copy];
+    return [self initWithCacheDirectory:cachesDirectory];
+}
+
+- (instancetype)initWithCacheDirectory:(NSString*)cacheDirectory {
+    if((self = [super init])) {
+        _cacheInfoQueue = dispatch_queue_create("com.enormego.egocache.info", DISPATCH_QUEUE_SERIAL);
+        dispatch_queue_t priority = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+        dispatch_set_target_queue(priority, _cacheInfoQueue);
+        
+        _frozenCacheInfoQueue = dispatch_queue_create("com.enormego.egocache.info.frozen", DISPATCH_QUEUE_SERIAL);
+        priority = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+        dispatch_set_target_queue(priority, _frozenCacheInfoQueue);
+        
+        _diskQueue = dispatch_queue_create("com.enormego.egocache.disk", DISPATCH_QUEUE_CONCURRENT);
+        priority = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+        dispatch_set_target_queue(priority, _diskQueue);
+        
+        
+        _directory = cacheDirectory;
+        
+        _cacheInfo = [[NSDictionary dictionaryWithContentsOfFile:cachePathForKey(_directory, @"EGOCache.plist")] mutableCopy];
+        
+        if(!_cacheInfo) {
+            _cacheInfo = [[NSMutableDictionary alloc] init];
+        }
+        
+        [[NSFileManager defaultManager] createDirectoryAtPath:_directory withIntermediateDirectories:YES attributes:nil error:NULL];
+        
+        NSTimeInterval now = [[NSDate date] timeIntervalSinceReferenceDate];
+        NSMutableArray* removedKeys = [[NSMutableArray alloc] init];
+        
+        for(NSString* key in _cacheInfo) {
+            if([_cacheInfo[key] timeIntervalSinceReferenceDate] <= now) {
+                [[NSFileManager defaultManager] removeItemAtPath:cachePathForKey(_directory, key) error:NULL];
+                [removedKeys addObject:key];
+            }
+        }
+        
+        [_cacheInfo removeObjectsForKeys:removedKeys];
+        self.frozenCacheInfo = _cacheInfo;
+        [self setDefaultTimeoutInterval:86400];
+    }
+    
+    return self;
+}
+
+- (void)clearCache {
+    dispatch_sync(_cacheInfoQueue, ^{
+        for(NSString* key in _cacheInfo) {
+            [[NSFileManager defaultManager] removeItemAtPath:cachePathForKey(_directory, key) error:NULL];
+        }
+        
+        [_cacheInfo removeAllObjects];
+        
+        dispatch_sync(_frozenCacheInfoQueue, ^{
+            self.frozenCacheInfo = [_cacheInfo copy];
+        });
+        
+        [self setNeedsSave];
+    });
+}
+
+- (void)removeCacheForKey:(NSString*)key {
+    CHECK_FOR_EGOCACHE_PLIST();
+    
+    dispatch_async(_diskQueue, ^{
+        [[NSFileManager defaultManager] removeItemAtPath:cachePathForKey(_directory, key) error:NULL];
+    });
+    
+    [self setCacheTimeoutInterval:0 forKey:key];
+}
+
+- (BOOL)hasCacheForKey:(NSString*)key {
+    NSDate* date = [self dateForKey:key];
+    if(date == nil) return NO;
+    if([date timeIntervalSinceReferenceDate] < CFAbsoluteTimeGetCurrent()) return NO;
+    
+    return [[NSFileManager defaultManager] fileExistsAtPath:cachePathForKey(_directory, key)];
+}
+
+- (NSDate*)dateForKey:(NSString*)key {
+    __block NSDate* date = nil;
+    
+    dispatch_sync(_frozenCacheInfoQueue, ^{
+        date = (self.frozenCacheInfo)[key];
+    });
+    
+    return date;
+}
+
+- (NSArray*)allKeys {
+    __block NSArray* keys = nil;
+    
+    dispatch_sync(_frozenCacheInfoQueue, ^{
+        keys = [self.frozenCacheInfo allKeys];
+    });
+    
+    return keys;
+}
+
+- (void)setCacheTimeoutInterval:(NSTimeInterval)timeoutInterval forKey:(NSString*)key {
+    NSDate* date = timeoutInterval > 0 ? [NSDate dateWithTimeIntervalSinceNow:timeoutInterval] : nil;
+    
+    // Temporarily store in the frozen state for quick reads
+    dispatch_sync(_frozenCacheInfoQueue, ^{
+        NSMutableDictionary* info = [self.frozenCacheInfo mutableCopy];
+        
+        if(date) {
+            info[key] = date;
+        } else {
+            [info removeObjectForKey:key];
+        }
+        
+        self.frozenCacheInfo = info;
+    });
+    
+    // Save the final copy (this may be blocked by other operations)
+    dispatch_async(_cacheInfoQueue, ^{
+        if(date) {
+            _cacheInfo[key] = date;
+        } else {
+            [_cacheInfo removeObjectForKey:key];
+        }
+        
+        dispatch_sync(_frozenCacheInfoQueue, ^{
+            self.frozenCacheInfo = [_cacheInfo copy];
+        });
+        
+        [self setNeedsSave];
+    });
+}
+
+#pragma mark -
+#pragma mark Copy file methods
+
+- (void)copyFilePath:(NSString*)filePath asKey:(NSString*)key {
+    [self copyFilePath:filePath asKey:key withTimeoutInterval:self.defaultTimeoutInterval];
+}
+
+- (void)copyFilePath:(NSString*)filePath asKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
+    dispatch_async(_diskQueue, ^{
+        [[NSFileManager defaultManager] copyItemAtPath:filePath toPath:cachePathForKey(_directory, key) error:NULL];
+    });
+    
+    [self setCacheTimeoutInterval:timeoutInterval forKey:key];
+}
+
+#pragma mark -
+#pragma mark Data methods
+
+- (void)setData:(NSData*)data forKey:(NSString*)key {
+    [self setData:data forKey:key withTimeoutInterval:self.defaultTimeoutInterval];
+}
+
+- (void)setData:(NSData*)data forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
+    CHECK_FOR_EGOCACHE_PLIST();
+    
+    NSString* cachePath = cachePathForKey(_directory, key);
+    
+    dispatch_async(_diskQueue, ^{
+        [data writeToFile:cachePath atomically:YES];
+    });
+    
+    [self setCacheTimeoutInterval:timeoutInterval forKey:key];
+}
+
+- (void)setNeedsSave {
+    dispatch_async(_cacheInfoQueue, ^{
+        if(_needsSave) return;
+        _needsSave = YES;
+        
+        double delayInSeconds = 0.5;
+        dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, delayInSeconds * NSEC_PER_SEC);
+        dispatch_after(popTime, _cacheInfoQueue, ^(void){
+            if(!_needsSave) return;
+            [_cacheInfo writeToFile:cachePathForKey(_directory, @"EGOCache.plist") atomically:YES];
+            _needsSave = NO;
+        });
+    });
+}
+
+- (NSData*)dataForKey:(NSString*)key {
+    if([self hasCacheForKey:key]) {
+        return [NSData dataWithContentsOfFile:cachePathForKey(_directory, key) options:0 error:NULL];
+    } else {
+        return nil;
+    }
+}
+
+#pragma mark -
+#pragma mark String methods
+
+- (NSString*)stringForKey:(NSString*)key {
+    return [[NSString alloc] initWithData:[self dataForKey:key] encoding:NSUTF8StringEncoding];
+}
+
+- (void)setString:(NSString*)aString forKey:(NSString*)key {
+    [self setString:aString forKey:key withTimeoutInterval:self.defaultTimeoutInterval];
+}
+
+- (void)setString:(NSString*)aString forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
+    [self setData:[aString dataUsingEncoding:NSUTF8StringEncoding] forKey:key withTimeoutInterval:timeoutInterval];
+}
+
+#pragma mark -
+#pragma mark Image methds
+
+#if TARGET_OS_IPHONE
+
+- (UIImage*)imageForKey:(NSString*)key {
+    UIImage* image = nil;
+    
+    @try {
+        image = [NSKeyedUnarchiver unarchiveObjectWithFile:cachePathForKey(_directory, key)];
+    } @catch (NSException* e) {
+        // Surpress any unarchiving exceptions and continue with nil
+    }
+    
+    return image;
+}
+
+- (void)setImage:(UIImage*)anImage forKey:(NSString*)key {
+    [self setImage:anImage forKey:key withTimeoutInterval:self.defaultTimeoutInterval];
+}
+
+- (void)setImage:(UIImage*)anImage forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
+    @try {
+        // Using NSKeyedArchiver preserves all information such as scale, orientation, and the proper image format instead of saving everything as pngs
+        [self setData:[NSKeyedArchiver archivedDataWithRootObject:anImage] forKey:key withTimeoutInterval:timeoutInterval];
+    } @catch (NSException* e) {
+        // Something went wrong, but we'll fail silently.
+    }
+}
+
+#else
+
+- (NSImage*)imageForKey:(NSString*)key {
+    return [[NSImage alloc] initWithData:[self dataForKey:key]];
+}
+
+- (void)setImage:(NSImage*)anImage forKey:(NSString*)key {
+    [self setImage:anImage forKey:key withTimeoutInterval:self.defaultTimeoutInterval];
+}
+
+- (void)setImage:(NSImage*)anImage forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
+    [self setData:[[NSBitmapImageRep imageRepWithData:anImage.TIFFRepresentation] representationUsingType:NSPNGFileType properties:@{ }] forKey:key withTimeoutInterval:timeoutInterval];
+}
+
+#endif
+
+#pragma mark -
+#pragma mark Property List methods
+
+- (NSData*)plistForKey:(NSString*)key; {
+    NSData* plistData = [self dataForKey:key];
+    return [NSPropertyListSerialization propertyListWithData:plistData options:NSPropertyListImmutable format:nil error:nil];
+}
+
+- (void)setPlist:(id)plistObject forKey:(NSString*)key; {
+    [self setPlist:plistObject forKey:key withTimeoutInterval:self.defaultTimeoutInterval];
+}
+
+- (void)setPlist:(id)plistObject forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval; {
+    // Binary plists are used over XML for better performance
+    NSData* plistData = [NSPropertyListSerialization dataWithPropertyList:plistObject format:NSPropertyListBinaryFormat_v1_0 options:0 error:nil];
+    
+    if(plistData != nil) {
+        [self setData:plistData forKey:key withTimeoutInterval:timeoutInterval];
+    }
+}
+
+#pragma mark -
+#pragma mark Object methods
+
+- (id<NSCoding>)objectForKey:(NSString*)key {
+    if([self hasCacheForKey:key]) {
+        return [NSKeyedUnarchiver unarchiveObjectWithData:[self dataForKey:key]];
+    } else {
+        return nil;
+    }
+}
+
+- (void)setObject:(id<NSCoding>)anObject forKey:(NSString*)key {
+    [self setObject:anObject forKey:key withTimeoutInterval:self.defaultTimeoutInterval];
+}
+
+- (void)setObject:(id<NSCoding>)anObject forKey:(NSString*)key withTimeoutInterval:(NSTimeInterval)timeoutInterval {
+    [self setData:[NSKeyedArchiver archivedDataWithRootObject:anObject] forKey:key withTimeoutInterval:timeoutInterval];
+}
+
+@end

--- a/sdk/PrebidMobile/PBBidManager.h
+++ b/sdk/PrebidMobile/PBBidManager.h
@@ -32,6 +32,7 @@ static int const kPCAttachTopBidMaxTimeoutMS = 1500;
 #endif
 
 typedef NS_ENUM(NSInteger, PBPrimaryAdServerType) {
+    PBPrimaryAdServerUnknown,
     PBPrimaryAdServerDFP,
     PBPrimaryAdServerMoPub
 };

--- a/sdk/PrebidMobile/PBBidManager.h
+++ b/sdk/PrebidMobile/PBBidManager.h
@@ -14,7 +14,6 @@
  */
 
 #import "PBAdUnit.h"
-#import "PBServerAdapter.h"
 
 @class PBBidResponse;
 

--- a/sdk/PrebidMobile/PBBidManager.h
+++ b/sdk/PrebidMobile/PBBidManager.h
@@ -32,10 +32,22 @@ static int const kPCAttachTopBidMaxTimeoutMS = 1500;
 + (void)resetSharedInstance;
 #endif
 
+typedef NS_ENUM(NSInteger, PBPrimaryAdServerType) {
+    PBPrimaryAdServerDFP,
+    PBPrimaryAdServerMoPub
+};
+
 /**
- * Registers all the ad units with the prebid server account id, and starts the auction for each ad unit
+ * DEPRECATED Registers all the ad units with the prebid server account id, and starts the auction for each ad unit
  */
-- (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits withAccountId:(nonnull NSString *)accountId;
+- (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits withAccountId:(nonnull NSString *)accountId __deprecated;
+
+/**
+ * Registers all the ad units with the prebid server account id, and primary ad server and starts the auction for each ad unit
+ */
+- (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits
+          withAccountId:(nonnull NSString *)accountId
+     andPrimaryAdServer:(PBPrimaryAdServerType)adServer;
 
 /**
  * Returns the ad unit for the string identifier

--- a/sdk/PrebidMobile/PBBidManager.m
+++ b/sdk/PrebidMobile/PBBidManager.m
@@ -94,6 +94,22 @@ static dispatch_once_t onceToken;
     [self requestBidsForAdUnits:adUnits];
 }
 
+- (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits
+          withAccountId:(nonnull NSString *)accountId
+     andPrimaryAdServer:(PBPrimaryAdServerType)adServer {
+    if (_adUnits == nil) {
+        _adUnits = [[NSMutableSet alloc] init];
+    }
+    _bidsMap = [[NSMutableDictionary alloc] init];
+    _demandAdapter = [[PBServerAdapter alloc] initWithAccountId:accountId];
+    _demandAdapter.primaryAdServer = adServer;
+    for (id adUnit in adUnits) {
+        [self registerAdUnit:adUnit];
+    }
+    [self startPollingBidsExpiryTimer];
+    [self requestBidsForAdUnits:adUnits];
+}
+
 - (nullable PBAdUnit *)adUnitByIdentifier:(nonnull NSString *)identifier {
     NSArray *adUnits = [_adUnits allObjects];
     for (PBAdUnit *adUnit in adUnits) {

--- a/sdk/PrebidMobile/PrebidMobile.h
+++ b/sdk/PrebidMobile/PrebidMobile.h
@@ -13,19 +13,30 @@
  limitations under the License.
  */
 
-#import <UIKit/UIKit.h>
+#import "PBBidManager.h"
 #import "PBLogging.h"
+#import <UIKit/UIKit.h>
 
 @class PBAdUnit;
 
 @interface PrebidMobile : NSObject
 
 /**
- * This method allows the developer to register the ad units created for Prebid Mobile
+ * DEPRECATED: This method allows the developer to register the ad units created for Prebid Mobile
  * @param adUnits : Array of AdUnits that can be registered
  * @param accountId : Prebid server accountId
  */
-+ (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits withAccountId:(nonnull NSString *)accountId;
++ (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits withAccountId:(nonnull NSString *)accountId __deprecated;
+
+/**
+ * This method allows the developer to register the ad units created for Prebid Mobile
+ * @param adUnits : Array of AdUnits that can be registered
+ * @param accountId : Prebid server accountId
+ * @param adServer : Primary ad server - needed to determine optimal bid caching
+ */
++ (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits
+          withAccountId:(nonnull NSString *)accountId
+     andPrimaryAdServer:(PBPrimaryAdServerType)adServer;
 
 + (void)setBidKeywordsOnAdObject:(nonnull id)adObject withAdUnitId:(nonnull NSString *)adUnitId;
 
@@ -33,5 +44,6 @@
                     withAdUnitId:(nonnull NSString *)adUnitIdentifier
                      withTimeout:(int)timeoutInMilliseconds
                completionHandler:(nullable void (^)(void))handler;
+
 
 @end

--- a/sdk/PrebidMobile/PrebidMobile.m
+++ b/sdk/PrebidMobile/PrebidMobile.m
@@ -13,15 +13,20 @@
  limitations under the License.
  */
 
-#import "PBBidManager.h"
 #import "PrebidMobile.h"
 #import "PrebidURLProtocol.h"
 
 @implementation PrebidMobile
 
 + (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits withAccountId:(nonnull NSString *)accountId {
-    [NSURLProtocol registerClass:[PrebidURLProtocol class]];
     [[PBBidManager sharedInstance] registerAdUnits:adUnits withAccountId:accountId];
+}
+
++ (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits
+          withAccountId:(nonnull NSString *)accountId
+     andPrimaryAdServer:(PBPrimaryAdServerType)adServer {
+    [NSURLProtocol registerClass:[PrebidURLProtocol class]];
+    [[PBBidManager sharedInstance] registerAdUnits:adUnits withAccountId:accountId andPrimaryAdServer:adServer];
 }
 
 + (void)setBidKeywordsOnAdObject:(nonnull id)adObject

--- a/sdk/PrebidMobile/PrebidMobile.m
+++ b/sdk/PrebidMobile/PrebidMobile.m
@@ -15,10 +15,12 @@
 
 #import "PBBidManager.h"
 #import "PrebidMobile.h"
+#import "PrebidURLProtocol.h"
 
 @implementation PrebidMobile
 
 + (void)registerAdUnits:(nonnull NSArray<PBAdUnit *> *)adUnits withAccountId:(nonnull NSString *)accountId {
+    [NSURLProtocol registerClass:[PrebidURLProtocol class]];
     [[PBBidManager sharedInstance] registerAdUnits:adUnits withAccountId:accountId];
 }
 

--- a/sdk/PrebidMobile/PrebidURLProtocol.h
+++ b/sdk/PrebidMobile/PrebidURLProtocol.h
@@ -1,0 +1,20 @@
+/*   Copyright 2017 APPNEXUS INC
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface PrebidURLProtocol : NSURLProtocol
+
+@end

--- a/sdk/PrebidMobile/PrebidURLProtocol.m
+++ b/sdk/PrebidMobile/PrebidURLProtocol.m
@@ -1,0 +1,26 @@
+/*   Copyright 2017 APPNEXUS INC
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "PrebidURLProtocol.h"
+
+@interface PrebidURLProtocol () <NSURLConnectionDelegate>
+
+@property (nonatomic, strong) NSURLConnection *connection;
+
+@end
+
+@implementation PrebidURLProtocol
+
+@end

--- a/sdk/PrebidMobile/PrebidURLProtocol.m
+++ b/sdk/PrebidMobile/PrebidURLProtocol.m
@@ -13,6 +13,7 @@
  limitations under the License.
  */
 
+#import "EGOCache.h"
 #import "PrebidURLProtocol.h"
 
 @interface PrebidURLProtocol () <NSURLConnectionDelegate>
@@ -22,5 +23,70 @@
 @end
 
 @implementation PrebidURLProtocol
+
++ (BOOL)canInitWithRequest:(NSURLRequest *)request {
+    static NSUInteger requestCount = 0;
+    if ([NSURLProtocol propertyForKey:@"PrebidURLProtocolHandledKey" inRequest:request]) {
+        return NO;
+    }
+    if ([request.URL.absoluteString containsString:@"prebid.adnxs.com/pbc/v1/cache"]) {
+        return YES;
+    }
+    return NO;
+}
+
++ (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
+    return request;
+}
+
++ (BOOL)requestIsCacheEquivalent:(NSURLRequest *)a toRequest:(NSURLRequest *)b {
+    return [super requestIsCacheEquivalent:a toRequest:b];
+}
+
+- (void)startLoading {
+    NSMutableURLRequest *newRequest = [self.request mutableCopy];
+    [NSURLProtocol setProperty:@YES forKey:@"PrebidURLProtocolHandledKey" inRequest:newRequest];
+
+    NSRange range = [newRequest.URL.absoluteString rangeOfString:@"uuid="];
+    if (range.location == NSNotFound) {
+        NSLog(@"No uuid in URL");
+    }
+    NSString *uuid = [newRequest.URL.absoluteString substringFromIndex:(range.location + 5)];
+
+    NSDictionary *dict = (NSDictionary *)[[EGOCache globalCache] objectForKey:uuid];
+    if (dict != nil) {
+        NSData *data = [NSJSONSerialization dataWithJSONObject:dict
+                                                       options:NSUTF8StringEncoding
+                                                         error:nil];
+        NSURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:[self.request URL] statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{@"Access-Control-Allow-Origin": @"https://pubads.g.doubleclick.net", @"Access-Control-Allow-Credentials" : @"true"}];
+
+        [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+        [self.client URLProtocol:self didLoadData:data];
+        [self.client URLProtocolDidFinishLoading:self];
+
+        [[EGOCache globalCache] removeCacheForKey:uuid];
+    }
+}
+
+- (void)stopLoading {
+    [self.connection cancel];
+    self.connection = nil;
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
+    [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
+    [self.client URLProtocol:self didLoadData:data];
+}
+
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
+    [self.client URLProtocolDidFinishLoading:self];
+}
+
+- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
+    [self.client URLProtocol:self didFailWithError:error];
+}
 
 @end

--- a/sdk/PrebidMobile/PrebidURLProtocol.m
+++ b/sdk/PrebidMobile/PrebidURLProtocol.m
@@ -25,7 +25,6 @@
 @implementation PrebidURLProtocol
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request {
-    static NSUInteger requestCount = 0;
     if ([NSURLProtocol propertyForKey:@"PrebidURLProtocolHandledKey" inRequest:request]) {
         return NO;
     }

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
@@ -58,6 +58,26 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
 
 #pragma mark - Test register ad units tests
 
+- (void)testRegisterBannerAdUnitWithDFPPrimaryAdServer {
+    PBAdUnit *bannerAdUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt1" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
+    [bannerAdUnit addSize:CGSizeMake(320, 50)];
+
+    [[PBBidManager sharedInstance] registerAdUnits:@[bannerAdUnit] withAccountId:self.accountId andPrimaryAdServer:PBPrimaryAdServerDFP];
+    PBPrimaryAdServerType primaryAdServer = [PBBidManager sharedInstance].demandAdapter.primaryAdServer;
+
+    XCTAssertTrue(primaryAdServer == PBPrimaryAdServerDFP);
+}
+
+- (void)testRegisterBannerAdUnitWithMoPubPrimaryAdServer {
+    PBAdUnit *bannerAdUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt1" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
+    [bannerAdUnit addSize:CGSizeMake(320, 50)];
+
+    [[PBBidManager sharedInstance] registerAdUnits:@[bannerAdUnit] withAccountId:self.accountId andPrimaryAdServer:PBPrimaryAdServerMoPub];
+    PBPrimaryAdServerType primaryAdServer = [PBBidManager sharedInstance].demandAdapter.primaryAdServer;
+
+    XCTAssertTrue(primaryAdServer == PBPrimaryAdServerMoPub);
+}
+
 - (void)testRegisterBannerAdUnit {
     PBAdUnit *returnedUnit = nil;
     PBAdUnit *bannerAdUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt1" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBServerAdapterTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBServerAdapterTests.m
@@ -75,6 +75,42 @@ static NSString *const kPrebidMobileVersion = @"0.1.1";
     XCTAssertTrue([sizesArray count] == 1);
 }
 
+- (void)testRequestBodyForAdUnitPrimaryAdServerUnknown {
+    PBAdUnit *adUnit = [[PBAdUnit alloc] initWithIdentifier:@"test_identifier" andAdType:PBAdUnitTypeBanner andConfigId:@"test_config_id"];
+    [adUnit addSize:CGSizeMake(250, 300)];
+    NSArray *adUnits = @[adUnit];
+
+    PBServerAdapter *serverAdapter = [[PBServerAdapter alloc] initWithAccountId:@"test_account_id"];
+    serverAdapter.primaryAdServer = PBPrimaryAdServerUnknown;
+    NSDictionary *requestBody = [serverAdapter requestBodyForAdUnits:adUnits];
+
+    XCTAssertEqualObjects(requestBody[@"cache_markup"], @(1));
+}
+
+- (void)testRequestBodyForAdUnitWithDFPAdServer {
+    PBAdUnit *adUnit = [[PBAdUnit alloc] initWithIdentifier:@"test_identifier" andAdType:PBAdUnitTypeBanner andConfigId:@"test_config_id"];
+    [adUnit addSize:CGSizeMake(250, 300)];
+    NSArray *adUnits = @[adUnit];
+
+    PBServerAdapter *serverAdapter = [[PBServerAdapter alloc] initWithAccountId:@"test_account_id"];
+    serverAdapter.primaryAdServer = PBPrimaryAdServerDFP;
+    NSDictionary *requestBody = [serverAdapter requestBodyForAdUnits:adUnits];
+
+    XCTAssertNil(requestBody[@"cache_markup"]);
+}
+
+- (void)testRequestBodyForAdUnitWithMoPubAdServer {
+    PBAdUnit *adUnit = [[PBAdUnit alloc] initWithIdentifier:@"test_identifier" andAdType:PBAdUnitTypeBanner andConfigId:@"test_config_id"];
+    [adUnit addSize:CGSizeMake(250, 300)];
+    NSArray *adUnits = @[adUnit];
+
+    PBServerAdapter *serverAdapter = [[PBServerAdapter alloc] initWithAccountId:@"test_account_id"];
+    serverAdapter.primaryAdServer = PBPrimaryAdServerMoPub;
+    NSDictionary *requestBody = [serverAdapter requestBodyForAdUnits:adUnits];
+
+    XCTAssertEqualObjects(requestBody[@"cache_markup"], @(1));
+}
+
 - (void)testPerformanceExample {
     // This is an example of a performance test case.
     [self measureBlock:^{

--- a/sdk/PrebidServerAdapter/PBServerAdapter.h
+++ b/sdk/PrebidServerAdapter/PBServerAdapter.h
@@ -21,6 +21,8 @@
 
 - (nonnull instancetype)initWithAccountId:(nonnull NSString *)accountId;
 
+@property (nonatomic, assign, readwrite) int primaryAdServer;
+
 - (void)requestBidsWithAdUnits:(nullable NSArray<PBAdUnit *> *)adUnits
                   withDelegate:(nonnull id<PBBidResponseDelegate>)delegate;
 

--- a/sdk/PrebidServerAdapter/PBServerAdapter.h
+++ b/sdk/PrebidServerAdapter/PBServerAdapter.h
@@ -15,13 +15,14 @@
 
 #import <Foundation/Foundation.h>
 #import "PBAdUnit.h"
+#import "PBBidManager.h"
 #import "PBBidResponseDelegate.h"
 
 @interface PBServerAdapter : NSObject
 
 - (nonnull instancetype)initWithAccountId:(nonnull NSString *)accountId;
 
-@property (nonatomic, assign, readwrite) int primaryAdServer;
+@property (nonatomic, assign, readwrite) PBPrimaryAdServerType primaryAdServer;
 
 - (void)requestBidsWithAdUnits:(nullable NSArray<PBAdUnit *> *)adUnits
                   withDelegate:(nonnull id<PBBidResponseDelegate>)delegate;

--- a/sdk/PrebidServerAdapter/PBServerAdapter.m
+++ b/sdk/PrebidServerAdapter/PBServerAdapter.m
@@ -106,7 +106,7 @@ static NSTimeInterval const kAdTimeoutInterval = 360;
 - (NSDictionary *)requestBodyForAdUnits:(NSArray<PBAdUnit *> *)adUnits {
     NSMutableDictionary *requestDict = [[NSMutableDictionary alloc] init];
 
-    if (self.primaryAdServer == PBPrimaryAdServerMoPub) {
+    if (self.primaryAdServer == PBPrimaryAdServerMoPub || self.primaryAdServer == PBPrimaryAdServerUnknown) {
         requestDict[@"cache_markup"] = @(1);
     }
 

--- a/sdk/PrebidServerAdapter/PBServerAdapter.m
+++ b/sdk/PrebidServerAdapter/PBServerAdapter.m
@@ -16,6 +16,7 @@
 #import <AdSupport/AdSupport.h>
 #import <CoreTelephony/CTCarrier.h>
 #import <CoreTelephony/CTTelephonyNetworkInfo.h>
+#import "EGOCache.h"
 #import <sys/utsname.h>
 #import <UIKit/UIKit.h>
 
@@ -32,6 +33,7 @@
 static NSString *const kAPNAdServerResponseKeyNoBid = @"nobid";
 static NSString *const kAPNAdServerResponseKeyUUID = @"uuid";
 static NSString *const kPrebidMobileVersion = @"0.1.1";
+static NSTimeInterval const kAdTimeoutInterval = 360;
 
 @interface PBServerAdapter ()
 
@@ -60,7 +62,14 @@ static NSString *const kPrebidMobileVersion = @"0.1.1";
             NSArray *bidsArray = (NSArray *)[adUnitToBidsMap objectForKey:adUnitId];
             NSMutableArray *bidResponsesArray = [[NSMutableArray alloc] init];
             for (NSDictionary *bid in bidsArray) {
-                PBBidResponse *bidResponse = [PBBidResponse bidResponseWithAdUnitId:adUnitId adServerTargeting:bid[@"ad_server_targeting"]];
+                NSString *cacheId = [[NSUUID UUID] UUIDString];
+                NSMutableDictionary *bidCopy = [bid mutableCopy];
+                NSMutableDictionary *adServerTargetingCopy = [bidCopy[@"ad_server_targeting"] mutableCopy];
+                adServerTargetingCopy[@"hb_cache_id"] = cacheId;
+                [bidCopy setObject:adServerTargetingCopy forKey:@"ad_server_targeting"];
+                [[EGOCache globalCache] setObject:bidCopy forKey:cacheId withTimeoutInterval:kAdTimeoutInterval];
+
+                PBBidResponse *bidResponse = [PBBidResponse bidResponseWithAdUnitId:adUnitId adServerTargeting:bidCopy[@"ad_server_targeting"]];
                 PBLogDebug(@"Bid Successful with rounded bid targeting keys are %@ for adUnit id is %@", bidResponse.customKeywords, adUnitId);
                 [bidResponsesArray addObject:bidResponse];
             }
@@ -89,15 +98,14 @@ static NSString *const kPrebidMobileVersion = @"0.1.1";
 
 - (NSDictionary *)requestBodyForAdUnits:(NSArray<PBAdUnit *> *)adUnits {
     NSMutableDictionary *requestDict = [[NSMutableDictionary alloc] init];
-    
-    requestDict[@"cache_markup"] = @(1);
+
     requestDict[@"sort_bids"] = @(1);
     // need this so DFP targeting keys aren't too long
     requestDict[@"max_key_length"] = @(20);
     requestDict[@"account_id"] = self.accountId;
     requestDict[@"tid"] = [[NSUUID UUID] UUIDString];
     requestDict[@"prebid_version"] = @"0.21.0-pre";
-    
+
     requestDict[@"sdk"] = @{@"source": @"prebid-mobile",
                             @"version": kPrebidMobileVersion,
                             @"platform": @"iOS"};
@@ -118,7 +126,7 @@ static NSString *const kPrebidMobileVersion = @"0.1.1";
     if (keywords) {
         requestDict[@"keywords"] = keywords;
     }
-    
+
     NSMutableArray *adUnitConfigs = [[NSMutableArray alloc] init];
     for (PBAdUnit *adUnit in adUnits) {
         NSMutableDictionary *adUnitConfig = [[NSMutableDictionary alloc] init];

--- a/sdk/PrebidServerAdapter/PBServerAdapter.m
+++ b/sdk/PrebidServerAdapter/PBServerAdapter.m
@@ -63,11 +63,15 @@ static NSTimeInterval const kAdTimeoutInterval = 360;
             NSMutableArray *bidResponsesArray = [[NSMutableArray alloc] init];
             for (NSDictionary *bid in bidsArray) {
                 PBBidResponse *bidResponse = [PBBidResponse bidResponseWithAdUnitId:adUnitId adServerTargeting:bid[@"ad_server_targeting"]];
-                if (_primaryAdServer == 0) {
+                if (self.primaryAdServer == PBPrimaryAdServerDFP) {
                     NSString *cacheId = [[NSUUID UUID] UUIDString];
                     NSMutableDictionary *bidCopy = [bid mutableCopy];
                     NSMutableDictionary *adServerTargetingCopy = [bidCopy[@"ad_server_targeting"] mutableCopy];
-                    adServerTargetingCopy[@"hb_cache_id"] = cacheId;
+                    for (NSString *key in [adServerTargetingCopy allKeys]) {
+                        if ([key containsString:@"hb_cache_id"]) {
+                            adServerTargetingCopy[key] = cacheId;
+                        }
+                    }
                     [bidCopy setObject:adServerTargetingCopy forKey:@"ad_server_targeting"];
                     [[EGOCache globalCache] setObject:bidCopy forKey:cacheId withTimeoutInterval:kAdTimeoutInterval];
 
@@ -102,7 +106,7 @@ static NSTimeInterval const kAdTimeoutInterval = 360;
 - (NSDictionary *)requestBodyForAdUnits:(NSArray<PBAdUnit *> *)adUnits {
     NSMutableDictionary *requestDict = [[NSMutableDictionary alloc] init];
 
-    if (self.primaryAdServer == 1) {
+    if (self.primaryAdServer == PBPrimaryAdServerMoPub) {
         requestDict[@"cache_markup"] = @(1);
     }
 


### PR DESCRIPTION
For pubs with DFP as primary ad server use [EGOCache library](https://github.com/enormego/EGOCache) to safely cache bids with a 6 minute expiry. This code caches the full bid object and generates cacheId client side.

For pubs with MoPub, still cache the bid on server side, send cache_markup = 1 through to PBS.

Deprecate old registerAdUnits API in favor of the new one where we can cache locally for DFP bids. 