### PR TITLE
Add option to configure the verbosity of the logs

### DIFF
--- a/src/PrebidMobile/PrebidMobile/BidManager.swift
+++ b/src/PrebidMobile/PrebidMobile/BidManager.swift
@@ -33,13 +33,13 @@ import Foundation
                 URLSession.shared.dataTask(with: urlRequest!) { data, _, error in
                     let demandFetchEndTime = self.getCurrentMillis()
                     guard error == nil else {
-                        print("error calling GET on /todos/1")
+                        Log.debug("error calling GET on /todos/1")
                         return
                     }
 
                     // make sure we got data
                     if (data == nil ) {
-                        print("Error: did not receive data")
+                        Log.debug("Error: did not receive data")
                         callback(nil, ResultCode.prebidNetworkError)
 
                     }
@@ -71,7 +71,7 @@ import Foundation
             }
 
         } catch let error {
-            print(error.localizedDescription)
+            Log.debug(error.localizedDescription)
             
             let errorCode = ResultCode.prebidServerURLInvalid
             Log.error(errorCode.name())
@@ -83,7 +83,7 @@ import Foundation
 
         do {
             let errorString: String = String.init(data: data, encoding: .utf8)!
-            print(String(format: "Response from server: %@", errorString))
+            Log.debug(String(format: "Response from server: %@", errorString))
             if (!errorString.contains("Invalid request")) {
                 let response: [String: AnyObject] = try JSONSerialization.jsonObject(with: data, options: []) as! [String: AnyObject]
 
@@ -137,7 +137,7 @@ import Foundation
             }
 
         } catch let error {
-            print(error.localizedDescription)
+            Log.debug(error.localizedDescription)
 
             return ([:], ResultCode.prebidDemandNoBids)
         }
@@ -156,7 +156,7 @@ import Foundation
                 return  ext["tmaxrequest"] as! Int
             }
         } catch let error {
-            print(error.localizedDescription)
+            Log.debug(error.localizedDescription)
         }
         return -1
     }

--- a/src/PrebidMobile/PrebidMobile/Logging.swift
+++ b/src/PrebidMobile/PrebidMobile/Logging.swift
@@ -17,12 +17,12 @@ import Foundation
 
 /// Enum which maps an appropiate symbol which added as prefix for each log message
 
-enum LogEvent: String {
-    case error = "[‼️]" // error
-    case info = "[ℹ️]" // info
+public enum LogLevel: String {
     case debug = "[💬]" // debug
     case verbose = "[🔬]" // verbose
+    case info = "[ℹ️]" // info
     case warn = "[⚠️]" // warning
+    case error = "[‼️]" // error
     case severe = "[🔥]" // severe
 }
 
@@ -50,12 +50,25 @@ class Log {
         return formatter
     }
 
-    private static var isLoggingEnabled: Bool {
-        #if DEBUG
-        return true
-        #else
+    private class func isLoggingEnabled(for currentEvent: LogLevel) -> Bool {
+        #if !(DEBUG)
         return false
         #endif
+        let currentLevel = Prebid.shared.logLevel
+        switch currentLevel {
+        case .debug:
+            return true
+        case .verbose:
+            return [ LogLevel.verbose, LogLevel.info, LogLevel.warn, LogLevel.error, LogLevel.severe].contains(currentEvent)
+        case .info:
+            return [ LogLevel.info, LogLevel.warn, LogLevel.error, LogLevel.severe].contains(currentEvent)
+        case .warn:
+            return [ LogLevel.warn, LogLevel.error, LogLevel.severe].contains(currentEvent)
+        case .error:
+            return [ LogLevel.error, LogLevel.severe].contains(currentEvent)
+        case .severe:
+            return [ LogLevel.severe].contains(currentEvent)
+        }
     }
 
     // MARK: - Loging methods
@@ -69,8 +82,8 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func error( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled {
-            print("\(Date().toString()) \(LogEvent.error.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
+        if isLoggingEnabled(for: .error) {
+            print("\(Date().toString()) \(LogLevel.error.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
         }
     }
 
@@ -83,8 +96,8 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func info ( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled {
-            print("\(Date().toString()) \(LogEvent.info.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
+        if isLoggingEnabled(for: .info) {
+            print("\(Date().toString()) \(LogLevel.info.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
         }
     }
 
@@ -97,8 +110,8 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func debug( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled {
-            print("\(Date().toString()) \(LogEvent.debug.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
+        if isLoggingEnabled(for: .debug) {
+            print("\(Date().toString()) \(LogLevel.debug.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
         }
     }
 
@@ -111,8 +124,8 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func verbose( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled {
-            print("\(Date().toString()) \(LogEvent.verbose.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
+        if isLoggingEnabled(for: .verbose) {
+            print("\(Date().toString()) \(LogLevel.verbose.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
         }
     }
 
@@ -125,8 +138,8 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func warn( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled {
-            print("\(Date().toString()) \(LogEvent.warn.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
+        if isLoggingEnabled(for: .warn) {
+            print("\(Date().toString()) \(LogLevel.warn.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
         }
     }
 
@@ -139,8 +152,8 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func severe( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled {
-            print("\(Date().toString()) \(LogEvent.severe.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
+        if isLoggingEnabled(for: .severe) {
+            print("\(Date().toString()) \(LogLevel.severe.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
         }
     }
 

--- a/src/PrebidMobile/PrebidMobile/Logging.swift
+++ b/src/PrebidMobile/PrebidMobile/Logging.swift
@@ -72,6 +72,11 @@ class Log {
     }
 
     // MARK: - Loging methods
+    private class func log(level: LogLevel, _ object: Any, filename: String, line: Int, column: Int, funcName: String) {
+        if isLoggingEnabled(for: level) {
+            print("\(Date().toString()) \(level.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
+        }
+    }
 
     /// Logs error messages on console with prefix [‼️]
     ///
@@ -82,9 +87,7 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func error( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled(for: .error) {
-            print("\(Date().toString()) \(LogLevel.error.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
-        }
+        log(level: .error, object, filename: filename, line: line, column: column, funcName: funcName)
     }
 
     /// Logs info messages on console with prefix [ℹ️]
@@ -96,9 +99,7 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func info ( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled(for: .info) {
-            print("\(Date().toString()) \(LogLevel.info.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
-        }
+        log(level: .info, object, filename: filename, line: line, column: column, funcName: funcName)
     }
 
     /// Logs debug messages on console with prefix [💬]
@@ -110,9 +111,7 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func debug( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled(for: .debug) {
-            print("\(Date().toString()) \(LogLevel.debug.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
-        }
+       log(level: .debug, object, filename: filename, line: line, column: column, funcName: funcName)
     }
 
     /// Logs messages verbosely on console with prefix [🔬]
@@ -124,9 +123,7 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func verbose( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled(for: .verbose) {
-            print("\(Date().toString()) \(LogLevel.verbose.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
-        }
+        log(level: .verbose, object, filename: filename, line: line, column: column, funcName: funcName)
     }
 
     /// Logs warnings verbosely on console with prefix [⚠️]
@@ -138,9 +135,7 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func warn( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled(for: .warn) {
-            print("\(Date().toString()) \(LogLevel.warn.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
-        }
+        log(level: .warn, object, filename: filename, line: line, column: column, funcName: funcName)
     }
 
     /// Logs severe events on console with prefix [🔥]
@@ -152,9 +147,7 @@ class Log {
     ///   - column: Column number of the log message
     ///   - funcName: Name of the function from where the logging is done
     class func severe( _ object: Any, filename: String = #file, line: Int = #line, column: Int = #column, funcName: String = #function) {
-        if isLoggingEnabled(for: .severe) {
-            print("\(Date().toString()) \(LogLevel.severe.rawValue)[\(sourceFileName(filePath: filename))]:\(line) \(column) \(funcName) -> \(object)")
-        }
+        log(level: .severe, object, filename: filename, line: line, column: column, funcName: funcName)
     }
 
     /// Extract the file name from the file path

--- a/src/PrebidMobile/PrebidMobile/Prebid.swift
+++ b/src/PrebidMobile/PrebidMobile/Prebid.swift
@@ -48,6 +48,11 @@ import Foundation
     }
 
     /**
+     * Set the desidered verbosity of the logs
+     */
+    public var logLevel: LogLevel = .debug
+
+    /**
      * The class is created as a singleton object & used
      */
     public static let shared = Prebid()


### PR DESCRIPTION
Hi,
The current logs produced by the SDK are pretty _verbose_. This is great during the debug but during the every day job is too much noise that hides the real important messages.

With this PR I added an option (https://github.com/technology-ebay-de/prebid-mobile-ios/blob/9d723ea3d07800a13c9d3a34382b3e9b567c0825/src/PrebidMobile/PrebidMobile/Prebid.swift#L53) to allow the clients to choose a different LogLevel. 

All the logs, are anyway disabled on `release` builds. 

The default of this value is `debug` to do not change the current behaviour. 

For the level of verbosity I reused the existing enum. This enum is sorted based on the verbosity of the log. `.debug` will print everything, `severe` only the severe error.

```swift
public enum LogLevel: String {
    case debug = "[💬]" // debug
    case verbose = "[🔬]" // verbose
    case info = "[ℹ️]" // info
    case warn = "[⚠️]" // warning
    case error = "[‼️]" // error
    case severe = "[🔥]" // severe
}
```