### PR TITLE
Fix prebid cache

### DIFF
--- a/sdk/PrebidMobile/PrebidCache.h
+++ b/sdk/PrebidMobile/PrebidCache.h
@@ -20,5 +20,5 @@
 
 + (nonnull instancetype)globalCache;
 
-- (void) cacheContents: (NSArray *) contents forAdserver:(PBPrimaryAdServerType) adserver withCompletionBlock: (void (^)(NSArray *))completionBlock;
+- (void) cacheContents: (NSArray *) contents forAdserver:(PBPrimaryAdServerType) adserver withCompletionBlock: (void (^)(NSError *, NSArray *))completionBlock;
 @end

--- a/sdk/PrebidMobile/PrebidCache.h
+++ b/sdk/PrebidMobile/PrebidCache.h
@@ -20,5 +20,5 @@
 
 + (nonnull instancetype)globalCache;
 
-- (void) cacheContents: (NSArray *) contents forAdserver:(PBPrimaryAdServerType) adserver withCompletionBlock: (void (^)(NSError *, NSArray *))completionBlock;
+- (void) cacheContents: (NSArray *) contents forAdserver:(PBPrimaryAdServerType) adserver withCompletionBlock: (nonnull void (^)(NSError *, NSArray *))completionBlock;
 @end

--- a/sdk/PrebidMobile/PrebidCache.m
+++ b/sdk/PrebidMobile/PrebidCache.m
@@ -36,7 +36,7 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
 @property WKWebView *wkwebviewCache;
 
 @property NSString* htmlToLoad;
-@property NSInteger checkingCount;
+@property NSMutableArray *cacheIds;
 @property (nonnull) void (^sendCacheIds)(NSError *, NSArray *);
 
 - (instancetype)initWithContentsToLoad: (NSArray *)contents withAdserver: (PBPrimaryAdServerType) adserver withCompletionHandler: (void (^) (NSError *, NSArray *)) completionBlock;

--- a/sdk/PrebidMobile/PrebidCache.m
+++ b/sdk/PrebidMobile/PrebidCache.m
@@ -50,7 +50,8 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
     if (self = [super init]) {
         executing = NO;
         finished = NO;
-        if (contents == nil || contents.count == 0 || completionBlock == nil) {
+        if (contents == nil || contents.count == 0) {
+            self.sendCacheIds = completionBlock;
             [self finishAndChangeState];
         } else {
             long long milliseconds = (long long)([[NSDate date] timeIntervalSince1970] * 1000.0);
@@ -177,9 +178,13 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
         strongSelf.wkwebviewCache = nil;
         strongSelf.uiwebviewCache = nil;
         if(self.cacheIds != nil && self.cacheIds.count>0){
-            strongSelf.sendCacheIds(nil, strongSelf.cacheIds);
+            if (strongSelf.sendCacheIds != nil) {
+                strongSelf.sendCacheIds(nil, strongSelf.cacheIds);
+            }
         } else {
-            strongSelf.sendCacheIds([NSError errorWithDomain:@"org.prebid" code:0 userInfo:nil ], nil);
+            if (strongSelf.sendCacheIds !=nil) {
+                strongSelf.sendCacheIds([NSError errorWithDomain:@"org.prebid" code:0 userInfo:nil ], nil);
+            }
         }
         [strongSelf willChangeValueForKey:@"isExecuting"];
         strongSelf->executing = NO;

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBPrebidCacheTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBPrebidCacheTests.m
@@ -30,10 +30,11 @@
     NSArray *contents = @[@"0", @"1", @"2"];
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"UIWebView expectation"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"WkWebView expectation"];
-    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerDFP withCompletionBlock:^(NSArray *cacheIds) {
+    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerDFP withCompletionBlock:^(NSError *error, NSArray *cacheIds) {
         //use cacheIds[0] should retrieve content 0
         //use cacheIds[1] should retrieve content 1
         //use cacheIds[2] should retrieve content 2
+        XCTAssertTrue(error == nil);
         XCTAssertTrue(cacheIds.count == 3);
         NSURL *host = [NSURL URLWithString:@"https://pubads.g.doubleclick.net"];
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -74,10 +75,11 @@
 {
     NSArray *contents = @[@"0", @"1", @"2"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"WkWebView expectation"];
-    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerMoPub withCompletionBlock:^(NSArray *cacheIds) {
+    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerMoPub withCompletionBlock:^(NSError *error, NSArray *cacheIds) {
         //use cacheIds[0] should retrieve content 0
         //use cacheIds[1] should retrieve content 1
         //use cacheIds[2] should retrieve content 2
+        XCTAssertTrue(error == nil);
         XCTAssertTrue(cacheIds.count == 3);
         NSURL *host = [NSURL URLWithString:@"https://ads.mopub.com"];
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -101,6 +103,21 @@
     }];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
 }
+
+- (void) testPrebidCacheReturnErrorForEmptyContents
+{
+    NSArray *contents = @[];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"cache error expection"];
+    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerDFP withCompletionBlock:^(NSError *error, NSArray *cacheIds) {
+        XCTAssertTrue(error != nil);
+        XCTAssertTrue([error.domain isEqualToString:@"org.prebid"]);
+        XCTAssertTrue(error.code == 0);
+        XCTAssertTrue(cacheIds == nil);
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation]  timeout:20.0];
+}
+
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView
 {

--- a/sdk/PrebidServerAdapter/PBServerAdapter.m
+++ b/sdk/PrebidServerAdapter/PBServerAdapter.m
@@ -101,23 +101,29 @@ static int const kBatchCount = 10;
                     [contentsToCache addObject:escapedBid];
                 }
                 
-                [[PrebidCache globalCache] cacheContents:contentsToCache forAdserver:self.primaryAdServer withCompletionBlock:^(NSArray *cacheIds) {
-
-                    for (int i = 0; i< bidsArray.count; i++) {
-                        NSMutableDictionary *adServerTargetingCopy = [bidsArray[i][@"ext"][@"prebid"][@"targeting"] mutableCopy];
-                        if (i == 0) {
-                            NSString *cacheId = cacheIds[i];
-                            adServerTargetingCopy[kAPNAdServerCacheIdKey] = cacheId;
+                [[PrebidCache globalCache] cacheContents:contentsToCache forAdserver:self.primaryAdServer withCompletionBlock:^(NSError * error, NSArray *cacheIds) {
+                    
+                    if(!error) {
+                        for (int i = 0; i< bidsArray.count; i++) {
+                            NSMutableDictionary *adServerTargetingCopy = [bidsArray[i][@"ext"][@"prebid"][@"targeting"] mutableCopy];
+                            if (adServerTargetingCopy != nil) {
+                                if (i == 0) {
+                                    NSString *cacheId = cacheIds[i];
+                                    adServerTargetingCopy[kAPNAdServerCacheIdKey] = cacheId;
+                                }
+                                NSString *bidderCacheId = cacheIds[i];
+                                NSString *cacheIdkey =[ NSString stringWithFormat:@"%@_%@", kAPNAdServerCacheIdKey, bidsArray[i][@"seat"]];
+                                cacheIdkey = cacheIdkey.length > 20 ? [cacheIdkey substringToIndex:20] : cacheIdkey;
+                                adServerTargetingCopy[cacheIdkey] = bidderCacheId;
+                                PBBidResponse *bidResponse = [PBBidResponse bidResponseWithAdUnitId:adUnitId adServerTargeting:adServerTargetingCopy];
+                                PBLogDebug(@"Bid Successful with rounded bid targeting keys are %@ for adUnit id is %@", [bidResponse.customKeywords description], adUnitId);
+                                [bidResponsesArray addObject:bidResponse];
+                            }
                         }
-                        NSString *bidderCacheId = cacheIds[i];
-                        NSString *cacheIdkey =[ NSString stringWithFormat:@"%@_%@", kAPNAdServerCacheIdKey, bidsArray[i][@"seat"]];
-                        cacheIdkey = cacheIdkey.length > 20 ? [cacheIdkey substringToIndex:20] : cacheIdkey;
-                        adServerTargetingCopy[cacheIdkey] = bidderCacheId;
-                        PBBidResponse *bidResponse = [PBBidResponse bidResponseWithAdUnitId:adUnitId adServerTargeting:adServerTargetingCopy];
-                        PBLogDebug(@"Bid Successful with rounded bid targeting keys are %@ for adUnit id is %@", [bidResponse.customKeywords description], adUnitId);
-                        [bidResponsesArray addObject:bidResponse];
+                        [delegate didReceiveSuccessResponse:bidResponsesArray];;
+                    } else {
+                        [delegate didCompleteWithError:error];
                     }
-                    [delegate didReceiveSuccessResponse:bidResponsesArray];;
                 }];
             }
         }];


### PR DESCRIPTION
PrebidCache doesn't write to disk until it's released in memory, thus causing DFP/MoPub webview unable to read from PrebidCache sometimes. Fix is only sending the cache id back after PrebidCache writes to disk, a.k.a ARC is zero for webviews caching the content. 