### PR TITLE
Fix Xcode 10 Compatibility

### DIFF
--- a/PrebidMobile.podspec
+++ b/PrebidMobile.podspec
@@ -32,6 +32,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/prebid/prebid-mobile-ios.git", :tag => "#{s.version}" }
   s.source_files = "sdk/PrebidMobile", "sdk/PrebidMobile/**/*.{h,m}", "sdk/PrebidServerAdapter/**/*.{h,m}"
   s.public_header_files = "sdk/PrebidServerAdapter/PBServerAdapter.h", "sdk/PrebidMobile/*.h", "sdk/PrebidMobile/Logging/*.h"
+  s.exclude_files = "sdk/PrebidMobile/**/PrebidMobile-umbrella.h"
   s.requires_arc = true
   s.xcconfig = {
 :LIBRARY_SEARCH_PATHS => '$(inherited)',


### PR DESCRIPTION
See issue #77 
Umbrella header is being generated by cocoapods and is colliding with the umbrella header being included by the podspec. Excluding the file in the podspec for cocoapods users. Leaving the umbrella.h for users adding the files directly to their projects.