### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: swift
-osx_image: xcode8
+osx_image: xcode10.2
 before_script: "./scripts/add-keys.sh"
 after_script: "./scripts/remove-key.sh"
 script:
-- "./scripts/swiftLint.sh"
-- "./scripts/buildPrebidMobile.sh"
-- "./scripts/testPrebidMobile.sh"
+  - "./scripts/swiftLint.sh"
+  - "./scripts/buildPrebidMobile.sh"
+  - "./scripts/testPrebidMobile.sh"
+  - "./scripts/testPrebidDemo.sh"

--- a/scripts/buildPrebidMobile.sh
+++ b/scripts/buildPrebidMobile.sh
@@ -30,10 +30,11 @@ touch "$LOGFILE"
 # 4
 # Build the framework for device and for simulator (using
 # all needed architectures).
-xcodebuild -target "${FRAMEWORK_NAME}" -configuration Release -arch arm64 -arch -arch  only_active_arch=yes defines_module=yes -sdk "iphoneos" > "$LOGFILE" 2>&1 || { echo "Error in build check log "$LOGFILE""; exit;}
+echo "Building the framework for device"
+xcodebuild -target "${FRAMEWORK_NAME}" -configuration Release -arch arm64 only_active_arch=no defines_module=yes -sdk "iphoneos" > "$LOGFILE" 2>&1 || { echo "Error in build check log "$LOGFILE""; exit 1;}
 
-xcodebuild -target "${FRAMEWORK_NAME}" -configuration Release -arch x86_64 -arch i386 only_active_arch=yes defines_module=yes -sdk "iphonesimulator" > "$LOGFILE" 2>&1 || { echo "Error in build check log "$LOGFILE""; exit;}
-
+echo "Building the framework for simulator"
+xcodebuild -target "${FRAMEWORK_NAME}" -configuration Release -arch x86_64 only_active_arch=no defines_module=yes -sdk "iphonesimulator" > "$LOGFILE" 2>&1 || { echo "Error in build check log "$LOGFILE""; exit 1;}
 # 5
 # Remove .framework file if exists on Desktop from previous run.
 if [ -d "${HOME}/Desktop/${FRAMEWORK_NAME}.framework" ]; then

--- a/scripts/testPrebidDemo.sh
+++ b/scripts/testPrebidDemo.sh
@@ -1,0 +1,20 @@
+if [ -d "scripts" ]; then
+cd scripts/
+fi
+
+echo "Running integration tests"
+cd ../example/Swift/PrebidDemo/
+echo $PWD
+gem install cocoapods --pre
+pod install --repo-update
+xcodebuild -workspace PrebidDemo.xcworkspace test -scheme "PrebidDemoTests" -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=12.2' | xcpretty -f `xcpretty-travis-formatter` --color --test
+
+# Make the keychain the default so identities are found
+security default-keychain -s ios-build.keychain
+
+# Unlock the keychain
+security unlock-keychain -p travis ios-build.keychain
+
+# Set keychain locking timeout to 3600 seconds
+security set-keychain-settings -t 3600 -u ios-build.keychain
+

--- a/scripts/testPrebidMobile.sh
+++ b/scripts/testPrebidMobile.sh
@@ -5,25 +5,18 @@ fi
 cd ../src/PrebidMobile/
 echo $PWD
 echo "Running unit tests"
+
 gem install xcpretty
-xcodebuild test -project PrebidMobile.xcodeproj -scheme "PrebidMobileTests" -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=11.0.1' | xcpretty
+gem install xcpretty-travis-formatter
+xcodebuild test -project PrebidMobile.xcodeproj -scheme "PrebidMobileTests" -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=12.2' | xcpretty -f `xcpretty-travis-formatter` --color --test
+if [[ ${PIPESTATUS[0]} == 0 ]]; then
+    echo "✅ Unit Tests Passed"
+else
+    echo "🔴 Unit Tests Failed"
+    exit 1
+fi
 
 cd ../src/PrebidMobile/
 echo $PWD
 echo "Running swiftlint tests"
 swiftlint --config .swiftlint.yml
-
-#echo "Running integration tests"
-cd ../../example/Swift/PrebidDemo/
-echo $PWD
-xcodebuild -workspace PrebidDemo.xcworkspace test -scheme "PrebidDemoTests" -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=12.1' | xcpretty
-
-# Make the keychain the default so identities are found
-security default-keychain -s ios-build.keychain
-
-# Unlock the keychain
-security unlock-keychain -p travis ios-build.keychain
-
-# Set keychain locking timeout to 3600 seconds
-security set-keychain-settings -t 3600 -u ios-build.keychain
-

--- a/src/PrebidMobile/PrebidMobile.xcodeproj/project.pbxproj
+++ b/src/PrebidMobile/PrebidMobile.xcodeproj/project.pbxproj
@@ -143,7 +143,7 @@
 		F543D52E220E101A00F1EF8F /* responseValidTwoBidsOnTheSameSeat.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = responseValidTwoBidsOnTheSameSeat.json; sourceTree = "<group>"; };
 		F543D530220E193200F1EF8F /* noBidResponseTmaxTooLarge.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = noBidResponseTmaxTooLarge.json; sourceTree = "<group>"; };
 		F543D531220E193200F1EF8F /* noBidResponseNoTmax.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = noBidResponseNoTmax.json; sourceTree = "<group>"; };
-		FA7C3EB4225E464300D2F128 /* PrebidServerOneBidFromAppNexusOneBidFromRubicon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PrebidServerOneBidFromAppNexusOneBidFromRubicon.json; path = ../../../../../../../../../../android/SDKPrebid/contributing/PrebidMobile/API1.0/src/test/resources/PrebidServerOneBidFromAppNexusOneBidFromRubicon.json; sourceTree = "<group>"; };
+		FA7C3EB4225E464300D2F128 /* PrebidServerOneBidFromAppNexusOneBidFromRubicon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PrebidServerOneBidFromAppNexusOneBidFromRubicon.json; path = PrebidServerOneBidFromAppNexusOneBidFromRubicon.json; sourceTree = "<group>"; };
 		FA7C3EB6225E4C2200D2F128 /* responseRubiconPBM.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = responseRubiconPBM.json; sourceTree = "<group>"; };
 		FA7C3EB8225E518000D2F128 /* noBidResponseRubicon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = noBidResponseRubicon.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */

--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/BidManagerTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/BidManagerTests.swift
@@ -93,7 +93,7 @@ class BidManagerTests: XCTestCase {
             XCTAssertEqual(resultCode, ResultCode.prebidDemandFetchSuccess)
             XCTAssertNotNil(bidResponse)
             let keywords = bidResponse?.customKeywords
-            XCTAssertEqual(16, keywords?.count)
+            XCTAssertEqual(15, keywords?.count)
             self.loadAdSuccesfulException?.fulfill()
         }
         loadAdSuccesfulException = expectation(description: "\(#function)")


### PR DESCRIPTION
Issue #195

Notes
1. osx_image was changed from xcode8 to the latest xcode10.2
2.-arch i386 was removed because the Deployment target is 11 that doe not support 32-bit arch.
3. defines_module was changed to no to build with arch from -arch parameter
4. added exit 1 to xcodebuild command to explicitly specify an error instead of using the exit code from the latest command
5. xcpretty-travis-formatter was added
6. testPrebidMobile.sh was divided into testPrebidMobile.sh(unit tests) and testPrebidDemo.sh (integration tests) to handle exit codes separately 
7. fixed wrong unit test
8. fixed wrong file path
Added log information