### PR TITLE
Fix version 1.0 

### DIFF
--- a/example/Swift/PrebidDemo/Podfile
+++ b/example/Swift/PrebidDemo/Podfile
@@ -8,7 +8,7 @@ target 'PrebidDemo' do
   # Pods for PrebidDemo
   pod 'Google-Mobile-Ads-SDK'
   pod 'mopub-ios-sdk'
-  
+
   target 'PrebidDemoTests' do
       inherit! :search_paths
   end

--- a/example/Swift/PrebidDemo/Podfile.lock
+++ b/example/Swift/PrebidDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Google-Mobile-Ads-SDK (7.39.0)
+  - Google-Mobile-Ads-SDK (7.38.0)
   - mopub-ios-sdk (5.5.0):
     - mopub-ios-sdk/MoPubSDK (= 5.5.0)
   - mopub-ios-sdk/Avid (5.5.0):
@@ -22,9 +22,9 @@ SPEC REPOS:
     - mopub-ios-sdk
 
 SPEC CHECKSUMS:
-  Google-Mobile-Ads-SDK: d0f10a7c4d7015db23075ff316602350d12049db
+  Google-Mobile-Ads-SDK: fec4a72b71a81302d3fd75454df3417c03c50ed5
   mopub-ios-sdk: 937b82dd76d8a396ba6a22ae005a1e24c61bf28b
 
 PODFILE CHECKSUM: a6cb731f1cf41f95a86f0113cec53bd282459ef5
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.5.2

--- a/example/Swift/PrebidDemo/Podfile.lock
+++ b/example/Swift/PrebidDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Google-Mobile-Ads-SDK (7.38.0)
+  - Google-Mobile-Ads-SDK (7.41.0)
   - mopub-ios-sdk (5.5.0):
     - mopub-ios-sdk/MoPubSDK (= 5.5.0)
   - mopub-ios-sdk/Avid (5.5.0):
@@ -22,9 +22,9 @@ SPEC REPOS:
     - mopub-ios-sdk
 
 SPEC CHECKSUMS:
-  Google-Mobile-Ads-SDK: fec4a72b71a81302d3fd75454df3417c03c50ed5
+  Google-Mobile-Ads-SDK: 101ce89b94fdf60ec64ba7b6e9b9d812dc765936
   mopub-ios-sdk: 937b82dd76d8a396ba6a22ae005a1e24c61bf28b
 
-PODFILE CHECKSUM: a6cb731f1cf41f95a86f0113cec53bd282459ef5
+PODFILE CHECKSUM: f360a1c025d20f1c83df3465389ff18c30132917
 
 COCOAPODS: 1.5.2

--- a/example/Swift/PrebidDemo/PrebidDemo/AppDelegate.swift
+++ b/example/Swift/PrebidDemo/PrebidDemo/AppDelegate.swift
@@ -26,6 +26,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate  {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         
+        //Declare in AppDelegate to the user agent could be passed in first call
+        Prebid.shared.prebidServerAccountId = "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
+        Prebid.shared.shareGeoLocation = true
+        //Prebid.shared.timeoutMillis = 1000;
+        //Prebid.shared.prebidServerHost = PrebidHost.Rubicon
+        //Prebid.shared.prebidServerAccountId = "12345"
+        
         coreLocation = CLLocationManager()
         coreLocation?.requestWhenInUseAuthorization()
                 

--- a/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
+++ b/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
@@ -39,14 +39,10 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
         super.viewDidLoad()
         
         adServerLabel.text = adServerName
-        
-        Prebid.shared.prebidServerAccountId = "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
-        //Prebid.shared.prebidServerAccountId = "12345"
-        Prebid.shared.shareGeoLocation = true
-        
-        
+                
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         bannerUnit.setAutoRefreshMillis(time: 35000)
+        //bannerUnit.addAdditionalSize(sizes: [CGSize(width: 300, height: 600)])
         
         if(adServerName == "DFP"){
             print("entered \(adServerName) loop" )

--- a/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
+++ b/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
@@ -39,7 +39,7 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
         super.viewDidLoad()
         
         adServerLabel.text = adServerName
-                
+        
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         bannerUnit.setAutoRefreshMillis(time: 35000)
         //bannerUnit.addAdditionalSize(sizes: [CGSize(width: 300, height: 600)])

--- a/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
+++ b/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
@@ -32,6 +32,7 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
     let request = DFPRequest()
     
     var dfpBanner: DFPBannerView!
+    var bannerUnit: BannerAdUnit!
     
     var mopubBanner: MPAdView?
     
@@ -40,7 +41,7 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
         
         adServerLabel.text = adServerName
         
-        let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
+        bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         bannerUnit.setAutoRefreshMillis(time: 35000)
         //bannerUnit.addAdditionalSize(sizes: [CGSize(width: 300, height: 600)])
         
@@ -53,6 +54,12 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
             loadMoPubBanner(bannerUnit: bannerUnit)
             
         }
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        // important to remove the time instance
+        bannerUnit.stopAutoRefresh()
+        bannerUnit = nil
     }
     
     func loadDFPBanner(bannerUnit : AdUnit){

--- a/example/Swift/PrebidDemo/PrebidDemoTests/Constants.swift
+++ b/example/Swift/PrebidDemo/PrebidDemoTests/Constants.swift
@@ -18,7 +18,7 @@ struct Constants {
     static let PBS_ACCOUNT_ID = "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
     static let PBS_CONFIG_ID_300x250_APPNEXUS_DEMAND = "6ace8c7d-88c0-4623-8117-75bc3f0a2e45"
     static let PBS_CONFIG_ID_INTERSTITIAL_APPNEXUS_DEMAND = "625c6125-f19e-4d5b-95c5-55501526b2a4"
-    static let MOPUB_BANNER_ADUNIT_ID_300x250 = "bd0a2cd5dd2241aaac18d7823d8e3a6f" 
+    static let MOPUB_BANNER_ADUNIT_ID_300x250 = "bd0a2cd5dd2241aaac18d7823d8e3a6f"
     static let MOPUB_INTERSTITIAL_ADUNIT_ID = "2829868d308643edbec0795977f17437"
     static let DFP_BANNER_ADUNIT_ID_300x250 = "/19968336/PrebidMobileValidator_Banner_All_Sizes"
     static let DFP_INTERSTITIAL_ADUNIT_ID = "/19968336/PrebidMobileValidator_Interstitial"

--- a/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
+++ b/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
@@ -22,7 +22,7 @@ import ObjectiveC.runtime
     
     var adSizes = Array<CGSize> ()
     
-    var identifier:String?
+    var identifier:String
     
     var timerClass:Dispatcher?
     
@@ -45,15 +45,17 @@ import ObjectiveC.runtime
     
     init(configId:String, size:CGSize) {
         self.closure = {_ in return}
-        super.init()
         prebidConfigId = configId
         adSizes.append(size)
         identifier = UUID.init().uuidString
+        super.init()
         
         timerClass = Dispatcher.init(withDelegate:self)
     }
     
     dynamic public func fetchDemand(adObject:AnyObject, completion: @escaping(_ result:ResultCode) -> Void) {
+        
+        Utils.shared.removeHBKeywords(adObject: adObject)
         
         for size in adSizes {
             if(size.width < 0 || size.height < 0){
@@ -89,20 +91,18 @@ import ObjectiveC.runtime
             self.didReceiveResponse = true
             if(bidResponse != nil){
                 if(!self.timeOutSignalSent){
-                        Utils.shared.removeHBKeywords(adObject: adObject)
                         Utils.shared.validateAndAttachKeywords (adObject: adObject, bidResponse: bidResponse!)
                         completion(resultCode)
                 }
                 
             } else {
                 if(!self.timeOutSignalSent){
-                    Utils.shared.removeHBKeywords(adObject: adObject)
                     completion(resultCode)
                 }
             }
         }
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(.PB_Request_Timeout) , execute: {
+        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(.PB_Request_Timeout) , execute: {
             if(!self.didReceiveResponse){
                 self.timeOutSignalSent = true
                 completion(ResultCode.prebidDemandTimedOut)

--- a/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
+++ b/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
@@ -102,7 +102,7 @@ import ObjectiveC.runtime
             }
         }
         
-        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(.PB_Request_Timeout) , execute: {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(.PB_Request_Timeout) , execute: {
             if(!self.didReceiveResponse){
                 self.timeOutSignalSent = true
                 completion(ResultCode.prebidDemandTimedOut)

--- a/src/PrebidMobile/PrebidMobile/BidManager.swift
+++ b/src/PrebidMobile/PrebidMobile/BidManager.swift
@@ -57,7 +57,7 @@ import Foundation
                             let bidResponse = BidResponse(adId: "PrebidMobile", adServerTargeting: bidMap)
                             Log.info("Bid Successful with rounded bid targeting keys are \(bidResponse.customKeywords) for adUnit id is \(bidResponse.adUnitId)")
                         
-                        DispatchQueue.global().async() {
+                        DispatchQueue.main.async() {
                             callback(bidResponse, ResultCode.prebidDemandFetchSuccess)
                         }
                     } else {

--- a/src/PrebidMobile/PrebidMobile/Constants.swift
+++ b/src/PrebidMobile/PrebidMobile/Constants.swift
@@ -49,7 +49,7 @@ extension Double {
 
 extension Int {
     
-    public static let PB_Request_Timeout = 10000
+    public static let PB_Request_Timeout = Prebid.shared.timeoutMillis
 }
 
 extension UIDevice {

--- a/src/PrebidMobile/PrebidMobile/Dispatcher.swift
+++ b/src/PrebidMobile/PrebidMobile/Dispatcher.swift
@@ -56,7 +56,6 @@ class Dispatcher:NSObject {
     }
     
     @objc func fireTimer(){
-        
         delegate?.refreshDemand()
     }
     

--- a/src/PrebidMobile/PrebidMobile/Dispatcher.swift
+++ b/src/PrebidMobile/PrebidMobile/Dispatcher.swift
@@ -23,7 +23,7 @@ class Dispatcher:NSObject {
     
     var timer : Timer?
     
-    var delegate: DispatcherDelegate?
+    weak var delegate: DispatcherDelegate?
     
     var repeatInSeconds:Double! = 0
     
@@ -44,7 +44,7 @@ class Dispatcher:NSObject {
         
         self.timer = Timer.scheduledTimer(timeInterval: repeatInSeconds, target: self, selector: #selector(fireTimer), userInfo: nil, repeats: true)
         
-        RunLoop.current.add(self.timer!, forMode: .commonModes)
+        RunLoop.main.add(self.timer!, forMode: .commonModes)
         
     }
     

--- a/src/PrebidMobile/PrebidMobile/Prebid.swift
+++ b/src/PrebidMobile/PrebidMobile/Prebid.swift
@@ -17,7 +17,7 @@ import Foundation
 
 
 @objcMembers public class Prebid:NSObject {
-    var timeoutMillis : Int = 10000
+    public var timeoutMillis : Int = 2000
     var timeoutUpdated: Bool = false
     
     public var prebidServerAccountId : String! = ""
@@ -41,9 +41,9 @@ import Foundation
         }
     }
 
-    public var prebidServerHost : PrebidHost = PrebidHost.Appnexus {
+    public var prebidServerHost : PrebidHost = PrebidHost.Appnexus{
         didSet {
-            timeoutMillis = 10000
+            timeoutMillis = 2000
             timeoutUpdated = false
         }
     }
@@ -58,6 +58,12 @@ import Foundation
      */
     private override init() {
         super.init()
+        if(RequestBuilder.myUserAgent == ""){
+            RequestBuilder.UserAgent(){(userAgentString) in
+                Log.info(userAgentString)
+                RequestBuilder.myUserAgent = userAgentString
+            }
+        }
     }
     
     public func setCustomPrebidServer(url:String) throws {

--- a/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
+++ b/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
@@ -143,10 +143,14 @@ import AdSupport
     func openrtbApp() -> [AnyHashable : Any]? {
         var app: [AnyHashable : Any] = [:]
         
+        let itunesID:String? = Targeting.shared.itunesID
         let bundle = Bundle.main.bundleIdentifier
-        if bundle != nil {
+        if itunesID != nil {
+            app["bundle"] = itunesID
+        } else if bundle != nil {
             app["bundle"] = bundle ?? ""
         }
+
         let version:String = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
         if version != "" {
             app["ver"] = version

--- a/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
+++ b/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
@@ -80,8 +80,9 @@ import AdSupport
     
     func openrtbSource() -> [String:Any]? {
         
+        let uuid = UUID().uuidString
         var sourceDict: [String : Any] = [:]
-        sourceDict["tid"] = "123"
+        sourceDict["tid"] = uuid
         
         return sourceDict
     }

--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/BidManagerTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/BidManagerTests.swift
@@ -243,7 +243,7 @@ class BidManagerTests: XCTestCase {
         stubRequestWithResponse("noBidResponse")
         Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-        XCTAssertTrue(Prebid.shared.timeoutMillis == 10000)
+        XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager:BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit() { (bidResponse, resultCode) in
@@ -260,12 +260,12 @@ class BidManagerTests: XCTestCase {
         stubRequestWithResponse("noBidResponseNoTmax")
         Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-        XCTAssertTrue(Prebid.shared.timeoutMillis == 10000)
+        XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager:BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit() { (bidResponse, resultCode) in
             XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-            XCTAssertTrue(Prebid.shared.timeoutMillis == 10000)
+            XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
             loadAdSuccesfulException.fulfill()
         }
         
@@ -277,12 +277,30 @@ class BidManagerTests: XCTestCase {
         stubRequestWithResponse("noBidResponseTmaxTooLarge")
         Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-        XCTAssertTrue(Prebid.shared.timeoutMillis == 10000)
+        XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager:BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit() { (bidResponse, resultCode) in
             XCTAssertTrue(Prebid.shared.timeoutUpdated)
-            XCTAssertTrue(Prebid.shared.timeoutMillis == 10000)
+            XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
+            loadAdSuccesfulException.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10.0, handler: nil)
+    }
+    
+    func testTimeoutMillisUpdate4(){
+        let loadAdSuccesfulException = expectation(description: "\(#function)")
+        stubRequestWithResponse("noBidResponseNoTmaxEdite")
+        Prebid.shared.prebidServerHost = PrebidHost.Appnexus
+        Prebid.shared.timeoutMillis = 1000;
+        XCTAssertTrue(!Prebid.shared.timeoutUpdated)
+        XCTAssertTrue(Prebid.shared.timeoutMillis == 1000)
+        let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
+        let manager:BidManager = BidManager(adUnit: bannerUnit)
+        manager.requestBidsForAdUnit() { (bidResponse, resultCode) in
+            XCTAssertTrue(!Prebid.shared.timeoutUpdated)
+            XCTAssertTrue(Prebid.shared.timeoutMillis == 1000)
             loadAdSuccesfulException.fulfill()
         }
         

--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
@@ -356,7 +356,9 @@ class RequestBuilderTests: XCTestCase,CLLocationManagerDelegate {
         }
         if let source = jsonRequestBody["source"] as? [String : Any]
         {
-            XCTAssertEqual("123", source["tid"] as! String)
+            let tid = source["tid"] as? String
+            XCTAssertNotNil(tid)
+
         }
     }
     

--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/Shared/Responses/noBidResponseTmaxTooLarge.json
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/Shared/Responses/noBidResponseTmaxTooLarge.json
@@ -4,6 +4,6 @@
         "responsetimemillis": {
             "appnexus": 1
         },
-        "tmaxrequest": 10000
+        "tmaxrequest": 2000
     }
 }

--- a/src/PrebidMobile/PrebidMobileTests/TargetingTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/TargetingTests.swift
@@ -77,5 +77,12 @@ class TargetingTests: XCTestCase {
         
         XCTAssertFalse(testGDPR)
     }
+    
+    func testItuneIDTargeting() {
+        Targeting.shared.itunesID = "54673893"
+        let testItuneID = Targeting.shared.itunesID
+        
+        XCTAssertTrue((testItuneID == "54673893"))
+    }
 
 }


### PR DESCRIPTION
Hello, I have noticed several snags on the new version as previously flagged with Appnexus team.

Here is a PR with many changes and should allow to have a stable version:
- delegate to weak
- run the completion in global not main queue as if a publisher is calling a DispatchQueue.main.sync from the completion it will raise a memory leak 
- unnecessary optionals remove as default value when class is init
- super.init must be done after property initialisation in swift
- fix the timer not bound to main loop (could raise issue in React Native)
- itunesID was not managed by RequestBuilder
- tid must be a random string and not always the same
- default timeout should be 2000ms as stated by prebid org. Also the timeout should be write as publisher may switch it
- removeHBKeywords could be called at start of fetchDemand so we are sure all is ok

Can you please review and push as new version.

Thanks,

Antoine Jacquemin (Rubicon Project) 