### PR TITLE
Analytics feature

### DIFF
--- a/PrebidMobile.podspec
+++ b/PrebidMobile.podspec
@@ -31,7 +31,8 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.source       = { :git => "https://github.com/prebid/prebid-mobile-ios.git", :tag => "#{s.version}" }
   s.source_files = "sdk/PrebidMobile", "sdk/PrebidMobile/**/*.{h,m}", "sdk/PrebidServerAdapter/**/*.{h,m}"
-  s.public_header_files = "sdk/PrebidServerAdapter/PBServerAdapter.h", "sdk/PrebidMobile/*.h", "sdk/PrebidMobile/Logging/*.h"
+  s.public_header_files = "sdk/PrebidServerAdapter/PBServerAdapter.h", "sdk/PrebidMobile/*.h", "sdk/PrebidMobile/Logging/*.h", "sdk/PrebidMobile/Analytics/*.h"
+  s.exclude_files = "sdk/PrebidMobile/Analytics/Services/*.{h,m}"
   s.requires_arc = true
   s.xcconfig = {
 :LIBRARY_SEARCH_PATHS => '$(inherited)',

--- a/examples/PrebidMobileDemo/Podfile
+++ b/examples/PrebidMobileDemo/Podfile
@@ -4,5 +4,5 @@
 target 'PrebidMobileDemo' do
   pod 'Google-Mobile-Ads-SDK'
   pod 'mopub-ios-sdk'
-
+  pod 'Analytics', '~> 3.0'
 end

--- a/examples/PrebidMobileDemo/PrebidMobileDemo.xcodeproj/project.pbxproj
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05E2E47B212CC8CF00D532F5 /* PBSegmentAnalyticsService.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2E47A212CC8CF00D532F5 /* PBSegmentAnalyticsService.m */; };
 		98DE194CD419CB43DF2EEE9F /* libPods-PrebidMobileDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BFB505B67305B895820CE279 /* libPods-PrebidMobileDemo.a */; };
 		C23386CB1EE5DAC9002FD404 /* PrebidMobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23386CA1EE5DAA7002FD404 /* PrebidMobile.framework */; };
 		C268CA911EA65FD7008656F2 /* pbm_basic.feature in Resources */ = {isa = PBXBuildFile; fileRef = C268CA871EA65FD7008656F2 /* pbm_basic.feature */; };
@@ -111,6 +112,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		05E2E479212CC8CF00D532F5 /* PBSegmentAnalyticsService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PBSegmentAnalyticsService.h; sourceTree = "<group>"; };
+		05E2E47A212CC8CF00D532F5 /* PBSegmentAnalyticsService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PBSegmentAnalyticsService.m; sourceTree = "<group>"; };
 		171395FED98D8A0665F34125 /* Pods-PrebidMobileDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidMobileDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PrebidMobileDemo/Pods-PrebidMobileDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		606A126220C72B2100B5DB32 /* CMPReference.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CMPReference.xcodeproj; path = ../../tools/CMPReference/CMPReference.xcodeproj; sourceTree = "<group>"; };
 		A1ECD3D3DF1C659CA6E60DDD /* Pods-PrebidMobileDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidMobileDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-PrebidMobileDemo/Pods-PrebidMobileDemo.release.xcconfig"; sourceTree = "<group>"; };
@@ -213,6 +216,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		05E2E477212CC8C200D532F5 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				05E2E479212CC8CF00D532F5 /* PBSegmentAnalyticsService.h */,
+				05E2E47A212CC8CF00D532F5 /* PBSegmentAnalyticsService.m */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
 		08AA719FD7B712EEB12D7083 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -302,6 +314,7 @@
 		C273C8071E82DAAD003EF1AB /* PrebidMobileDemo */ = {
 			isa = PBXGroup;
 			children = (
+				05E2E477212CC8C200D532F5 /* Analytics */,
 				C273CAB31E83168B003EF1AB /* BannerViewControllers */,
 				C273CAB71E83242B003EF1AB /* IntersitialViewControllers */,
 				C273CAB81E832435003EF1AB /* NativeViewControllers */,
@@ -417,7 +430,6 @@
 				C273C8021E82DAAD003EF1AB /* Frameworks */,
 				C273C8031E82DAAD003EF1AB /* Resources */,
 				C23386CF1EE5DAC9002FD404 /* Embed Frameworks */,
-				7F490B3B6729BC8F03F10971 /* [CP] Embed Pods Frameworks */,
 				2DD0B09C41622022A4A69457 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -582,26 +594,31 @@
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPAdBrowserController.nib",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseBtn.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseBtn@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseBtn@3x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseButtonX.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseButtonX@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseButtonX@3x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCountdownTimer.html",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPDAAIcon.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPDAAIcon@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPDAAIcon@3x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPMutedBtn.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPMutedBtn@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPMutedBtn@3x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPPlayBtn.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPPlayBtn@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPPlayBtn@3x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPUnmutedBtn.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPUnmutedBtn@2x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPUnmutedBtn@3x.png",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MRAID.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PrebidMobileDemo/Pods-PrebidMobileDemo-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7F490B3B6729BC8F03F10971 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PrebidMobileDemo/Pods-PrebidMobileDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F50F7C340E70812CE7F317AE /* [CP] Check Pods Manifest.lock */ = {
@@ -637,6 +654,7 @@
 				C273C80A1E82DAAD003EF1AB /* main.m in Sources */,
 				C273CAC21E832494003EF1AB /* VideoTestsViewController.m in Sources */,
 				C2E8097D1E95899800DC7732 /* Constants.m in Sources */,
+				05E2E47B212CC8CF00D532F5 /* PBSegmentAnalyticsService.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/examples/PrebidMobileDemo/PrebidMobileDemo/Analytics/PBSegmentAnalyticsService.h
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo/Analytics/PBSegmentAnalyticsService.h
@@ -1,0 +1,21 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <PrebidMobile/PBAnalyticsService.h>
+
+@interface PBSegmentAnalyticsService : NSObject <PBAnalyticsService>
+
+@end

--- a/examples/PrebidMobileDemo/PrebidMobileDemo/Analytics/PBSegmentAnalyticsService.m
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo/Analytics/PBSegmentAnalyticsService.m
@@ -1,0 +1,44 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "PBSegmentAnalyticsService.h"
+#import <PrebidMobile/PBAnalyticsEvent.h>
+#import <Analytics/SEGAnalytics.h>
+
+@implementation PBSegmentAnalyticsService
+
+- (void)initializeWithApplication:(UIApplication *)application launchOptions:(NSDictionary *)launchOptions {
+    SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:@"insert_key_here"];
+    configuration.trackApplicationLifecycleEvents = NO; // Enable this to record certain application events automatically!
+    configuration.recordScreenViews = NO; // Enable this to record screen views automatically!
+    [SEGAnalytics setupWithConfiguration:configuration];
+}
+
+- (void)trackEvent:(PBAnalyticsEvent *)event {
+    if ([self isSupportedWithEvent:event]) {
+        NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+        NSDictionary *options = @{ @"context" : @{ @"app" : @{ @"name" : appName }}};
+        [[SEGAnalytics sharedAnalytics] track:event.title
+                                   properties:event.info
+                                      options:options];
+    }
+}
+
+- (BOOL)isSupportedWithEvent:(PBAnalyticsEvent *)event {
+    // check to see if this event is supported, all by default
+    return YES;
+}
+
+@end

--- a/examples/PrebidMobileDemo/PrebidMobileDemo/AppDelegate.m
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo/AppDelegate.m
@@ -21,6 +21,8 @@
 #import <PrebidMobile/PBTargetingParams.h>
 #import <PrebidMobile/PrebidMobile.h>
 #import <PrebidMobile/PBLogging.h>
+#import <PrebidMobile/PBAnalyticsManager.h>
+#import "PBSegmentAnalyticsService.h"
 #import "Constants.h"
 #import "SettingsViewController.h"
 #import <CMPReference/CMPStorage.h>
@@ -36,6 +38,12 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [self enablePrebidLogs];
+    
+    // Prebid Mobile analytics setup
+    PBSegmentAnalyticsService *analytics = [[PBSegmentAnalyticsService alloc] init];
+    [[PBAnalyticsManager sharedInstance] addService:analytics];
+    [[PBAnalyticsManager sharedInstance] initializeWithApplication:application launchOptions:launchOptions];
+    
     [self setupPrebidAndRegisterAdUnits];
 
     SettingsViewController *settingsViewController = [[SettingsViewController alloc] init];

--- a/sdk/PrebidMobile.xcodeproj/project.pbxproj
+++ b/sdk/PrebidMobile.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05E2E45E212B36C300D532F5 /* PBAnalyticsService.h in Headers */ = {isa = PBXBuildFile; fileRef = 05E2E45D212B36C300D532F5 /* PBAnalyticsService.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05E2E465212B37F800D532F5 /* PBAnalyticsEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 05E2E463212B37F800D532F5 /* PBAnalyticsEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05E2E466212B37F800D532F5 /* PBAnalyticsEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2E464212B37F800D532F5 /* PBAnalyticsEvent.m */; };
+		05E2E469212B751E00D532F5 /* PBAnalyticsManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 05E2E467212B751E00D532F5 /* PBAnalyticsManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		05E2E46A212B751E00D532F5 /* PBAnalyticsManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2E468212B751E00D532F5 /* PBAnalyticsManager.m */; };
+		05E2E48C212DFA2900D532F5 /* PBAnalyticsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2E48B212DFA2900D532F5 /* PBAnalyticsTests.m */; };
+		05E2E490212DFB5B00D532F5 /* PBMockAnalyticsService.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E2E48F212DFB5B00D532F5 /* PBMockAnalyticsService.m */; };
 		606A4299202005C400492433 /* ReadMe.md in Resources */ = {isa = PBXBuildFile; fileRef = 606A4298202005C400492433 /* ReadMe.md */; };
 		606A42A42020FD4600492433 /* PBServerRequestBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 606A42A22020FD4600492433 /* PBServerRequestBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		606A42A52020FD4600492433 /* PBServerRequestBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 606A42A32020FD4600492433 /* PBServerRequestBuilder.m */; };
@@ -90,6 +97,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		05E2E45D212B36C300D532F5 /* PBAnalyticsService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBAnalyticsService.h; sourceTree = "<group>"; };
+		05E2E45F212B371500D532F5 /* PBSegmentAnalyticsService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBSegmentAnalyticsService.h; sourceTree = "<group>"; };
+		05E2E460212B371500D532F5 /* PBSegmentAnalyticsService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBSegmentAnalyticsService.m; sourceTree = "<group>"; };
+		05E2E463212B37F800D532F5 /* PBAnalyticsEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBAnalyticsEvent.h; sourceTree = "<group>"; };
+		05E2E464212B37F800D532F5 /* PBAnalyticsEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBAnalyticsEvent.m; sourceTree = "<group>"; };
+		05E2E467212B751E00D532F5 /* PBAnalyticsManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBAnalyticsManager.h; sourceTree = "<group>"; };
+		05E2E468212B751E00D532F5 /* PBAnalyticsManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBAnalyticsManager.m; sourceTree = "<group>"; };
+		05E2E48B212DFA2900D532F5 /* PBAnalyticsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBAnalyticsTests.m; sourceTree = "<group>"; };
+		05E2E48E212DFB5B00D532F5 /* PBMockAnalyticsService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBMockAnalyticsService.h; sourceTree = "<group>"; };
+		05E2E48F212DFB5B00D532F5 /* PBMockAnalyticsService.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBMockAnalyticsService.m; sourceTree = "<group>"; };
 		606A4298202005C400492433 /* ReadMe.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ReadMe.md; sourceTree = "<group>"; };
 		606A42A22020FD4600492433 /* PBServerRequestBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBServerRequestBuilder.h; sourceTree = "<group>"; };
 		606A42A32020FD4600492433 /* PBServerRequestBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBServerRequestBuilder.m; sourceTree = "<group>"; };
@@ -170,7 +187,6 @@
 		C2B1747B1EE1E3C9006304C0 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		C2B1747D1EE1E3CE006304C0 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		E6BF995E1F7167B0001016FD /* PrebidMobile-umbrella.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PrebidMobile-umbrella.h"; sourceTree = "<group>"; };
-		EFD3C940519B957467FE94E6 /* libPods-PrebidMobile.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PrebidMobile.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F576AEF320D1B1FF00D41FBC /* PBPrebidCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBPrebidCacheTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -202,6 +218,28 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		05E2E458212B34AC00D532F5 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				05E2E482212DD3CF00D532F5 /* Services */,
+				05E2E45D212B36C300D532F5 /* PBAnalyticsService.h */,
+				05E2E463212B37F800D532F5 /* PBAnalyticsEvent.h */,
+				05E2E464212B37F800D532F5 /* PBAnalyticsEvent.m */,
+				05E2E467212B751E00D532F5 /* PBAnalyticsManager.h */,
+				05E2E468212B751E00D532F5 /* PBAnalyticsManager.m */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
+		05E2E482212DD3CF00D532F5 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				05E2E45F212B371500D532F5 /* PBSegmentAnalyticsService.h */,
+				05E2E460212B371500D532F5 /* PBSegmentAnalyticsService.m */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
 		606A4351202BC90800492433 /* Recovered References */ = {
 			isa = PBXGroup;
 			children = (
@@ -225,11 +263,12 @@
 			isa = PBXGroup;
 			children = (
 				C281E1941EE5F2AD00F2F4A9 /* PBAdUnitTests.m */,
+				05E2E48B212DFA2900D532F5 /* PBAnalyticsTests.m */,
 				C281E1951EE5F2AD00F2F4A9 /* PBBidManagerTests.m */,
 				C281E1961EE5F2AD00F2F4A9 /* PBBidResponseTests.m */,
-				C281E1981EE5F2AD00F2F4A9 /* PBTargetingParamsTests.m */,
-				C29238D81F3E38D100217075 /* PBServerAdapterTests.m */,
 				F576AEF320D1B1FF00D41FBC /* PBPrebidCacheTests.m */,
+				C29238D81F3E38D100217075 /* PBServerAdapterTests.m */,
+				C281E1981EE5F2AD00F2F4A9 /* PBTargetingParamsTests.m */,
 			);
 			path = PrebidMobileCoreTests;
 			sourceTree = "<group>";
@@ -262,6 +301,8 @@
 			children = (
 				C281E1B01EE5F2E500F2F4A9 /* PBMockServerAdapter.h */,
 				C281E1B11EE5F2E500F2F4A9 /* PBMockServerAdapter.m */,
+				05E2E48E212DFB5B00D532F5 /* PBMockAnalyticsService.h */,
+				05E2E48F212DFB5B00D532F5 /* PBMockAnalyticsService.m */,
 			);
 			path = MockObjects;
 			sourceTree = "<group>";
@@ -290,6 +331,7 @@
 		C2B16E1D1EE1BE69006304C0 /* PrebidMobile */ = {
 			isa = PBXGroup;
 			children = (
+				05E2E458212B34AC00D532F5 /* Analytics */,
 				60CEC02A2084DF3A00CA104B /* PBConstants.h */,
 				60CEC02B2084DF3A00CA104B /* PBConstants.m */,
 				606A4352202BC98100492433 /* PrebidMobile-umbrella.h */,
@@ -389,7 +431,6 @@
 				C2B1746E1EE1E3AC006304C0 /* CoreLocation.framework */,
 				C2B1746F1EE1E3AC006304C0 /* CoreMedia.framework */,
 				C2B174701EE1E3AC006304C0 /* CoreTelephony.framework */,
-				EFD3C940519B957467FE94E6 /* libPods-PrebidMobile.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -412,6 +453,7 @@
 				B455F9011FE460E3005D6261 /* PBBidManager.h in Headers */,
 				C23386D61EE5DC95002FD404 /* PBAdUnit.h in Headers */,
 				B40B92AF1FCCC5E300A676A8 /* PBHost.h in Headers */,
+				05E2E45E212B36C300D532F5 /* PBAnalyticsService.h in Headers */,
 				C2B16E3D1EE1BEA6006304C0 /* PBKeywordsManager.h in Headers */,
 				C23FCCEE1EE5E41E00CFFEF0 /* PBLogManager.h in Headers */,
 				C23386DA1EE5DCDB002FD404 /* PBServerAdapter.h in Headers */,
@@ -423,6 +465,8 @@
 				C2B16E9D1EE1BF1A006304C0 /* PBServerLocation.h in Headers */,
 				C2B16E981EE1BF1A006304C0 /* PBServerFetcher.h in Headers */,
 				C210FE381FC3375D0010B588 /* PrebidCache.h in Headers */,
+				05E2E469212B751E00D532F5 /* PBAnalyticsManager.h in Headers */,
+				05E2E465212B37F800D532F5 /* PBAnalyticsEvent.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -531,11 +575,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				606A42A62020FD4600492433 /* PBServerRequestBuilder.m in Sources */,
+				05E2E490212DFB5B00D532F5 /* PBMockAnalyticsService.m in Sources */,
 				C281E1AE1EE5F2DA00F2F4A9 /* ANURLConnectionStub.m in Sources */,
 				C281E1AD1EE5F2DA00F2F4A9 /* ANHTTPStubURLProtocol.m in Sources */,
 				C281E1B21EE5F2E500F2F4A9 /* PBMockServerAdapter.m in Sources */,
 				C281E19B1EE5F2AD00F2F4A9 /* PBBidResponseTests.m in Sources */,
 				C29238D91F3E38D100217075 /* PBServerAdapterTests.m in Sources */,
+				05E2E48C212DFA2900D532F5 /* PBAnalyticsTests.m in Sources */,
 				C281E19D1EE5F2AD00F2F4A9 /* PBTargetingParamsTests.m in Sources */,
 				F576AEF420D1B1FF00D41FBC /* PBPrebidCacheTests.m in Sources */,
 				C281E1991EE5F2AD00F2F4A9 /* PBAdUnitTests.m in Sources */,
@@ -556,6 +602,7 @@
 				C2B16E9C1EE1BF1A006304C0 /* PBServerGlobal.m in Sources */,
 				C2B16E3C1EE1BEA6006304C0 /* PBInterstitialAdUnit.m in Sources */,
 				C23FCCEB1EE5E3F500CFFEF0 /* PBLogging.m in Sources */,
+				05E2E46A212B751E00D532F5 /* PBAnalyticsManager.m in Sources */,
 				C210FE391FC3375D0010B588 /* PrebidCache.m in Sources */,
 				C2B16E401EE1BEA6006304C0 /* PBTargetingParams.m in Sources */,
 				C2B16E9E1EE1BF1A006304C0 /* PBServerLocation.m in Sources */,
@@ -571,6 +618,7 @@
 				C2B16E3E1EE1BEA6006304C0 /* PBKeywordsManager.m in Sources */,
 				C2B16E991EE1BF1A006304C0 /* PBServerFetcher.m in Sources */,
 				60CEC02D2084DF3A00CA104B /* PBConstants.m in Sources */,
+				05E2E466212B37F800D532F5 /* PBAnalyticsEvent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sdk/PrebidMobile/Analytics/PBAnalyticsEvent.h
+++ b/sdk/PrebidMobile/Analytics/PBAnalyticsEvent.h
@@ -1,0 +1,33 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSUInteger, PBAnalyticsEventType) {
+    PBAnalyticsEventCustom = 0,
+    PBAnalyticsEventRegisterAdUnit,
+    PBAnalyticsEventRequestBids,
+    PBAnalyticsEventAttachKeywords
+};
+
+@interface PBAnalyticsEvent : NSObject
+@property (nonatomic, readonly) NSDate *__nullable date;
+@property (nonatomic, assign, readonly) PBAnalyticsEventType type;
+@property (nonatomic) NSString *__nullable title;
+@property (nonatomic) NSDictionary *__nullable info;
+
+- (instancetype)initWithEventType:(PBAnalyticsEventType)type;
+
+@end

--- a/sdk/PrebidMobile/Analytics/PBAnalyticsEvent.m
+++ b/sdk/PrebidMobile/Analytics/PBAnalyticsEvent.m
@@ -1,0 +1,65 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "PBAnalyticsEvent.h"
+
+@implementation PBAnalyticsEvent
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _date = [NSDate date];
+    }
+    return self;
+}
+
+- (instancetype)initWithEventType:(PBAnalyticsEventType)type {
+    if (self = [self init]) {
+        _type = type;
+    }
+    return self;
+}
+
+- (NSString *)title {
+    if (_title) {
+        return _title;
+    } else {
+        [self updateTitle];
+    }
+    
+    return _title;
+}
+
+- (void)updateTitle {
+    NSString *title = @"undefined";
+    switch (_type) {
+        case PBAnalyticsEventCustom:
+            title = @"custom";
+            break;
+        case PBAnalyticsEventRegisterAdUnit:
+            title = @"register adunit";
+            break;
+        case PBAnalyticsEventRequestBids:
+            title = @"bid request";
+            break;
+        case PBAnalyticsEventAttachKeywords:
+            title = @"attach keywords";
+            break;
+        default:
+            break;
+    }
+    _title = title;
+}
+
+@end

--- a/sdk/PrebidMobile/Analytics/PBAnalyticsManager.h
+++ b/sdk/PrebidMobile/Analytics/PBAnalyticsManager.h
@@ -1,0 +1,34 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+#import "PBAnalyticsEvent.h"
+
+@protocol PBAnalyticsService;
+
+@interface PBAnalyticsManager : NSObject
+
+@property (nonatomic, assign, getter=isEnabled) BOOL enabled;
+
++ (instancetype)sharedInstance;
+- (void)initializeWithApplication:(UIApplication *)application launchOptions:(NSDictionary *)launchOptions;
+- (void)trackEvent:(PBAnalyticsEvent *)event;
+- (void)trackEventType:(PBAnalyticsEventType)type info:(NSDictionary *)info;
+- (void)addService:(id<PBAnalyticsService>)service;
+- (void)removeService:(id<PBAnalyticsService>)service;
+- (void)removeAllServices;
+
+@end

--- a/sdk/PrebidMobile/Analytics/PBAnalyticsManager.m
+++ b/sdk/PrebidMobile/Analytics/PBAnalyticsManager.m
@@ -1,0 +1,108 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "PBAnalyticsManager.h"
+#import "PBAnalyticsService.h"
+#import "PBLogging.h"
+
+@interface PBAnalyticsManager ()
+
+@property (atomic, strong) NSMutableSet *__nullable services;
+@property (nonatomic, strong) dispatch_queue_t queue;
+@property (nonatomic, assign, getter=isReady) BOOL ready;
+
+@end
+
+@implementation PBAnalyticsManager {
+    UIApplication *_application;
+    NSDictionary *_launchOptions;
+}
+
++ (instancetype)sharedInstance {
+    static PBAnalyticsManager *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] init];
+        sharedInstance.services = [[NSMutableSet alloc] init];
+        sharedInstance.queue = dispatch_queue_create("PBAnalyticsManagerQueue", DISPATCH_QUEUE_SERIAL);
+        sharedInstance.enabled = YES;
+    });
+    return sharedInstance;
+}
+
+- (void)initializeWithApplication:(UIApplication *)application launchOptions:(NSDictionary *)launchOptions {
+    if (_ready) {
+        PBLogInfo(@"Analytics manager already initialized.");
+        return;
+    }
+
+    _application = application;
+    _launchOptions = launchOptions;
+    [self doServiceWithExecutionHandler:^(id<PBAnalyticsService> service) {
+        [service initializeWithApplication:application launchOptions:launchOptions];
+    }];
+    _ready = YES;
+}
+
+- (void)trackEvent:(PBAnalyticsEvent *)event {
+    if (!_enabled || !_ready) {
+        PBLogInfo(@"Unable to send tracking [%@] event, because it is currently disabled or has not yet been initialized.", event.title);
+        return;
+    }
+        
+    [self doServiceWithExecutionHandler:^(id<PBAnalyticsService> service) {
+        [service trackEvent:event];
+    }];
+}
+
+- (void)trackEventType:(PBAnalyticsEventType)type
+                  info:(NSDictionary *)info {
+    PBAnalyticsEvent *event = [[PBAnalyticsEvent alloc] initWithEventType:type];
+    event.info = info;
+    [self trackEvent:event];
+}
+
+- (void)doServiceWithExecutionHandler:(void (^)(id<PBAnalyticsService>))handler {
+    dispatch_sync(self.queue, ^{
+        [self.services enumerateObjectsUsingBlock:^(id<PBAnalyticsService> service, BOOL *stop) {
+            handler(service);
+        }];
+    });
+}
+
+- (void)addService:(id<PBAnalyticsService>)service {
+    dispatch_async(self.queue, ^{
+        [self.services addObject:service];
+        if (self->_ready) {
+            // initialize service
+            PBLogInfo(@"%@ added.", NSStringFromClass([service class]));
+            [service initializeWithApplication:self->_application launchOptions:self->_launchOptions];
+        }
+    });
+}
+
+- (void)removeService:(id<PBAnalyticsService>)service {
+    dispatch_async(self.queue, ^{
+        [self.services removeObject:service];
+    });
+}
+
+- (void)removeAllServices {
+    dispatch_async(self.queue, ^{
+        [self.services removeAllObjects];
+    });
+}
+
+@end

--- a/sdk/PrebidMobile/Analytics/PBAnalyticsService.h
+++ b/sdk/PrebidMobile/Analytics/PBAnalyticsService.h
@@ -1,0 +1,27 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+@class PBAnalyticsEvent;
+
+@protocol PBAnalyticsService <NSObject>
+
+- (void)initializeWithApplication:(UIApplication *)application launchOptions:(NSDictionary *)launchOptions;
+- (void)trackEvent:(PBAnalyticsEvent *)event;
+- (BOOL)isSupportedWithEvent:(PBAnalyticsEvent *)event;
+
+@end

--- a/sdk/PrebidMobile/Analytics/Services/PBSegmentAnalyticsService.h
+++ b/sdk/PrebidMobile/Analytics/Services/PBSegmentAnalyticsService.h
@@ -1,0 +1,21 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <PrebidMobile/PBAnalyticsService.h>
+
+@interface PBSegmentAnalyticsService : NSObject <PBAnalyticsService>
+
+@end

--- a/sdk/PrebidMobile/Analytics/Services/PBSegmentAnalyticsService.m
+++ b/sdk/PrebidMobile/Analytics/Services/PBSegmentAnalyticsService.m
@@ -1,0 +1,44 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "PBSegmentAnalyticsService.h"
+#import <PrebidMobile/PBAnalyticsEvent.h>
+#import <Analytics/SEGAnalytics.h>
+
+@implementation PBSegmentAnalyticsService
+
+- (void)initializeWithApplication:(UIApplication *)application launchOptions:(NSDictionary *)launchOptions {
+    SEGAnalyticsConfiguration *configuration = [SEGAnalyticsConfiguration configurationWithWriteKey:@"insert_key_here"];
+    configuration.trackApplicationLifecycleEvents = NO; // Enable this to record certain application events automatically!
+    configuration.recordScreenViews = NO; // Enable this to record screen views automatically!
+    [SEGAnalytics setupWithConfiguration:configuration];
+}
+
+- (void)trackEvent:(PBAnalyticsEvent *)event {
+    if ([self isSupportedWithEvent:event]) {
+        NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
+        NSDictionary *options = @{ @"context" : @{ @"app" : @{ @"name" : appName }}};
+        [[SEGAnalytics sharedAnalytics] track:event.title
+                                   properties:event.info
+                                      options:options];
+    }
+}
+
+- (BOOL)isSupportedWithEvent:(PBAnalyticsEvent *)event {
+    // check to see if this event is supported, all by default
+    return YES;
+}
+
+@end

--- a/sdk/PrebidMobile/PrebidMobile-umbrella.h
+++ b/sdk/PrebidMobile/PrebidMobile-umbrella.h
@@ -12,3 +12,6 @@
 #import "PBKeywordsManager.h"
 #import "PBTargetingParams.h"
 #import "PBServerAdapter.h"
+#import "PBAnalyticsService.h"
+#import "PBAnalyticsManager.h"
+#import "PBAnalyticsEvent.h"

--- a/sdk/PrebidMobileTests/MockObjects/PBMockAnalyticsService.h
+++ b/sdk/PrebidMobileTests/MockObjects/PBMockAnalyticsService.h
@@ -1,0 +1,21 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import "PBAnalyticsService.h"
+
+@interface PBMockAnalyticsService : NSObject <PBAnalyticsService>
+
+@end

--- a/sdk/PrebidMobileTests/MockObjects/PBMockAnalyticsService.m
+++ b/sdk/PrebidMobileTests/MockObjects/PBMockAnalyticsService.m
@@ -1,0 +1,33 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "PBMockAnalyticsService.h"
+#import "PBAnalyticsEvent.h"
+
+@implementation PBMockAnalyticsService
+
+- (void)initializeWithApplication:(UIApplication *)application launchOptions:(NSDictionary *)launchOptions {
+    NSLog(@"initializeWithApplication");
+}
+
+- (void)trackEvent:(PBAnalyticsEvent *)event {
+//    NSLog(@"trackEvent: %@", event.title);
+}
+
+- (BOOL)isSupportedWithEvent:(PBAnalyticsEvent *)event {
+    return YES;
+}
+
+@end

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBAnalyticsTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBAnalyticsTests.m
@@ -1,0 +1,78 @@
+/*   Copyright 2017 Prebid.org, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+#import "PBAnalyticsManager.h"
+#import "PBMockAnalyticsService.h"
+#import "PBAnalyticsEvent.h"
+
+@interface PBAnalyticsManager ()
+
+@property (atomic, strong) NSMutableSet *__nullable services;
+
+@end
+
+@interface PBAnalyticsTests : XCTestCase
+
+@end
+
+@implementation PBAnalyticsTests {
+    PBMockAnalyticsService *_service;
+    PBAnalyticsManager *_manager;
+}
+
+- (void)setUp {
+    [super setUp];
+    
+    self->_manager = [PBAnalyticsManager sharedInstance];
+    self->_service = [[PBMockAnalyticsService alloc] init];
+    [_manager initializeWithApplication:nil launchOptions:nil];
+    [self->_manager addService:self->_service];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testServiceAdd {
+    XCTestExpectation *expectation = [self expectationWithDescription:@"add analytics service"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        [expectation fulfill];
+        XCTAssertTrue(self->_manager.services.count > 0);
+    });
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+}
+
+- (void)testServiceRemove {
+    XCTAssertTrue(_manager.services.count > 0);
+    unsigned long count = self->_manager.services.count;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"remove analytics service"];
+    [_manager removeService:_service];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+        [expectation fulfill];
+        XCTAssertTrue(self->_manager.services.count <= (count - 1));
+    });
+    [self waitForExpectationsWithTimeout:0.2 handler:nil];
+}
+
+- (void)testEvent {
+    PBAnalyticsEvent *event = [[PBAnalyticsEvent alloc] initWithEventType:PBAnalyticsEventRegisterAdUnit];
+    XCTAssertEqual(event.type, PBAnalyticsEventRegisterAdUnit);
+    XCTAssertNotEqual(event.type, PBAnalyticsEventAttachKeywords);
+    XCTAssertNotEqual(event.type, PBAnalyticsEventRequestBids);
+    XCTAssertNotNil(event.title);
+}
+
+@end


### PR DESCRIPTION
Initial support for analytics.  This includes an analytics manager, an event model class, and service adapter architecture.  Also, included are unit test(s) and an update for the demo app using the segment (https://segment.com/) analytics service as an example.  Currently, only 3 analytics events are implemented (keywords, register ad unit, and request bids), so looking at the community to add more events, if needed.