### PR TITLE
Client API behavior  

### DIFF
--- a/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
+++ b/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
@@ -33,16 +33,17 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
     
     var dfpBanner: DFPBannerView!
     
+    var bannerUnit: BannerAdUnit!
+    
     var mopubBanner: MPAdView?
-    var dispatcher: Dispatcher?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         adServerLabel.text = adServerName
         
-        let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
-        dispatcher = bannerUnit.setAutoRefreshMillis(time: 35000)
+        bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
+        bannerUnit.setAutoRefreshMillis(time: 35000)
         //bannerUnit.addAdditionalSize(sizes: [CGSize(width: 300, height: 600)])
         
         if(adServerName == "DFP"){
@@ -58,7 +59,7 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
     
     override func viewDidDisappear(_ animated: Bool) {
         // important to remove the time instance
-        dispatcher?.invalidate()
+        bannerUnit?.stopAutoRefresh()
     }
     
     func loadDFPBanner(bannerUnit : AdUnit){

--- a/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
+++ b/example/Swift/PrebidDemo/PrebidDemo/BannerController.swift
@@ -32,17 +32,17 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
     let request = DFPRequest()
     
     var dfpBanner: DFPBannerView!
-    var bannerUnit: BannerAdUnit!
     
     var mopubBanner: MPAdView?
+    var dispatcher: Dispatcher?
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         adServerLabel.text = adServerName
         
-        bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
-        bannerUnit.setAutoRefreshMillis(time: 35000)
+        let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
+        dispatcher = bannerUnit.setAutoRefreshMillis(time: 35000)
         //bannerUnit.addAdditionalSize(sizes: [CGSize(width: 300, height: 600)])
         
         if(adServerName == "DFP"){
@@ -58,8 +58,7 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
     
     override func viewDidDisappear(_ animated: Bool) {
         // important to remove the time instance
-        bannerUnit.stopAutoRefresh()
-        bannerUnit = nil
+        dispatcher?.invalidate()
     }
     
     func loadDFPBanner(bannerUnit : AdUnit){
@@ -72,9 +71,9 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
         appBannerView.addSubview(dfpBanner)
         request.testDevices = [ kGADSimulatorID,"cc7ca766f86b43ab6cdc92bed424069b"]
     
-        bannerUnit.fetchDemand(adObject:self.request) { (ResultCode) in
+        bannerUnit.fetchDemand(adObject:self.request) { [weak self] (ResultCode) in
             print("Prebid demand fetch for DFP \(ResultCode.name())")
-            self.dfpBanner!.load(self.request)
+            self?.dfpBanner!.load(self?.request)
         }
     }
     

--- a/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
+++ b/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
@@ -24,14 +24,12 @@ import ObjectiveC.runtime
     
     var identifier:String
     
-    var timerClass:Dispatcher?
-    
-    var refreshTime:Double? = 0.0
+    var dispatcher: Dispatcher?
     
     private var customKeywords = [String: Array<String>]()
     
     //This flag is set to check if the refresh needs to be made though the user has not invoked the fetch demand after initialization
-    private var isInitialCallMade:Bool! = false
+    private var isInitialFetchDemandCallMade: Bool = false
     
     private var adServerObject:AnyObject?
     
@@ -49,8 +47,6 @@ import ObjectiveC.runtime
         adSizes.append(size)
         identifier = UUID.init().uuidString
         super.init()
-        
-        timerClass = Dispatcher.init(withDelegate:self)
     }
     
     dynamic public func fetchDemand(adObject:AnyObject, completion: @escaping(_ result:ResultCode) -> Void) {
@@ -72,15 +68,12 @@ import ObjectiveC.runtime
             completion(ResultCode.prebidInvalidAccountId)
             return
         }
-        if(isInitialCallMade == false){
-            //the publisher called the fetch demand 1st fire the timer
-             isInitialCallMade = true
-            //start the timer only if the refresh timer is valided & set
-            if(refreshTime! > 0.0){
-                self.timerClass?.start(autoRefreshMillies: refreshTime!)
-            }
+
+        if !isInitialFetchDemandCallMade {
+            isInitialFetchDemandCallMade = true
+            startDispatcher()
         }
-       
+
         didReceiveResponse = false
         timeOutSignalSent = false
         self.closure = completion
@@ -165,28 +158,34 @@ import ObjectiveC.runtime
     
     /**
      * This method allows to set the auto refresh period for the demand
+     * - important: Do not forget to call invalidate() on the returned Dispatcher object to prevent reference cycle
+     *
+     * - Parameter time: refresh time interval
+     * - Returns: A new Dispatcher object, configured according to the specified parameters.
      */
-    public func setAutoRefreshMillis(time:Double){
-            if(time >= .PB_MIN_RefreshTime){
-            //Stop the old refresh & start a new timer
-            if(refreshTime! > 0.0 && isInitialCallMade == true){
-                timerClass!.stop()
-                refreshTime = time
-                timerClass!.start(autoRefreshMillies: refreshTime!)
-                
-            } else {
-                refreshTime = time
-            }
-        } else {
-            Log.error("auto refresh not set as the refresh time is less than to 30 seconds")
+    public func setAutoRefreshMillis(time:Double) -> Dispatcher? {
+        
+        stopDispatcher()
+        
+        guard time >= .PB_MIN_RefreshTime else {
+            Log.error("auto refresh not set as the refresh time is less than to \(.PB_MIN_RefreshTime as Double) seconds")
+            return nil
         }
+        
+        initDispatcher(refreshTime: time)
+        
+        if isInitialFetchDemandCallMade {
+            startDispatcher();
+        }
+        
+        return self.dispatcher
     }
     
     /**
      * This method stops the auto refresh of demand
      */
     public func stopAutoRefresh(){
-       timerClass!.stop()
+        stopDispatcher()
     }
     
     func refreshDemand(){
@@ -194,6 +193,29 @@ import ObjectiveC.runtime
                 self.fetchDemand(adObject: adServerObject!, completion: self.closure)
             }
         
+    }
+    
+    func initDispatcher(refreshTime: Double) {
+        self.dispatcher = Dispatcher.init(withDelegate:self, autoRefreshMillies: refreshTime)
+    }
+    
+    func startDispatcher() {
+        guard let dispatcher = self.dispatcher else {
+            Log.verbose("Dispatcher is nil")
+            return
+        }
+        
+        dispatcher.start()
+    }
+    
+    func stopDispatcher() {
+        guard let dispatcher = self.dispatcher else {
+            Log.verbose("Dispatcher is nil")
+            return
+        }
+        
+        dispatcher.stop()
+        self.dispatcher = nil
     }
     
 }

--- a/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
+++ b/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
@@ -163,13 +163,13 @@ import ObjectiveC.runtime
      * - Parameter time: refresh time interval
      * - Returns: A new Dispatcher object, configured according to the specified parameters.
      */
-    public func setAutoRefreshMillis(time:Double) -> Dispatcher? {
+    public func setAutoRefreshMillis(time:Double) {
         
         stopDispatcher()
         
         guard time >= .PB_MIN_RefreshTime else {
             Log.error("auto refresh not set as the refresh time is less than to \(.PB_MIN_RefreshTime as Double) seconds")
-            return nil
+            return
         }
         
         initDispatcher(refreshTime: time)
@@ -177,8 +177,6 @@ import ObjectiveC.runtime
         if isInitialFetchDemandCallMade {
             startDispatcher();
         }
-        
-        return self.dispatcher
     }
     
     /**

--- a/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
+++ b/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
@@ -158,10 +158,8 @@ import ObjectiveC.runtime
     
     /**
      * This method allows to set the auto refresh period for the demand
-     * - important: Do not forget to call invalidate() on the returned Dispatcher object to prevent reference cycle
      *
      * - Parameter time: refresh time interval
-     * - Returns: A new Dispatcher object, configured according to the specified parameters.
      */
     public func setAutoRefreshMillis(time:Double) {
         

--- a/src/PrebidMobile/PrebidMobile/Dispatcher.swift
+++ b/src/PrebidMobile/PrebidMobile/Dispatcher.swift
@@ -19,28 +19,32 @@ protocol DispatcherDelegate: class {
     func refreshDemand()
 }
 
-class Dispatcher:NSObject {
+open class Dispatcher:NSObject {
     
     var timer : Timer?
     
-    weak var delegate: DispatcherDelegate?
+    var delegate: DispatcherDelegate!
     
-    var repeatInSeconds:Double! = 0
+    var repeatInSeconds:Double = 0
     
-    init(withDelegate:DispatcherDelegate) {
-        super.init()
+    init(withDelegate:DispatcherDelegate, autoRefreshMillies:Double) {
+        
+        //timer takes values in seconds...
+        repeatInSeconds = autoRefreshMillies/1000
         delegate = withDelegate
+        
+        super.init()
+        
     }
     
-    func start(autoRefreshMillies:Double) {
+    open func invalidate() {
+        stop()
+        delegate = nil
+    }
+    
+    func start() {
         
-        if(self.timer != nil){
-            self.timer?.invalidate();
-            self.timer = nil;
-        }
-        
-        //timer takes values in seconds... 
-        repeatInSeconds = autoRefreshMillies/1000
+        stop()
         
         self.timer = Timer.scheduledTimer(timeInterval: repeatInSeconds, target: self, selector: #selector(fireTimer), userInfo: nil, repeats: true)
         

--- a/src/PrebidMobile/PrebidMobile/Dispatcher.swift
+++ b/src/PrebidMobile/PrebidMobile/Dispatcher.swift
@@ -19,7 +19,7 @@ protocol DispatcherDelegate: class {
     func refreshDemand()
 }
 
-open class Dispatcher:NSObject {
+class Dispatcher:NSObject {
     
     var timer : Timer?
     

--- a/src/PrebidMobile/PrebidMobileTests/AdUnitTests/BannerAdUnitTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/AdUnitTests/BannerAdUnitTests.swift
@@ -31,7 +31,7 @@ class BannerAdUnitTests: XCTestCase {
         let adUnit = BannerAdUnit(configId: Constants.configID1, size: CGSize(width: Constants.width2, height: Constants.height2))
         XCTAssertTrue(1 == adUnit.adSizes.count)
         XCTAssertTrue(adUnit.prebidConfigId == Constants.configID1)
-        XCTAssertTrue(0 == adUnit.refreshTime)
+        XCTAssertNil(adUnit.dispatcher)
     }
     
     func testBannerAdUnitAddSize()

--- a/src/PrebidMobile/PrebidMobileTests/AdUnitTests/InterstItialAdUnitTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/AdUnitTests/InterstItialAdUnitTests.swift
@@ -30,7 +30,7 @@ class InterstItialAdUnitTests: XCTestCase {
     {
         let adUnit = InterstitialAdUnit(configId: Constants.configID1)
         XCTAssertTrue(adUnit.prebidConfigId == Constants.configID1)
-        XCTAssertTrue(0 == adUnit.refreshTime)
+        XCTAssertNil(adUnit.dispatcher)
     }
 
     func testSetUserKeyword()

--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/DispatcherTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/DispatcherTests.swift
@@ -33,15 +33,15 @@ class DispatcherTests: XCTestCase, DispatcherDelegate {
 
     func testDispatcherIsNotNil()
     {
-        let dispatcher = Dispatcher(withDelegate: self)
+        let dispatcher = Dispatcher(withDelegate: self, autoRefreshMillies: 0.0)
         XCTAssertNotNil(dispatcher)
         XCTAssertNil(dispatcher.timer)
     }
     
     func testStartDispatcherWithRefreshMiliseconds()
     {
-        let dispatcher = Dispatcher(withDelegate: self)
-        dispatcher.start(autoRefreshMillies: 10.0)
+        let dispatcher = Dispatcher(withDelegate: self, autoRefreshMillies: 10.0)
+        dispatcher.start()
         XCTAssertNotNil(dispatcher.timer)
         XCTAssertEqual(dispatcher.timer?.timeInterval, TimeInterval(10.0/1000))
         loadSuccesfulException = expectation(description: "\(#function)")
@@ -50,8 +50,8 @@ class DispatcherTests: XCTestCase, DispatcherDelegate {
     
     func testStopDispatcher()
     {
-        let dispatcher = Dispatcher(withDelegate: self)
-        dispatcher.start(autoRefreshMillies: 10.0)
+        let dispatcher = Dispatcher(withDelegate: self, autoRefreshMillies: 10.0)
+        dispatcher.start()
         XCTAssertNotNil(dispatcher.timer)
         XCTAssertTrue(dispatcher.timer!.isValid)
         dispatcher.stop()


### PR DESCRIPTION
Issue #162 

My PR suggests:
1. go back to strong reference Dispatcher -> AdUnit
2. Open Dispatcher class and return it as a result on bannerUnit.setAutoRefreshMillis() to have a possibility to call dispatcher?.invalidate()

If a client forgets, Xcode will show a warning
<img width="842" alt="Screen Shot 2019-03-14 at 8 14 06 PM" src="https://user-images.githubusercontent.com/8141931/54385221-caa37d80-469e-11e9-8921-9b33c3bddcd3.png">

This variant still has a memory leak(AdUnit <-> Dispatcher <-> Timer) if the client 
1. calls bannerUnit.setAutoRefreshMillis() 
and
2. does not call dispatcher?.invalidate()

In any case auto-refresh feature works