### PR TITLE
Update V0.5 to select cache server or local

### DIFF
--- a/sdk/PrebidMobile/PBTargetingParams.h
+++ b/sdk/PrebidMobile/PBTargetingParams.h
@@ -74,6 +74,17 @@ typedef NS_ENUM(NSUInteger, PBTargetingParamsGender) {
 @property (nonatomic, readonly, assign) BOOL isGDPREnabled;
 
 /**
+ * The boolean value set by the user to collect user data
+ */
+@property (nonatomic, readwrite) BOOL localCache;
+
+/**
+ * The boolean value set by the user to define the cache type
+ */
+
+@property (nonatomic, readonly, assign) BOOL useLocalCache;
+
+/**
  * This property stores the set of custom keywords that prebid provides for targeting
  */
 @property (nonatomic, strong, readonly) NSDictionary<NSString *, NSArray *> *__nullable customKeywords DEPRECATED_ATTRIBUTE;

--- a/sdk/PrebidMobile/PBTargetingParams.m
+++ b/sdk/PrebidMobile/PBTargetingParams.m
@@ -23,6 +23,8 @@
 
 @property (nonatomic, readwrite) BOOL isGDPREnabledHere;
 
+@property (nonatomic, readwrite) BOOL useLocalCacheHere;
+
 @end
 
 @implementation PBTargetingParams
@@ -31,7 +33,7 @@
 - (instancetype)init {
     if (self = [super init]) {
         _locationPrecision = (NSInteger)-1;
-        
+        _useLocalCacheHere = NO;
         _customKeywords = [[NSMutableDictionary alloc] init];
         _userKeywords = [[NSMutableDictionary alloc] init];
         _isGDPREnabledHere = NO;
@@ -162,6 +164,10 @@ static dispatch_once_t onceToken;
     _itunesID = itunesID;
 }
 
+- (void)setLocalCache:(BOOL)localCache {
+    _useLocalCacheHere = localCache;
+}
+
 -(void) setSubjectToGDPR:(BOOL)subjectToGDPR{
     [[NSUserDefaults standardUserDefaults] setBool:subjectToGDPR forKey:PB_GDPR_SubjectToConsent];
     self.isGDPREnabledHere = YES;
@@ -195,6 +201,10 @@ static dispatch_once_t onceToken;
     return savedConsent;
     }
     return nil;
+}
+
+-(BOOL) useLocalCache {
+    return self.useLocalCacheHere;
 }
 
 @end

--- a/sdk/PrebidMobile/PrebidCache.h
+++ b/sdk/PrebidMobile/PrebidCache.h
@@ -20,5 +20,5 @@
 
 + (nonnull instancetype)globalCache;
 
-- (void) cacheContents: (NSArray *) contents forAdserver:(PBPrimaryAdServerType) adserver withCompletionBlock: (void (^)(NSArray *))completionBlock;
+- (void) cacheContents: (NSArray *) contents forAdserver:(PBPrimaryAdServerType) adserver withCompletionBlock: (nonnull void (^)(NSError *, NSArray *))completionBlock;
 @end

--- a/sdk/PrebidMobile/PrebidCache.m
+++ b/sdk/PrebidMobile/PrebidCache.m
@@ -35,45 +35,64 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
 @property UIWebView *uiwebviewCache;
 @property WKWebView *wkwebviewCache;
 
-
 @property NSString* htmlToLoad;
+@property NSMutableArray *cacheIds;
+@property (nonnull) void (^sendCacheIds)(NSError *, NSArray *);
 
-- (instancetype)initWithHTMLLoad: (NSString *) htmlToLoad withAdserver: (PBPrimaryAdServerType) adserver;
+- (instancetype)initWithContentsToLoad: (NSArray *)contents withAdserver: (PBPrimaryAdServerType) adserver withCompletionHandler: (void (^) (NSError *, NSArray *)) completionBlock;
 @end
 
 @implementation PrebidCacheOperation
-- (instancetype)initWithHTMLLoad:(NSString *)htmlToLoad withAdserver: (PBPrimaryAdServerType) adserver
+
+- (instancetype)initWithContentsToLoad: (NSArray *)contents withAdserver: (PBPrimaryAdServerType) adserver withCompletionHandler:(void (^)(NSError *, NSArray *))completionBlock
 {
+    
     if (self = [super init]) {
-        self.htmlToLoad = htmlToLoad;
         executing = NO;
         finished = NO;
-        
-        if(adserver == PBPrimaryAdServerDFP){
-            // We need UIWebView only for Mopub & not for DFP
-            _uiwebviewCache = [[UIWebView alloc] init];
-            _uiwebviewCache.frame = CGRectZero;
-            _uiwebviewCache.delegate = self;
-        }
-        _wkwebviewCache = [[WKWebView alloc] init];
-        _wkwebviewCache.frame = CGRectZero;
-        _wkwebviewCache.navigationDelegate = self;
-    
-        if (adserver == PBPrimaryAdServerDFP) {
-            _httpsHost = [NSURL URLWithString:@"https://pubads.g.doubleclick.net"];
-            _loadingCount = 2;
-        } else if (adserver == PBPrimaryAdServerMoPub){
-            // Grab the ATS dictionary from the Info.plist
-            NSDictionary *atsSettingsDictionary = [NSBundle mainBundle].infoDictionary[kPBAppTransportSecurityDictionaryKey];
-            if ([atsSettingsDictionary[kPBAppTransportSecurityAllowsArbitraryLoadsKey] boolValue]) {
-                _httpsHost = [NSURL URLWithString:@"http://ads.mopub.com"];
-            } else {
-                _httpsHost = [NSURL URLWithString:@"https://ads.mopub.com"];
-            }
-            _loadingCount = 1;
+        if (contents == nil || contents.count == 0) {
+            self.sendCacheIds = completionBlock;
+            [self finishAndChangeState];
         } else {
-            [self finishAndChangeState]; // TODO: check for a proper handling here
+            long long milliseconds = (long long)([[NSDate date] timeIntervalSince1970] * 1000.0);
+            NSMutableString *htmlToLoad = [[NSMutableString alloc] init];
+            [htmlToLoad appendString:@"<head>"];
+            NSString *scriptString = [NSString stringWithFormat:@"<script>var currentTime = %lld;var toBeDeleted = [];for(i = 0; i< localStorage.length; i ++){if(localStorage.key(i).startsWith('Prebid_')) {createdTime = localStorage.key(i).split('_')[2];if (( currentTime - createdTime) > %ld){toBeDeleted.push(localStorage.key(i));}}}for ( i = 0; i< toBeDeleted.length; i ++) {localStorage.removeItem(toBeDeleted[i]);}</script>", milliseconds, (long) expireCacheMilliSeconds];
+            [htmlToLoad appendString:scriptString];
+            self.cacheIds = [[NSMutableArray alloc] init];
+            for (NSString *content in contents) {
+                NSString *cacheId = [NSString stringWithFormat:@"Prebid_%@_%lld", [NSString stringWithFormat:@"%08X", arc4random()], milliseconds];
+                [self.cacheIds addObject:cacheId];
+                [htmlToLoad appendString:[NSString stringWithFormat:@"<script>localStorage.setItem('%@','%@');</script>", cacheId, content]];
+            }
+            [htmlToLoad appendString:@"</head>"];
+            self.htmlToLoad = htmlToLoad;
+            self.sendCacheIds = completionBlock;
+            _loadingCount = 1;
+            _wkwebviewCache = [[WKWebView alloc] init];
+            _wkwebviewCache.frame = CGRectZero;
+            _wkwebviewCache.navigationDelegate = self;
+            
+            if (adserver == PBPrimaryAdServerDFP) {
+                _httpsHost = [NSURL URLWithString:@"https://pubads.g.doubleclick.net"];
+                // We need UIWebView only for DFP & not for MoPub
+                _uiwebviewCache = [[UIWebView alloc] init];
+                _uiwebviewCache.frame = CGRectZero;
+                _uiwebviewCache.delegate = self;
+                _loadingCount = 2;
+            } else if (adserver == PBPrimaryAdServerMoPub){
+                // Grab the ATS dictionary from the Info.plist
+                NSDictionary *atsSettingsDictionary = [NSBundle mainBundle].infoDictionary[kPBAppTransportSecurityDictionaryKey];
+                if ([atsSettingsDictionary[kPBAppTransportSecurityAllowsArbitraryLoadsKey] boolValue]) {
+                    _httpsHost = [NSURL URLWithString:@"http://ads.mopub.com"];
+                } else {
+                    _httpsHost = [NSURL URLWithString:@"https://ads.mopub.com"];
+                }
+            } else {
+                [self finishAndChangeState]; // TODO: check for a proper handling here
+            }
         }
+        
     }
     return self;
 }
@@ -131,6 +150,7 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView
 {
+    NSLog(@"testAntoine finishLoadView");
     self.loadingCount--;
     if (self.loadingCount == 0) {
         [self finishAndChangeState];
@@ -147,24 +167,34 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
 
 - (void) finishAndChangeState
 {
+    
     __weak PrebidCacheOperation *weakSelf = self;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            __strong PrebidCacheOperation *strongSelf = weakSelf;
-            
-            [strongSelf.wkwebviewCache setNavigationDelegate:nil];
-            [strongSelf.wkwebviewCache setUIDelegate:nil];
-            
-            [strongSelf.wkwebviewCache removeFromSuperview];
-            strongSelf.wkwebviewCache = nil;
-            
-            [strongSelf willChangeValueForKey:@"isExecuting"];
-            strongSelf->executing = NO;
-            [strongSelf didChangeValueForKey:@"isExecuting"];
-            [strongSelf willChangeValueForKey:@"isFinished"];
-            strongSelf->finished = YES;
-            [strongSelf didChangeValueForKey:@"isFinished"];
-            
-        });
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong PrebidCacheOperation *strongSelf = weakSelf;
+        
+        [strongSelf.wkwebviewCache setNavigationDelegate:nil];
+        [strongSelf.wkwebviewCache setUIDelegate:nil];
+        
+        [strongSelf.wkwebviewCache removeFromSuperview];
+        strongSelf.wkwebviewCache = nil;
+        strongSelf.uiwebviewCache = nil;
+        if(self.cacheIds != nil && self.cacheIds.count>0){
+            if (strongSelf.sendCacheIds != nil) {
+                strongSelf.sendCacheIds(nil, strongSelf.cacheIds);
+            }
+        } else {
+            if (strongSelf.sendCacheIds !=nil) {
+                strongSelf.sendCacheIds([NSError errorWithDomain:@"org.prebid" code:0 userInfo:nil ], nil);
+            }
+        }
+        [strongSelf willChangeValueForKey:@"isExecuting"];
+        strongSelf->executing = NO;
+        [strongSelf didChangeValueForKey:@"isExecuting"];
+        [strongSelf willChangeValueForKey:@"isFinished"];
+        strongSelf->finished = YES;
+        [strongSelf didChangeValueForKey:@"isFinished"];
+        
+    });
 }
 
 @end
@@ -192,22 +222,10 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
     self.cacheQueue = [NSOperationQueue new];
 }
 
-- (void) cacheContents:(NSArray *)contents forAdserver:(PBPrimaryAdServerType)adserver withCompletionBlock:(void (^)(NSArray *))completionBlock
+- (void) cacheContents:(NSArray *)contents forAdserver:(PBPrimaryAdServerType)adserver withCompletionBlock:(void (^)(NSError *, NSArray *))completionBlock
 {
-    long long milliseconds = (long long)([[NSDate date] timeIntervalSince1970] * 1000.0);
-    NSMutableString *htmlToLoad = [[NSMutableString alloc] init];
-    [htmlToLoad appendString:@"<head>"];
-    NSString *scriptString = [NSString stringWithFormat:@"<script>var currentTime = %lld;var toBeDeleted = [];for(i = 0; i< localStorage.length; i ++){if(localStorage.key(i).startsWith('Prebid_')) {createdTime = localStorage.key(i).split('_')[2];if (( currentTime - createdTime) > %ld){toBeDeleted.push(localStorage.key(i));}}}for ( i = 0; i< toBeDeleted.length; i ++) {localStorage.removeItem(toBeDeleted[i]);}</script>", milliseconds, (long) expireCacheMilliSeconds];
-    [htmlToLoad appendString:scriptString];
-    NSMutableArray *cacheIds = [[NSMutableArray alloc] init];
-    for (NSString *content in contents) {
-        NSString *cacheId = [NSString stringWithFormat:@"Prebid_%@_%lld", [NSString stringWithFormat:@"%08X", arc4random()], milliseconds];
-        [cacheIds addObject:cacheId];
-        [htmlToLoad appendString:[NSString stringWithFormat:@"<script>localStorage.setItem('%@','%@');</script>", cacheId, content]];
-    }
-    [htmlToLoad appendString:@"</head>"];
-    PrebidCacheOperation *cacheOperation = [[PrebidCacheOperation alloc] initWithHTMLLoad:htmlToLoad withAdserver:adserver];
-    cacheOperation.completionBlock = ^{ completionBlock(cacheIds);};
+    
+    PrebidCacheOperation *cacheOperation = [[PrebidCacheOperation alloc] initWithContentsToLoad:contents withAdserver:adserver withCompletionHandler:completionBlock];
     [self.cacheQueue addOperation:cacheOperation];
 }
 

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
@@ -14,6 +14,7 @@
  */
 
 #import "PBServerAdapter.h"
+#import "PBTargetingParams.h"
 #import "PBAdUnit.h"
 #import "PBBannerAdUnit.h"
 #import "PBBidManager.h"
@@ -262,13 +263,29 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)testAttachTopBidHelperWithNoReadyBid {
+- (void)testAttachTopBidHelperWithNoReadyBidServerCache {
     XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
     PBAdUnit *adUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt10" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
     [adUnit addSize:CGSizeMake(320, 50)];
     [[PBBidManager sharedInstance] registerAdUnits:@[adUnit] withAccountId:self.accountId withHost:PBServerHostAppNexus andPrimaryAdServer:PBPrimaryAdServerMoPub];
 
     [[PBBidManager sharedInstance] attachTopBidHelperForAdUnitId:adUnit.identifier andTimeout:50 completionHandler:^{
+        NSDictionary *bidKeywords = [[PBBidManager sharedInstance] keywordsForWinningBidForAdUnit:adUnit];
+        XCTAssertNil(bidKeywords);
+        [expectation fulfill];
+    }];
+    // Wait for the expectation for 1 second
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testAttachTopBidHelperWithNoReadyBidLocalCache {
+    [[PBTargetingParams sharedInstance] setLocalCache:TRUE];
+    XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+    PBAdUnit *adUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt10" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
+    [adUnit addSize:CGSizeMake(320, 50)];
+    [[PBBidManager sharedInstance] registerAdUnits:@[adUnit] withAccountId:self.accountId withHost:PBServerHostAppNexus andPrimaryAdServer:PBPrimaryAdServerMoPub];
+    
+    [[PBBidManager sharedInstance] attachTopBidHelperForAdUnitId:adUnit.identifier andTimeout:500 completionHandler:^{
         NSDictionary *bidKeywords = [[PBBidManager sharedInstance] keywordsForWinningBidForAdUnit:adUnit];
         XCTAssertNil(bidKeywords);
         [expectation fulfill];

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBPrebidCacheTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBPrebidCacheTests.m
@@ -30,10 +30,11 @@
     NSArray *contents = @[@"0", @"1", @"2"];
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"UIWebView expectation"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"WkWebView expectation"];
-    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerDFP withCompletionBlock:^(NSArray *cacheIds) {
+   [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerDFP withCompletionBlock:^(NSError *error, NSArray *cacheIds) {
         //use cacheIds[0] should retrieve content 0
         //use cacheIds[1] should retrieve content 1
         //use cacheIds[2] should retrieve content 2
+        XCTAssertTrue(error == nil);
         XCTAssertTrue(cacheIds.count == 3);
         NSURL *host = [NSURL URLWithString:@"https://pubads.g.doubleclick.net"];
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -74,10 +75,11 @@
 {
     NSArray *contents = @[@"0", @"1", @"2"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"WkWebView expectation"];
-    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerMoPub withCompletionBlock:^(NSArray *cacheIds) {
+    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerMoPub withCompletionBlock:^(NSError *error, NSArray *cacheIds) {
         //use cacheIds[0] should retrieve content 0
         //use cacheIds[1] should retrieve content 1
         //use cacheIds[2] should retrieve content 2
+        //XCTAssertTrue(error == nil);
         XCTAssertTrue(cacheIds.count == 3);
         NSURL *host = [NSURL URLWithString:@"https://ads.mopub.com"];
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -100,6 +102,20 @@
         });
     }];
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+- (void) testPrebidCacheReturnErrorForEmptyContents
+{
+    NSArray *contents = @[];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"cache error expection"];
+    [[PrebidCache globalCache] cacheContents:contents forAdserver:PBPrimaryAdServerDFP withCompletionBlock:^(NSError *error, NSArray *cacheIds) {
+        XCTAssertTrue(error != nil);
+        XCTAssertTrue([error.domain isEqualToString:@"org.prebid"]);
+        XCTAssertTrue(error.code == 0);
+        XCTAssertTrue(cacheIds == nil);
+        [expectation fulfill];
+    }];
+    [self waitForExpectations:@[expectation]  timeout:20.0];
 }
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBServerAdapterTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBServerAdapterTests.m
@@ -1,11 +1,11 @@
 /*   Copyright 2017 Prebid.org, Inc.
-
+ 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
-
+ 
  http://www.apache.org/licenses/LICENSE-2.0
-
+ 
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,15 +51,15 @@ static NSString *testResponse = @"";
 - (void)startLoading {
     NSMutableURLRequest *newRequest = [self.request mutableCopy];
     [NSURLProtocol setProperty:@YES forKey:@"PrebidURLProtocolHandledKey" inRequest:newRequest];
-
+    
     NSData *data = [testResponse dataUsingEncoding:NSUTF8StringEncoding];
     if (data) {
         NSURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:[self.request URL] statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:@{@"Access-Control-Allow-Origin": kAPNPrebidServerUrl, @"Access-Control-Allow-Credentials" : @"true"}];
-                [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
-                [self.client URLProtocol:self didLoadData:data];
-                [self.client URLProtocolDidFinishLoading:self];
+        [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+        [self.client URLProtocol:self didLoadData:data];
+        [self.client URLProtocolDidFinishLoading:self];
     }
-
+    
 }
 
 - (void)stopLoading
@@ -93,12 +93,12 @@ static NSString *testResponse = @"";
     if (self.completionHandler) {
         self.completionHandler(nil, error);
     }
-
+    
 }
 
 - (void)didReceiveSuccessResponse:(nonnull NSArray<PBBidResponse *> *)bid {
     if (self.completionHandler) {
-         self.completionHandler(bid, nil);
+        self.completionHandler(bid, nil);
     }
 }
 
@@ -141,7 +141,7 @@ static NSString *testResponse = @"";
             } else {
                 XCTAssertTrue(![bid.customKeywords.allKeys containsObject:@"hb_cahce_id"]);
                 XCTAssertTrue([@"14.00" isEqualToString:[bid.customKeywords objectForKey:@"hb_pb_rubicon"]] );
-              
+                
             }
         }
         [expectation fulfill];
@@ -151,6 +151,7 @@ static NSString *testResponse = @"";
 
 -(void)testNoCacheIdFromServer
 {
+    [[PBTargetingParams sharedInstance] setLocalCache:NO];
     // This test response contains 1 bid, but no cache id is in the response
     testResponse = @"{\"id\":\"3dc76667-a500-4e01-a43b-368e36d6c7cc\",\"seatbid\":[{\"bid\":[{\"id\":\"3829649260126183529\",\"impid\":\"Banner_300x250\",\"price\":15,\"adm\":\"hello\",\"adid\":\"68501584\",\"adomain\":[\"peugeot.com\"],\"iurl\":\"https:\/\/nym1-ib.adnxs.com\/cr?id=68501584\",\"cid\":\"958\",\"crid\":\"68501584\",\"cat\":[\"IAB2-3\"],\"w\":300,\"h\":250,\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"appnexus\",\"hb_bidder_appnexus\":\"appnexus\",\"hb_creative_loadtype\":\"html\",\"hb_env\":\"mobile-app\",\"hb_env_appnexus\":\"mobile-app\",\"hb_pb\":\"15.00\",\"hb_pb_appnexus\":\"15.00\",\"hb_size\":\"300x250\",\"hb_size_appnexus\":\"300x250\"},\"type\":\"banner\"},\"bidder\":{\"appnexus\":{\"brand_id\":3264,\"auction_id\":8160292782530908000,\"bidder_id\":2,\"bid_ad_type\":0}}}}],\"seat\":\"appnexus\"}],\"ext\":{\"responsetimemillis\":{\"appnexus\":258}}}";
     [NSURLProtocol registerClass:[PBTestProtocol class]];
@@ -173,8 +174,111 @@ static NSString *testResponse = @"";
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
 }
 
+-(void)testAllBidsAreCached
+{
+    [[PBTargetingParams sharedInstance] setLocalCache:TRUE];
+    testResponse = @"{\"id\":\"3dc76667-a500-4e01-a43b-368e36d6c7cc\",\"seatbid\":[{\"bid\":[{\"id\":\"4009307468250838284\",\"impid\":\"Banner_300x250\",\"price\":0.5,\"adm\":\"<script><\/script>\",\"adid\":\"73501515\",\"adomain\":[\"appnexus.com\"],\"iurl\":\"https:\/\/nym1-ib.adnxs.com\/cr?id=73501515\",\"cid\":\"958\",\"crid\":\"73501515\",\"w\":300,\"h\":250,\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"appnexus\",\"hb_bidder_appnexus\":\"appnexus\",\"hb_creative_loadtype\":\"html\",\"hb_env\":\"mobile-app\",\"hb_env_appnexus\":\"mobile-app\",\"hb_pb\":\"0.50\",\"hb_pb_appnexus\":\"0.50\",\"hb_size\":\"300x250\",\"hb_size_appnexus\":\"300x250\"},\"type\":\"banner\"},\"bidder\":{\"appnexus\":{\"brand_id\":1,\"auction_id\":7466795334738195000,\"bidder_id\":2,\"bid_ad_type\":0}}}}],\"seat\":\"appnexus\"},{\"bid\":[{\"id\":\"4009307468250838284\",\"impid\":\"Banner_300x250\",\"price\":0.5,\"adm\":\"<script><\/script>\",\"adid\":\"73501515\",\"adomain\":[\"rubicon.com\"],\"iurl\":\"https:\/\/nym1-ib.adnxs.com\/cr?id=73501515\",\"cid\":\"958\",\"crid\":\"73501515\",\"w\":300,\"h\":250,\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder_rubicon\":\"rubicon\",\"hb_creative_loadtype\":\"html\",\"hb_env_rubicon\":\"mobile-app\",\"hb_pb_rubicon\":\"0.50\",\"hb_size_rubicon\":\"300x250\"},\"type\":\"banner\"}}}],\"seat\":\"rubicon\"},{\"bid\":[{\"id\":\"4009307468250838284\",\"impid\":\"Banner_300x250\",\"price\":0.5,\"adm\":\"<script><\/script>\",\"adid\":\"73501515\",\"adomain\":[\"superlongnamethatshouldbecropped.com\"],\"iurl\":\"https:\/\/nym1-ib.adnxs.com\/cr?id=73501515\",\"cid\":\"958\",\"crid\":\"73501515\",\"w\":300,\"h\":250,\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder_superlongnamet\":\"superlongnamethatshouldbecropped\",\"hb_creative_loadtype\":\"html\",\"hb_env_superlongnamethat\":\"mobile-app\",\"hb_pb_superlongnamethats\":\"0.50\",\"hb_size_superlongnametha\":\"300x250\"},\"type\":\"banner\"}}}],\"seat\":\"superlongnamethatshouldbecropped\"}],\"ext\":{\"responsetimemillis\":{\"appnexus\":19}}}";
+    [[PBTargetingParams sharedInstance] setLocalCache:TRUE];
+    [NSURLProtocol registerClass:[PBTestProtocol class]];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Dummy Expectation"];
+    PBAdUnit *adUnit1 = [[PBAdUnit alloc] initWithIdentifier:@"ad1" andAdType:PBAdUnitTypeBanner andConfigId:@"test_config_id1"];
+    [adUnit1 addSize:CGSizeMake(250, 300)];
+    PBAdUnit *adUnit2 = [[PBAdUnit alloc] initWithIdentifier:@"ad2" andAdType:PBAdUnitTypeBanner andConfigId:@"test_config_id2"];
+    [adUnit2 addSize:CGSizeMake(250, 300)];
+    self.adUnits = @[adUnit1, adUnit2];
+    PBServerAdapter *serverAdapter = [[PBServerAdapter alloc] initWithAccountId:@"test_account_id" andHost:PBServerHostAppNexus andAdServer:PBPrimaryAdServerDFP];
+    [serverAdapter requestBidsWithAdUnits:self.adUnits withDelegate:self];
+    __weak PBServerAdapterTests *weakSelf = self;
+    weakSelf.completionHandler = ^(NSArray *bids, NSError *error){
+        // veryfy that all bids has a cache id
+        // veryfy that only top bid has hb_cache_id
+        // verify cache_id is truncated after 20 characters
+        XCTAssertTrue(bids.count == 3);
+        BOOL cacheIdHasBeenSeen = NO;
+        for(PBBidResponse *bid in bids){
+            BOOL isCacheIdPresent = NO;
+            BOOL isTopBid = NO;
+            NSString *cacheKey = @"";
+            NSLog(@"Bid keywords: %@", bid.customKeywords);
+            for (NSString *key in bid.customKeywords.allKeys) {
+                if ([key containsString:@"hb_cache_id_"]) {
+                    isCacheIdPresent = YES;
+                    cacheKey = key;
+                    XCTAssertTrue(key.length <=20);
+                }
+                if ([key isEqualToString:@"hb_bidder"]) {
+                    isTopBid = YES;
+                }
+                if ([key isEqualToString:@"hb_cache_id"]) {
+                    if (cacheIdHasBeenSeen) {
+                        XCTFail(@"should not be setting hb_cache_id twice");
+                    } else {
+                        cacheIdHasBeenSeen = YES;
+                    }
+                }
+                
+            }
+            if (isTopBid) {
+                XCTAssertTrue([bid.customKeywords.allKeys containsObject:@"hb_cache_id"]);
+                XCTAssertEqual([bid.customKeywords objectForKey:@"hb_cache_id"], [bid.customKeywords objectForKey:cacheKey]);
+            } else {
+                XCTAssertTrue(![bid.customKeywords.allKeys containsObject:@"hb_cahce_id"]);
+            }
+            XCTAssertTrue(isCacheIdPresent);
+        }
+        
+        [expectation fulfill];
+    };
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
 - (void)testRequestBodyForAdUnit {
+    [[PBTargetingParams sharedInstance] setLocalCache:NO];
+    [[PBTargetingParams sharedInstance] setUserKeywords:@"targeting1" withValue:@"value1"];
+    [[PBTargetingParams sharedInstance] setUserKeywords:@"targeting2" withValue:@"value2"];
     
+    NSURL *hostURL = [NSURL URLWithString:kAPNPrebidServerUrl];
+    
+    [[PBServerRequestBuilder sharedInstance] setHostURL: hostURL];
+    NSURLRequest *request = [[PBServerRequestBuilder sharedInstance] buildRequest:self.adUnits withAccountId:@"account_id" withSecureParams:NO];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Dummy expectation"];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        
+        
+        
+        NSError* error;
+        NSDictionary* requestBody = [NSJSONSerialization JSONObjectWithData:[request HTTPBody]
+                                                                    options:kNilOptions
+                                                                      error:&error];
+        
+        XCTAssertNotNil(requestBody);
+        
+        XCTAssertEqualObjects(requestBody[@"app"][@"publisher"][@"id"], @"account_id");
+        
+        NSDictionary *app = requestBody[@"app"][@"ext"][@"prebid"];
+        XCTAssertNotNil(app[@"version"]);
+        
+        XCTAssertEqualObjects(app[@"source"], @"prebid-mobile");
+        
+        NSString *targetingParams = requestBody[@"user"][@"keywords"];
+        XCTAssertNotNil(targetingParams);
+        
+        NSDictionary *targetingPrebid = requestBody[@"ext"][@"prebid"];
+        XCTAssertEqualObjects(targetingPrebid[@"storedrequest"][@"id"], @"account_id");
+        NSLog(@"Bid keywords antoine: %@", targetingPrebid.allKeys);
+        XCTAssertTrue([targetingPrebid.allKeys containsObject:@"targeting"]);
+        
+        NSDictionary *device = requestBody[@"device"];
+        XCTAssertEqualObjects(device[@"os"], @"iOS");
+        XCTAssertEqualObjects(device[@"make"], @"Apple");
+        
+        [expectation fulfill];
+    });
+    [self waitForExpectationsWithTimeout:20.0 handler:nil];
+}
+
+- (void)testRequestBodyForAdUnitServerCaching {
+
     [[PBTargetingParams sharedInstance] setUserKeywords:@"targeting1" withValue:@"value1"];
     [[PBTargetingParams sharedInstance] setUserKeywords:@"targeting2" withValue:@"value2"];
     
@@ -224,6 +328,7 @@ static NSString *testResponse = @"";
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
 }
 
+
 - (void)testBuildRequestForAdUnitsInvalidHost {
     PBServerAdapter *serverAdapter = [[PBServerAdapter alloc] initWithAccountId:@"test_account_id" andHost:PBServerHostAppNexus andAdServer:PBPrimaryAdServerDFP];
     @try {
@@ -250,7 +355,7 @@ static NSString *testResponse = @"";
         [expectation fulfill];
     });
     [self waitForExpectationsWithTimeout:20.0 handler:nil];
-
+    
 }
 
 -(void) testBatchRequestBidsWithAdUnits{

--- a/sdk/PrebidServerAdapter/PrebidServerModule/PBServerRequestBuilder.m
+++ b/sdk/PrebidServerAdapter/PrebidServerModule/PBServerRequestBuilder.m
@@ -87,7 +87,9 @@ static NSString *const kPrebidMobileVersion = @"0.5";
     NSMutableDictionary *requestPrebidExt = [[NSMutableDictionary alloc] init];
     requestPrebidExt[@"targeting"] = @{};
     requestPrebidExt[@"storedrequest"] = @{@"id" :accountId};
-    requestPrebidExt[@"cache"] = @{@"bids" : [[NSMutableDictionary alloc] init]};
+    if (![[PBTargetingParams sharedInstance] useLocalCache]){
+        requestPrebidExt[@"cache"] = @{@"bids" : [[NSMutableDictionary alloc] init]};
+    }
     NSMutableDictionary *requestExt = [[NSMutableDictionary alloc] init];
     requestExt[@"prebid"] = requestPrebidExt;
     return [requestExt copy];


### PR DESCRIPTION
@anwzhang , I have used your PR and add a small parameters so Publisher can use server or local caching. Both have perks and drawback. 
Local caching seem to work fine with your PR, I have tested and see no more blank ad (when webview has not cached yet the creative before it is request by the dfp creative).