### PR TITLE
Fix cache and react

### DIFF
--- a/examples/PrebidMobileDemo/PrebidMobileDemo/AppDelegate.m
+++ b/examples/PrebidMobileDemo/PrebidMobileDemo/AppDelegate.m
@@ -88,6 +88,7 @@
 
 - (void)setPrebidTargetingParams {
     [[PBTargetingParams sharedInstance] setAge:25];
+    [[PBTargetingParams sharedInstance] setLocalCache: TRUE];
     [[PBTargetingParams sharedInstance] setGender:PBTargetingParamsGenderFemale];    
     CMPStorage *consentStorageVC = [[CMPStorage alloc] init];
     

--- a/sdk/PrebidMobile/PBTargetingParams.h
+++ b/sdk/PrebidMobile/PBTargetingParams.h
@@ -73,6 +73,16 @@ typedef NS_ENUM(NSUInteger, PBTargetingParamsGender) {
 
 @property (nonatomic, readonly, assign) BOOL isGDPREnabled;
 
+
+/**
+ * The boolean value set by the user to collect user data
+ */
+@property (nonatomic, readwrite) BOOL localCache;
+/**
+ * The boolean value set by the user to define the cache type
+ */
+@property (nonatomic, readonly, assign) BOOL useLocalCache;
+
 /**
  * This property stores the set of custom keywords that prebid provides for targeting
  */

--- a/sdk/PrebidMobile/PBTargetingParams.m
+++ b/sdk/PrebidMobile/PBTargetingParams.m
@@ -33,7 +33,6 @@
 - (instancetype)init {
     if (self = [super init]) {
         _locationPrecision = (NSInteger)-1;
-        
         _customKeywords = [[NSMutableDictionary alloc] init];
         _userKeywords = [[NSMutableDictionary alloc] init];
         _useLocalCacheHere = NO;

--- a/sdk/PrebidMobile/PBTargetingParams.m
+++ b/sdk/PrebidMobile/PBTargetingParams.m
@@ -23,6 +23,8 @@
 
 @property (nonatomic, readwrite) BOOL isGDPREnabledHere;
 
+@property (nonatomic, readwrite) BOOL useLocalCacheHere;
+
 @end
 
 @implementation PBTargetingParams
@@ -34,6 +36,7 @@
         
         _customKeywords = [[NSMutableDictionary alloc] init];
         _userKeywords = [[NSMutableDictionary alloc] init];
+        _useLocalCacheHere = NO;
         _isGDPREnabledHere = NO;
         
     }
@@ -195,6 +198,14 @@ static dispatch_once_t onceToken;
     return savedConsent;
     }
     return nil;
+}
+
+-(BOOL) useLocalCache {
+    return self.useLocalCacheHere;
+}
+
+- (void)setLocalCache:(BOOL)localCache {
+    _useLocalCacheHere = localCache;
 }
 
 @end

--- a/sdk/PrebidMobile/PrebidCache.h
+++ b/sdk/PrebidMobile/PrebidCache.h
@@ -20,5 +20,5 @@
 
 + (nonnull instancetype)globalCache;
 
-- (void) cacheContents: (NSArray *) contents forAdserver:(PBPrimaryAdServerType) adserver withCompletionBlock: (void (^)(NSArray *))completionBlock;
+- (void) cacheContents: (NSArray *) contents forAdserver:(PBPrimaryAdServerType) adserver withCompletionBlock: (nonnull void (^)(NSError *, NSArray *))completionBlock;
 @end

--- a/sdk/PrebidMobile/PrebidCache.m
+++ b/sdk/PrebidMobile/PrebidCache.m
@@ -22,59 +22,66 @@ static NSInteger expireCacheMilliSeconds = 270000; // expire bids cached longer 
 static NSString *const kPBAppTransportSecurityDictionaryKey = @"NSAppTransportSecurity";
 static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllowsArbitraryLoads";
 
-@interface PrebidCacheOperation : NSOperation <UIWebViewDelegate, WKNavigationDelegate>
+@interface PrebidCacheOperation : NSOperation <WKNavigationDelegate>
 {
     BOOL executing;
     BOOL finished;
 }
 
-@property NSInteger loadingCount;
-
 @property NSURL *httpsHost;
 
-@property UIWebView *uiwebviewCache;
 @property WKWebView *wkwebviewCache;
 
-
 @property NSString* htmlToLoad;
+@property NSMutableArray *cacheIds;
+@property NSArray* contents;
+@property (nonnull) void (^sendCacheIds)(NSError *, NSArray *);
 
-- (instancetype)initWithHTMLLoad: (NSString *) htmlToLoad withAdserver: (PBPrimaryAdServerType) adserver;
+- (instancetype)initWithContentsToLoad: (NSArray *)contents withAdserver: (PBPrimaryAdServerType) adserver withCompletionHandler: (void (^) (NSError *, NSArray *)) completionBlock;
 @end
 
 @implementation PrebidCacheOperation
-- (instancetype)initWithHTMLLoad:(NSString *)htmlToLoad withAdserver: (PBPrimaryAdServerType) adserver
+- (instancetype)initWithContentsToLoad: (NSArray *)contents withAdserver: (PBPrimaryAdServerType) adserver withCompletionHandler:(void (^)(NSError *, NSArray *))completionBlock
 {
     if (self = [super init]) {
-        self.htmlToLoad = htmlToLoad;
-        executing = NO;
-        finished = NO;
-        
-        if(adserver == PBPrimaryAdServerDFP){
-            // We need UIWebView only for Mopub & not for DFP
-            _uiwebviewCache = [[UIWebView alloc] init];
-            _uiwebviewCache.frame = CGRectZero;
-            _uiwebviewCache.delegate = self;
-        }
-        _wkwebviewCache = [[WKWebView alloc] init];
-        _wkwebviewCache.frame = CGRectZero;
-        _wkwebviewCache.navigationDelegate = self;
-    
-        if (adserver == PBPrimaryAdServerDFP) {
-            _httpsHost = [NSURL URLWithString:@"https://pubads.g.doubleclick.net"];
-            _loadingCount = 2;
-        } else if (adserver == PBPrimaryAdServerMoPub){
-            // Grab the ATS dictionary from the Info.plist
-            NSDictionary *atsSettingsDictionary = [NSBundle mainBundle].infoDictionary[kPBAppTransportSecurityDictionaryKey];
-            if ([atsSettingsDictionary[kPBAppTransportSecurityAllowsArbitraryLoadsKey] boolValue]) {
-                _httpsHost = [NSURL URLWithString:@"http://ads.mopub.com"];
+            executing = NO;
+            finished = NO;
+            if (contents == nil || contents.count == 0) {
+                self.sendCacheIds = completionBlock;
+                [self finishAndChangeState];
             } else {
-                _httpsHost = [NSURL URLWithString:@"https://ads.mopub.com"];
+                long long milliseconds = (long long)([[NSDate date] timeIntervalSince1970] * 1000.0);
+                NSMutableString *htmlToLoad = [[NSMutableString alloc] init];
+                [htmlToLoad appendString:@"<head>"];
+                NSString *scriptString = [NSString stringWithFormat:@"<script>var currentTime = %lld;var toBeDeleted = [];for(i = 0; i< localStorage.length; i ++){if(localStorage.key(i).startsWith('Prebid_')) {createdTime = localStorage.key(i).split('_')[2];if (( currentTime - createdTime) > %ld){toBeDeleted.push(localStorage.key(i));}}}for ( i = 0; i< toBeDeleted.length; i ++) {localStorage.removeItem(toBeDeleted[i]);}</script>", milliseconds, (long) expireCacheMilliSeconds];
+                [htmlToLoad appendString:scriptString];
+
+                self.contents = [[NSArray alloc] init];
+                self.contents = contents;
+                
+                [htmlToLoad appendString:@"</head>"];
+                self.htmlToLoad = htmlToLoad;
+                self.sendCacheIds = completionBlock;
+
+                _wkwebviewCache = [[WKWebView alloc] init];
+                _wkwebviewCache.frame = CGRectZero;
+                _wkwebviewCache.navigationDelegate = self;
+                
+                if (adserver == PBPrimaryAdServerDFP) {
+                    _httpsHost = [NSURL URLWithString:@"https://pubads.g.doubleclick.net"];
+                } else if (adserver == PBPrimaryAdServerMoPub){
+                    // Grab the ATS dictionary from the Info.plist
+                    NSDictionary *atsSettingsDictionary = [NSBundle mainBundle].infoDictionary[kPBAppTransportSecurityDictionaryKey];
+                    if ([atsSettingsDictionary[kPBAppTransportSecurityAllowsArbitraryLoadsKey] boolValue]) {
+                        _httpsHost = [NSURL URLWithString:@"http://ads.mopub.com"];
+                    } else {
+                        _httpsHost = [NSURL URLWithString:@"https://ads.mopub.com"];
+                    }
+                } else {
+                    [self finishAndChangeState]; // TODO: check for a proper handling here
+                }
             }
-            _loadingCount = 1;
-        } else {
-            [self finishAndChangeState]; // TODO: check for a proper handling here
         }
-    }
     return self;
 }
 
@@ -102,9 +109,6 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
             [self.wkwebviewCache removeFromSuperview];
             UIWindow *window = [[UIApplication sharedApplication] keyWindow];
             [window addSubview:self.wkwebviewCache];
-            if(self.uiwebviewCache != nil){
-                [self.uiwebviewCache loadHTMLString:self.htmlToLoad baseURL:self.httpsHost];
-            }
             [self.wkwebviewCache loadHTMLString:self.htmlToLoad baseURL:self.httpsHost];
         });
     }
@@ -129,18 +133,28 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
     return finished;
 }
 
-- (void)webViewDidFinishLoad:(UIWebView *)webView
-{
-    self.loadingCount--;
-    if (self.loadingCount == 0) {
-        [self finishAndChangeState];
-    }
-}
-
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    self.loadingCount--;
-    if (self.loadingCount == 0) {
+    self.cacheIds = [[NSMutableArray alloc] init];
+    long long milliseconds = (long long)([[NSDate date] timeIntervalSince1970] * 1000.0);
+    
+    if (self.contents != nil && self.contents.count>0) {
+        for (NSString *content in self.contents) {
+            NSString *cacheId = [NSString stringWithFormat:@"Prebid_%@_%lld", [NSString stringWithFormat:@"%08X", arc4random()], milliseconds];
+            NSString* setLocalStorageValue =
+            [NSString stringWithFormat:@"localStorage.setItem('%@','%@');", cacheId, content];
+            
+            [webView evaluateJavaScript:setLocalStorageValue completionHandler:^(NSString* result, NSError *error) {
+                if(!error) {
+                    [self.cacheIds addObject:cacheId];
+                }
+                if (content == [self.contents lastObject]){
+                    [self finishAndChangeState];
+                }
+            }];
+        }
+    }
+    else {
         [self finishAndChangeState];
     }
 }
@@ -148,23 +162,31 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
 - (void) finishAndChangeState
 {
     __weak PrebidCacheOperation *weakSelf = self;
-        dispatch_async(dispatch_get_main_queue(), ^{
-            __strong PrebidCacheOperation *strongSelf = weakSelf;
-            
-            [strongSelf.wkwebviewCache setNavigationDelegate:nil];
-            [strongSelf.wkwebviewCache setUIDelegate:nil];
-            
-            [strongSelf.wkwebviewCache removeFromSuperview];
-            strongSelf.wkwebviewCache = nil;
-            
-            [strongSelf willChangeValueForKey:@"isExecuting"];
-            strongSelf->executing = NO;
-            [strongSelf didChangeValueForKey:@"isExecuting"];
-            [strongSelf willChangeValueForKey:@"isFinished"];
-            strongSelf->finished = YES;
-            [strongSelf didChangeValueForKey:@"isFinished"];
-            
-        });
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong PrebidCacheOperation *strongSelf = weakSelf;
+        
+        [strongSelf.wkwebviewCache setNavigationDelegate:nil];
+        [strongSelf.wkwebviewCache setUIDelegate:nil];
+        
+        [strongSelf.wkwebviewCache removeFromSuperview];
+        strongSelf.wkwebviewCache = nil;
+        if(self.cacheIds != nil && self.cacheIds.count>0){
+            if (strongSelf.sendCacheIds != nil) {
+                strongSelf.sendCacheIds(nil, strongSelf.cacheIds);
+            }
+        } else {
+            if (strongSelf.sendCacheIds !=nil) {
+                strongSelf.sendCacheIds([NSError errorWithDomain:@"org.prebid" code:0 userInfo:nil ], nil);
+            }
+        }
+        [strongSelf willChangeValueForKey:@"isExecuting"];
+        strongSelf->executing = NO;
+        [strongSelf didChangeValueForKey:@"isExecuting"];
+        [strongSelf willChangeValueForKey:@"isFinished"];
+        strongSelf->finished = YES;
+        [strongSelf didChangeValueForKey:@"isFinished"];
+        
+    });
 }
 
 @end
@@ -192,22 +214,10 @@ static NSString *const kPBAppTransportSecurityAllowsArbitraryLoadsKey = @"NSAllo
     self.cacheQueue = [NSOperationQueue new];
 }
 
-- (void) cacheContents:(NSArray *)contents forAdserver:(PBPrimaryAdServerType)adserver withCompletionBlock:(void (^)(NSArray *))completionBlock
+- (void) cacheContents:(NSArray *)contents forAdserver:(PBPrimaryAdServerType)adserver withCompletionBlock:(void (^)(NSError *, NSArray *))completionBlock
 {
-    long long milliseconds = (long long)([[NSDate date] timeIntervalSince1970] * 1000.0);
-    NSMutableString *htmlToLoad = [[NSMutableString alloc] init];
-    [htmlToLoad appendString:@"<head>"];
-    NSString *scriptString = [NSString stringWithFormat:@"<script>var currentTime = %lld;var toBeDeleted = [];for(i = 0; i< localStorage.length; i ++){if(localStorage.key(i).startsWith('Prebid_')) {createdTime = localStorage.key(i).split('_')[2];if (( currentTime - createdTime) > %ld){toBeDeleted.push(localStorage.key(i));}}}for ( i = 0; i< toBeDeleted.length; i ++) {localStorage.removeItem(toBeDeleted[i]);}</script>", milliseconds, (long) expireCacheMilliSeconds];
-    [htmlToLoad appendString:scriptString];
-    NSMutableArray *cacheIds = [[NSMutableArray alloc] init];
-    for (NSString *content in contents) {
-        NSString *cacheId = [NSString stringWithFormat:@"Prebid_%@_%lld", [NSString stringWithFormat:@"%08X", arc4random()], milliseconds];
-        [cacheIds addObject:cacheId];
-        [htmlToLoad appendString:[NSString stringWithFormat:@"<script>localStorage.setItem('%@','%@');</script>", cacheId, content]];
-    }
-    [htmlToLoad appendString:@"</head>"];
-    PrebidCacheOperation *cacheOperation = [[PrebidCacheOperation alloc] initWithHTMLLoad:htmlToLoad withAdserver:adserver];
-    cacheOperation.completionBlock = ^{ completionBlock(cacheIds);};
+    
+    PrebidCacheOperation *cacheOperation = [[PrebidCacheOperation alloc] initWithContentsToLoad:contents withAdserver:adserver withCompletionHandler:completionBlock];
     [self.cacheQueue addOperation:cacheOperation];
 }
 

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBBidManagerTests.m
@@ -19,6 +19,7 @@
 #import "PBBidManager.h"
 #import "PBBidResponse.h"
 #import "PBException.h"
+#import "PBTargetingParams.h"
 #import "PBInterstitialAdUnit.h"
 #import "PBMockServerAdapter.h"
 #import <XCTest/XCTest.h>
@@ -262,13 +263,29 @@ NSString *const kBidManagerTestAdUnitId = @"TestAdUnitId";
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)testAttachTopBidHelperWithNoReadyBid {
+- (void)testAttachTopBidHelperWithNoReadyBidServerCache {
     XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
     PBAdUnit *adUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt10" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
     [adUnit addSize:CGSizeMake(320, 50)];
     [[PBBidManager sharedInstance] registerAdUnits:@[adUnit] withAccountId:self.accountId withHost:PBServerHostAppNexus andPrimaryAdServer:PBPrimaryAdServerMoPub];
 
     [[PBBidManager sharedInstance] attachTopBidHelperForAdUnitId:adUnit.identifier andTimeout:50 completionHandler:^{
+        NSDictionary *bidKeywords = [[PBBidManager sharedInstance] keywordsForWinningBidForAdUnit:adUnit];
+        XCTAssertNil(bidKeywords);
+        [expectation fulfill];
+    }];
+    // Wait for the expectation for 1 second
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testAttachTopBidHelperWithNoReadyBidLocalCache {
+    [[PBTargetingParams sharedInstance] setLocalCache:TRUE];
+    XCTestExpectation *expectation = [self expectationWithDescription:NSStringFromSelector(_cmd)];
+    PBAdUnit *adUnit = [[PBBannerAdUnit alloc] initWithAdUnitIdentifier:@"bmt10" andConfigId:@"0b33e7ae-cf61-4003-8404-0711eea6e673"];
+    [adUnit addSize:CGSizeMake(320, 50)];
+    [[PBBidManager sharedInstance] registerAdUnits:@[adUnit] withAccountId:self.accountId withHost:PBServerHostAppNexus andPrimaryAdServer:PBPrimaryAdServerMoPub];
+    
+    [[PBBidManager sharedInstance] attachTopBidHelperForAdUnitId:adUnit.identifier andTimeout:500 completionHandler:^{
         NSDictionary *bidKeywords = [[PBBidManager sharedInstance] keywordsForWinningBidForAdUnit:adUnit];
         XCTAssertNil(bidKeywords);
         [expectation fulfill];

--- a/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBServerAdapterTests.m
+++ b/sdk/PrebidMobileTests/PrebidMobileCoreTests/PBServerAdapterTests.m
@@ -266,7 +266,6 @@ static NSString *testResponse = @"";
         
         NSDictionary *targetingPrebid = requestBody[@"ext"][@"prebid"];
         XCTAssertEqualObjects(targetingPrebid[@"storedrequest"][@"id"], @"account_id");
-        NSLog(@"Bid keywords antoine: %@", targetingPrebid.allKeys);
         XCTAssertTrue([targetingPrebid.allKeys containsObject:@"targeting"]);
         
         NSDictionary *device = requestBody[@"device"];

--- a/sdk/PrebidServerAdapter/PrebidServerModule/PBServerGlobal.m
+++ b/sdk/PrebidServerAdapter/PrebidServerModule/PBServerGlobal.m
@@ -23,10 +23,12 @@ static NSString *const kIFASentinelValue = @"00000000-0000-0000-0000-00000000000
 NSString *PBSUserAgent() {
     static NSString *userAgent = nil;
     if (userAgent == nil) {
-        UIWebView *webview = [[UIWebView alloc] init];
-        userAgent = [[webview stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"] copy];
-        webview.delegate = nil;
-        [webview stopLoading];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UIWebView *webview = [[UIWebView alloc] init];
+            userAgent = [[webview stringByEvaluatingJavaScriptFromString:@"navigator.userAgent"] copy];
+            webview.delegate = nil;
+            [webview stopLoading];
+        });
     }
     return userAgent;
 }
@@ -80,5 +82,9 @@ NSString *PBSConvertToNSString(id value) {
 }
 
 @implementation PBServerGlobal
+
++ (void)load {
+    PBSUserAgent();
+}
 
 @end

--- a/sdk/PrebidServerAdapter/PrebidServerModule/PBServerRequestBuilder.m
+++ b/sdk/PrebidServerAdapter/PrebidServerModule/PBServerRequestBuilder.m
@@ -87,7 +87,9 @@ static NSString *const kPrebidMobileVersion = @"0.5";
     NSMutableDictionary *requestPrebidExt = [[NSMutableDictionary alloc] init];
     requestPrebidExt[@"targeting"] = @{};
     requestPrebidExt[@"storedrequest"] = @{@"id" :accountId};
-    requestPrebidExt[@"cache"] = @{@"bids" : [[NSMutableDictionary alloc] init]};
+    if (![[PBTargetingParams sharedInstance] useLocalCache]){
+        requestPrebidExt[@"cache"] = @{@"bids" : [[NSMutableDictionary alloc] init]};
+    }
     NSMutableDictionary *requestExt = [[NSMutableDictionary alloc] init];
     requestExt[@"prebid"] = requestPrebidExt;
     return [requestExt copy];


### PR DESCRIPTION
Here is a PR linked to the pull/97/

Here are the changes:

### **_Caching option:_**
I have a field to select the caching option. Publishers just need to call when initiate the SDK:
[[PBTargetingParams sharedInstance] setLocalCache: BOOL];

requestPrebidExt[@"cache"] will be only passed for server caching in the request.

### **_Caching bug fix:_**
I have changed the logic and start the caching when didFinishNavigation is called.
Also the cacheIds are passed only when the JS is start executing (completion handler of evaluateJavaScript).
I also clean the code to only use WKWebView and remove some non use part.

### **_Fix Reactive Native Crash:_**
PBServerGlobal.m:26 at UIWebView init. It is being relied on having the main thread active which is not the case with react native. I wrapped the user agent retrieval using GCD. And since it becomes async, I also call it for the first time once the PBServerGlobal class is loaded in ObjC runtime.

### **_WKWebView:_**
WebView is being deprecated. I have edited the caching class, the only remaining webView is the one used for the UA. WKWebView evaluateJavaScript is async when stringByEvaluatingJavaScript was sync so often the first call won't have the UA...
Some easy ways to handle it (semaphore + loop, move it to PrebidMobile and call as registerAdUnits as completionHandler, performSelector) but not nice practices so I would suggest keeping the WebView until a nice solution is found.

