### PR TITLE
Fixing Objective-C DemoApp

### DIFF
--- a/example/ObjectiveC/PrebidDemo/Podfile.lock
+++ b/example/ObjectiveC/PrebidDemo/Podfile.lock
@@ -1,16 +1,44 @@
 PODS:
-  - Google-Mobile-Ads-SDK (7.39.0)
-  - mopub-ios-sdk (5.5.0):
-    - mopub-ios-sdk/MoPubSDK (= 5.5.0)
-  - mopub-ios-sdk/Avid (5.5.0):
+  - Google-Mobile-Ads-SDK (7.44.0):
+    - GoogleAppMeasurement (~> 6.0)
+  - GoogleAppMeasurement (6.0.1):
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (~> 0.3)
+  - GoogleUtilities/AppDelegateSwizzler (6.2.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+  - GoogleUtilities/Environment (6.2.0)
+  - GoogleUtilities/Logger (6.2.0):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (6.2.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (6.2.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (6.2.0)"
+  - GoogleUtilities/Reachability (6.2.0):
+    - GoogleUtilities/Logger
+  - mopub-ios-sdk (5.7.1):
+    - mopub-ios-sdk/MoPubSDK (= 5.7.1)
+  - mopub-ios-sdk/Avid (5.7.1):
     - mopub-ios-sdk/Core
-  - mopub-ios-sdk/Core (5.5.0)
-  - mopub-ios-sdk/Moat (5.5.0):
+  - mopub-ios-sdk/Core (5.7.1)
+  - mopub-ios-sdk/Moat (5.7.1):
     - mopub-ios-sdk/Core
-  - mopub-ios-sdk/MoPubSDK (5.5.0):
+  - mopub-ios-sdk/MoPubSDK (5.7.1):
     - mopub-ios-sdk/Avid
     - mopub-ios-sdk/Core
     - mopub-ios-sdk/Moat
+  - nanopb (0.3.901):
+    - nanopb/decode (= 0.3.901)
+    - nanopb/encode (= 0.3.901)
+  - nanopb/decode (0.3.901)
+  - nanopb/encode (0.3.901)
 
 DEPENDENCIES:
   - Google-Mobile-Ads-SDK
@@ -19,12 +47,18 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - Google-Mobile-Ads-SDK
+    - GoogleAppMeasurement
+    - GoogleUtilities
     - mopub-ios-sdk
+    - nanopb
 
 SPEC CHECKSUMS:
-  Google-Mobile-Ads-SDK: d0f10a7c4d7015db23075ff316602350d12049db
-  mopub-ios-sdk: 937b82dd76d8a396ba6a22ae005a1e24c61bf28b
+  Google-Mobile-Ads-SDK: 1e72b4f438d997ab0f2ee62b3a7b0cbcc87c47cb
+  GoogleAppMeasurement: 51d8d9ea48f0ca44484d29cfbdef976fbd4fc336
+  GoogleUtilities: 996e0db07153674fd1b54b220fda3a3dc3547cba
+  mopub-ios-sdk: b1167e8c86afaccd37d484828c4ad2c3c1656a32
+  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
 
 PODFILE CHECKSUM: 046766c8e4e0e44a0c7bac93f52bd49e0cb7fac3
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.7.0

--- a/example/ObjectiveC/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
+++ b/example/ObjectiveC/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,7 +14,8 @@
 		60EE7AEF21F11864000B12A8 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 60EE7AED21F11864000B12A8 /* LaunchScreen.storyboard */; };
 		60EE7AF221F11864000B12A8 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 60EE7AF121F11864000B12A8 /* main.m */; };
 		60EE7B1121F7B900000B12A8 /* PrebidNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 60EE7B1021F7B900000B12A8 /* PrebidNavigationController.m */; };
-		7483E1479FF730821B0CD46E /* libPods-PrebidDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F518154EA6D714E60F9C28A9 /* libPods-PrebidDemo.a */; };
+		FA6EC84E22AE72490023DBAC /* PrebidMobile.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60EE7B1921F7CBBF000B12A8 /* PrebidMobile.framework */; };
+		FA6EC84F22AE72490023DBAC /* PrebidMobile.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 60EE7B1921F7CBBF000B12A8 /* PrebidMobile.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,7 +33,14 @@
 			remoteGlobalIDString = 60D792FB217E229B0080F428;
 			remoteInfo = PrebidMobileTests;
 		};
-		60EE7B1C21F7CBC9000B12A8 /* PBXContainerItemProxy */ = {
+		FA6EC84B22AE71030023DBAC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 60EE7B1321F7CBBF000B12A8 /* PrebidMobile.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 60D792F1217E229A0080F428;
+			remoteInfo = PrebidMobile;
+		};
+		FA6EC85022AE72490023DBAC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 60EE7B1321F7CBBF000B12A8 /* PrebidMobile.xcodeproj */;
 			proxyType = 1;
@@ -41,7 +49,22 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		FA6EC85222AE72490023DBAC /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				FA6EC84F22AE72490023DBAC /* PrebidMobile.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		5B8F8C13519735761A8D82D6 /* Pods-PrebidDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemo.release.xcconfig"; path = "Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo.release.xcconfig"; sourceTree = "<group>"; };
 		60EE7ADF21F11861000B12A8 /* PrebidDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PrebidDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		60EE7AE221F11861000B12A8 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		60EE7AE321F11861000B12A8 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -56,9 +79,8 @@
 		60EE7B1021F7B900000B12A8 /* PrebidNavigationController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PrebidNavigationController.m; sourceTree = "<group>"; };
 		60EE7B1321F7CBBF000B12A8 /* PrebidMobile.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PrebidMobile.xcodeproj; path = ../../../src/PrebidMobile/PrebidMobile.xcodeproj; sourceTree = "<group>"; };
 		60EE7B2021F7D002000B12A8 /* PrebidDemo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PrebidDemo-Bridging-Header.h"; sourceTree = "<group>"; };
-		8D9685DF5DC5A56162EAC304 /* Pods-PrebidDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo.release.xcconfig"; sourceTree = "<group>"; };
-		F518154EA6D714E60F9C28A9 /* libPods-PrebidDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PrebidDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FAADFB7FEAEB9A813D375229 /* Pods-PrebidDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		C78F9183CDA76261C04171A6 /* Pods-PrebidDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemo.debug.xcconfig"; path = "Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		CDF49DBA5FABFD312218FC52 /* libPods-PrebidDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PrebidDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -66,20 +88,28 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7483E1479FF730821B0CD46E /* libPods-PrebidDemo.a in Frameworks */,
+				FA6EC84E22AE72490023DBAC /* PrebidMobile.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		570A8DB05CBDE7E60C8C0478 /* Pods */ = {
+		0ED6B0341EC9B46995FFF579 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				FAADFB7FEAEB9A813D375229 /* Pods-PrebidDemo.debug.xcconfig */,
-				8D9685DF5DC5A56162EAC304 /* Pods-PrebidDemo.release.xcconfig */,
+				C78F9183CDA76261C04171A6 /* Pods-PrebidDemo.debug.xcconfig */,
+				5B8F8C13519735761A8D82D6 /* Pods-PrebidDemo.release.xcconfig */,
 			);
-			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		3B913DCCAB26A672A89F507B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CDF49DBA5FABFD312218FC52 /* libPods-PrebidDemo.a */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		60EE7AD621F11861000B12A8 = {
@@ -89,8 +119,8 @@
 				60EE7B1321F7CBBF000B12A8 /* PrebidMobile.xcodeproj */,
 				60EE7AE121F11861000B12A8 /* PrebidDemo */,
 				60EE7AE021F11861000B12A8 /* Products */,
-				570A8DB05CBDE7E60C8C0478 /* Pods */,
-				643F76532DC75BFCCF4139A3 /* Frameworks */,
+				0ED6B0341EC9B46995FFF579 /* Pods */,
+				3B913DCCAB26A672A89F507B /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -129,14 +159,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		643F76532DC75BFCCF4139A3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				F518154EA6D714E60F9C28A9 /* libPods-PrebidDemo.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -144,16 +166,18 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 60EE7AF521F11864000B12A8 /* Build configuration list for PBXNativeTarget "PrebidDemo" */;
 			buildPhases = (
-				14F01326A2E8D468D07FC158 /* [CP] Check Pods Manifest.lock */,
+				04897DA52F2D5014678259E1 /* [CP] Check Pods Manifest.lock */,
 				60EE7ADB21F11861000B12A8 /* Sources */,
 				60EE7ADC21F11861000B12A8 /* Frameworks */,
 				60EE7ADD21F11861000B12A8 /* Resources */,
-				C9958D70620122E25B8B4A4B /* [CP] Copy Pods Resources */,
+				04A613B2975FA8BD157C35E7 /* [CP] Copy Pods Resources */,
+				FA6EC85222AE72490023DBAC /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				60EE7B1D21F7CBC9000B12A8 /* PBXTargetDependency */,
+				FA6EC84C22AE71030023DBAC /* PBXTargetDependency */,
+				FA6EC85122AE72490023DBAC /* PBXTargetDependency */,
 			);
 			name = PrebidDemo;
 			productName = PrebidDemo;
@@ -230,16 +254,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		14F01326A2E8D468D07FC158 /* [CP] Check Pods Manifest.lock */ = {
+		04897DA52F2D5014678259E1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			inputFileListPaths = (
 			);
 			inputPaths = (
 				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
 				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-PrebidDemo-checkManifestLockResult.txt",
 			);
@@ -248,64 +276,21 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C9958D70620122E25B8B4A4B /* [CP] Copy Pods Resources */ = {
+		04A613B2975FA8BD157C35E7 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo-resources.sh",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Internal/Common/MPAdBrowserController.xib",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPCloseBtn.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPCloseBtn@2x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPCloseBtn@3x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPCloseButtonX.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPCloseButtonX@2x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPCloseButtonX@3x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPCountdownTimer.html",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPDAAIcon.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPDAAIcon@2x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPDAAIcon@3x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPMutedBtn.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPMutedBtn@2x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPMutedBtn@3x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPPlayBtn.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPPlayBtn@2x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPPlayBtn@3x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPUnmutedBtn.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPUnmutedBtn@2x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPUnmutedBtn@3x.png",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MRAID.bundle",
-				"${PODS_ROOT}/mopub-ios-sdk/MoPubSDK/Resources/MPAdapters.plist",
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPAdBrowserController.nib",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseBtn.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseBtn@2x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseBtn@3x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseButtonX.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseButtonX@2x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCloseButtonX@3x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPCountdownTimer.html",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPDAAIcon.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPDAAIcon@2x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPDAAIcon@3x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPMutedBtn.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPMutedBtn@2x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPMutedBtn@3x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPPlayBtn.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPPlayBtn@2x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPPlayBtn@3x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPUnmutedBtn.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPUnmutedBtn@2x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPUnmutedBtn@3x.png",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MRAID.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/MPAdapters.plist",
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-PrebidDemo/Pods-PrebidDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -325,10 +310,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		60EE7B1D21F7CBC9000B12A8 /* PBXTargetDependency */ = {
+		FA6EC84C22AE71030023DBAC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PrebidMobile;
-			targetProxy = 60EE7B1C21F7CBC9000B12A8 /* PBXContainerItemProxy */;
+			targetProxy = FA6EC84B22AE71030023DBAC /* PBXContainerItemProxy */;
+		};
+		FA6EC85122AE72490023DBAC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PrebidMobile;
+			targetProxy = FA6EC85022AE72490023DBAC /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -466,13 +456,14 @@
 		};
 		60EE7AF621F11864000B12A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FAADFB7FEAEB9A813D375229 /* Pods-PrebidDemo.debug.xcconfig */;
+			baseConfigurationReference = C78F9183CDA76261C04171A6 /* Pods-PrebidDemo.debug.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = HR94J6TSB3;
+				DEVELOPMENT_TEAM = U6N2KTUT7H;
 				INFOPLIST_FILE = PrebidDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -489,13 +480,14 @@
 		};
 		60EE7AF721F11864000B12A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8D9685DF5DC5A56162EAC304 /* Pods-PrebidDemo.release.xcconfig */;
+			baseConfigurationReference = 5B8F8C13519735761A8D82D6 /* Pods-PrebidDemo.release.xcconfig */;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = HR94J6TSB3;
+				DEVELOPMENT_TEAM = U6N2KTUT7H;
 				INFOPLIST_FILE = PrebidDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/example/ObjectiveC/PrebidDemo/PrebidDemo/Info.plist
+++ b/example/ObjectiveC/PrebidDemo/PrebidDemo/Info.plist
@@ -41,6 +41,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>GADIsAdManagerApp</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
GitHub issue #201 

1. GADIsAdManagerApp key with TRUE value was added to Info.plist, for AdManager v.7.42.0 as [Google recommended](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/quick-start)
2. dyld: Library not loaded was fixed was fixed by adding `PrebidMobile.framework` to `Embedded Binaries` section