### PR TITLE
Update getting PrebidSDK version approach

### DIFF
--- a/src/PrebidMobile/PrebidMobile.xcodeproj/project.pbxproj
+++ b/src/PrebidMobile/PrebidMobile.xcodeproj/project.pbxproj
@@ -143,7 +143,7 @@
 		F543D52E220E101A00F1EF8F /* responseValidTwoBidsOnTheSameSeat.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = responseValidTwoBidsOnTheSameSeat.json; sourceTree = "<group>"; };
 		F543D530220E193200F1EF8F /* noBidResponseTmaxTooLarge.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = noBidResponseTmaxTooLarge.json; sourceTree = "<group>"; };
 		F543D531220E193200F1EF8F /* noBidResponseNoTmax.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = noBidResponseNoTmax.json; sourceTree = "<group>"; };
-		FA7C3EB4225E464300D2F128 /* PrebidServerOneBidFromAppNexusOneBidFromRubicon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = PrebidServerOneBidFromAppNexusOneBidFromRubicon.json; path = PrebidServerOneBidFromAppNexusOneBidFromRubicon.json; sourceTree = "<group>"; };
+		FA7C3EB4225E464300D2F128 /* PrebidServerOneBidFromAppNexusOneBidFromRubicon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PrebidServerOneBidFromAppNexusOneBidFromRubicon.json; sourceTree = "<group>"; };
 		FA7C3EB6225E4C2200D2F128 /* responseRubiconPBM.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = responseRubiconPBM.json; sourceTree = "<group>"; };
 		FA7C3EB8225E518000D2F128 /* noBidResponseRubicon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = noBidResponseRubicon.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -549,7 +549,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.1;
+				CURRENT_PROJECT_VERSION = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -573,7 +573,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VERSIONING_SYSTEM = "apple-generic";
+				VERSIONING_SYSTEM = "";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
@@ -612,7 +612,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.1;
+				CURRENT_PROJECT_VERSION = "";
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -630,7 +630,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
+				VERSIONING_SYSTEM = "";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;

--- a/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
+++ b/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
@@ -157,7 +157,9 @@ import AdSupport
         }
 
         app["publisher"] = ["id": Prebid.shared.prebidServerAccountId ?? 0] as NSDictionary
-        app["ext"] = ["prebid": ["version": String(PrebidMobileVersionNumber), "source": "prebid-mobile"]]
+
+        let prebidSdkVersion = Bundle(for: type(of: self)).infoDictionary?["CFBundleShortVersionString"] as? String
+        app["ext"] = ["prebid": ["version": prebidSdkVersion, "source": "prebid-mobile"]]
         
         if let storeUrl = Targeting.shared.storeURL, !storeUrl.isEmpty {
             app["storeurl"] = storeUrl

--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
@@ -338,7 +338,9 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
             if let ext = app["ext"] as? [String: Any] {
                 if let prebid = ext["prebid"] as? [String: Any] {
                     XCTAssertEqual("prebid-mobile", prebid["source"] as! String)
-                    XCTAssertEqual(String(PrebidMobileVersionNumber), prebid["version"] as! String)
+                    
+                    let prebidSdkVersion = Bundle(for: RequestBuilder.self).infoDictionary?["CFBundleShortVersionString"] as? String
+                    XCTAssertEqual(prebidSdkVersion, prebid["version"] as! String)
                 }
             }
             if let publisher = app["publisher"] as? [String: Any] {


### PR DESCRIPTION
Current implementation relies on autogenerated `PrebidMobileVersionNumber` field that is not workable with CocoaPods(The value is always 1).  

I propose to get the PrebidSDK version via `Bundle(for: type(of: self)).infoDictionary?["CFBundleShortVersionString"]` function. It returns value from sdk module's Info.plist that we change during new release