### PR TITLE
Fix DFP swizzling

### DIFF
--- a/sdk/PrebidMobile/Categories/NSObject+Prebid.m
+++ b/sdk/PrebidMobile/Categories/NSObject+Prebid.m
@@ -23,6 +23,11 @@
 @implementation NSObject (Prebid)
 
 @dynamic pb_identifier;
+static bool swizzlingDisable = false;
+
++ (void)disableSwizzling {
+    swizzlingDisable = true;
+}
 
 + (void)load {
     static dispatch_once_t loadToken;
@@ -30,6 +35,9 @@
         dispatch_async(dispatch_get_main_queue(), ^{
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wundeclared-selector"
+            if (swizzlingDisable) { 
+             return;
+            }
             if (NSClassFromString(@"GADSlot") == nil) {
                 [NSClassFromString(@"GADOSlot") pb_swizzleInstanceSelector:@selector(requestParameters)
                                                          withSelector:@selector(pb_requestParameters)];

--- a/sdk/PrebidMobile/PrebidMobile.h
+++ b/sdk/PrebidMobile/PrebidMobile.h
@@ -41,6 +41,11 @@
                      withTimeout:(int)timeoutInMilliseconds
                completionHandler:(nullable void (^)(void))handler;
 
++ (void)setBidKeywordsOnDFPBannerView:(nonnull id)adView
+                         withAdUnitId:(NSString *)adUnitIdentifier
+                          withTimeout:(int)timeoutInMilliseconds
+                          withRequest:(nonnull id)request;
+
 + (void) shouldLoadOverSecureConnection:(BOOL) secureConnection;
 
 @end

--- a/sdk/PrebidMobile/PrebidMobile.m
+++ b/sdk/PrebidMobile/PrebidMobile.m
@@ -53,6 +53,34 @@
                                                completionHandler:completionHandler];
 }
 
++ (void)setBidKeywordsOnDFPBannerView:(id)adView
+                         withAdUnitId:(NSString *)adUnitIdentifier
+                          withTimeout:(int)timeoutInMilliseconds
+                          withRequest:(id)request {
+    void (^completionHandler)(void) = ^{
+        [self setBidKeywordsOnAdObject:adView withAdUnitId:adUnitIdentifier];
+        SEL getPb_identifier = NSSelectorFromString(@"pb_identifier");
+        if ([adView respondsToSelector:getPb_identifier]) {
+            PBAdUnit *adUnit = (PBAdUnit *)[adView performSelector:getPb_identifier];
+            NSDictionary<NSString *, NSString *> *prebidTargeting = [[PBBidManager sharedInstance] keywordsForWinningBidForAdUnit:adUnit];
+            SEL getCustomTargeting = NSSelectorFromString(@"customTargeting");
+            if ([request respondsToSelector:getCustomTargeting]) {
+                NSMutableDictionary<NSString *, NSString *> *targeting = [[request performSelector:getCustomTargeting] mutableCopy];
+                if (targeting == nil) {
+                    targeting = [NSMutableDictionary dictionary];
+                }
+                [targeting addEntriesFromDictionary:prebidTargeting];
+                [request setValue:targeting forKey:@"customTargeting"];
+            }
+        }
+        [adView loadRequest:request];
+        [[PBBidManager sharedInstance] clearBidOnAdObject:adView];
+    };
+    [[PBBidManager sharedInstance] attachTopBidHelperForAdUnitId:adUnitIdentifier
+                                                      andTimeout:timeoutInMilliseconds
+                                               completionHandler:completionHandler];
+}
+
 + (void) shouldLoadOverSecureConnection:(BOOL) secureConnection {
     [[PBBidManager sharedInstance] loadOnSecureConnection:secureConnection];
 }

--- a/sdk/PrebidMobile/PrebidMobile.m
+++ b/sdk/PrebidMobile/PrebidMobile.m
@@ -73,7 +73,9 @@
                 [request setValue:targeting forKey:@"customTargeting"];
             }
         }
-        [adView loadRequest:request];
+        dispatch_sync(dispatch_get_main_queue(), ^{
+            [adView loadRequest:request];
+        });
         [[PBBidManager sharedInstance] clearBidOnAdObject:adView];
     };
     [[PBBidManager sharedInstance] attachTopBidHelperForAdUnitId:adUnitIdentifier

--- a/sdk/PrebidMobile/PrebidMobile.m
+++ b/sdk/PrebidMobile/PrebidMobile.m
@@ -73,9 +73,13 @@
                 [request setValue:targeting forKey:@"customTargeting"];
             }
         }
-        dispatch_sync(dispatch_get_main_queue(), ^{
+        if ([NSThread isMainThread]) {
             [adView loadRequest:request];
-        });
+        } else {
+            dispatch_sync(dispatch_get_main_queue(), ^{
+                [adView loadRequest:request];
+            });
+        }
         [[PBBidManager sharedInstance] clearBidOnAdObject:adView];
     };
     [[PBBidManager sharedInstance] attachTopBidHelperForAdUnitId:adUnitIdentifier


### PR DESCRIPTION
DFP has changed their GadSlot and it would be better to stop relying on swizzling technique on 3rd party SDK (Google SDK's or Mopub). It is a dangerous practise behaviour in case on of the class or method we are swizzling is edited (that happened with GadSlot fixed in v0.5.3). Some publisher may also use a SDK rewriting the SDK api already.

The new method is adding the key value to the customTargeting array and will be easy to implement.
 
Objective-c:
.....
        self.bannerView.adUnitID = @"/7191/header-bidding";
        self.bannerView.rootViewController = self;
        DFPRequest *request = [DFPRequest request];
        [PrebidMobile setBidKeywordsOnDFPBannerView:_dfpAdView withAdUnitId:kAdUnit1Id withTimeout:600 withRequest:request];

Swift:
        banner.adUnitID = "/7191/header-bidding"
        banner.rootViewController = self
        let request = DFPRequest()
        PrebidMobile.setBidKeywordsOnDFPBannerView(self.banner, withAdUnitId: "TestUnit1", withTimeout: 600, withRequest: request)
