### PR TITLE
Fix invalid stub for rubicon, and ensure correct prebid host in BidManagerTests.

### DIFF
--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/BidManagerTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/BidManagerTests.swift
@@ -37,6 +37,7 @@ class BidManagerTests: XCTestCase {
         PBHTTPStubbingManager.shared().broadcastRequests = true
         NotificationCenter.default.addObserver(self, selector: #selector(self.requestCompleted(_:)), name: NSNotification.Name.pbhttpStubURLProtocolRequestDidLoad, object: nil)
         request = nil
+        Prebid.shared.prebidServerHost = PrebidHost.Appnexus
     }
 
     override func tearDown() {
@@ -58,10 +59,10 @@ class BidManagerTests: XCTestCase {
         loadAdSuccesfulException = expectation(description: "\(#function)")
         waitForExpectations(timeout: timeoutForImpbusRequest, handler: nil)
     }
-    
+
     func testRubiconBidManagerAdUnitRequest() {
         Prebid.shared.prebidServerHost = PrebidHost.Rubicon
-        
+
         stubAppNexusRequestWithResponse("responseRubiconPBM")
         let bannerUnit = BannerAdUnit(configId: Constants.pbsConfigId300x250Rubicon, size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
@@ -73,6 +74,7 @@ class BidManagerTests: XCTestCase {
     }
 
     func testBidManagerRequestForInvaidBidResponseNoCacheId() {
+
         stubAppNexusRequestWithResponse("responseInvalidResponseWithoutCacheId")
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
@@ -156,11 +158,11 @@ class BidManagerTests: XCTestCase {
         loadAdSuccesfulException = expectation(description: "\(#function)")
         waitForExpectations(timeout: timeoutForImpbusRequest, handler: nil)
     }
-    
+
     func testRubiconBidManagerRequestForNoBidResponse() {
         Prebid.shared.prebidServerHost = PrebidHost.Rubicon
-        
-        stubAppNexusRequestWithResponse("noBidResponseRubicon")
+
+        stubRubiconRequestWithResponse("noBidResponseRubicon")
         let bannerUnit = BannerAdUnit(configId: Constants.pbsConfigId300x250Rubicon, size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit { (bidResponse, _) in
@@ -172,7 +174,6 @@ class BidManagerTests: XCTestCase {
     }
 
     func testAppNexusBidManagerRequestForSuccessfulBidResponse() {
-
         stubAppNexusRequestWithResponse("responseAppNexusPBM")
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
@@ -196,16 +197,16 @@ class BidManagerTests: XCTestCase {
         loadAdSuccesfulException = expectation(description: "\(#function)")
         waitForExpectations(timeout: timeoutForImpbusRequest, handler: nil)
     }
-    
+
     func testRubiconBidManagerRequestForSuccessfulBidResponse() {
         Prebid.shared.prebidServerHost = PrebidHost.Rubicon
-        
+
         stubRubiconRequestWithResponse("responseRubiconPBM")
         let bannerUnit = BannerAdUnit(configId: Constants.pbsConfigId300x250Rubicon, size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit { (bidResponse, _) in
             if let bidResponse = bidResponse {
-                
+
                 XCTAssertEqual("mobile-app", bidResponse.customKeywords["hb_env"])
                 XCTAssertEqual("https://prebid-cache-europe.rubiconproject.com/cache", bidResponse.customKeywords["hb_cache_hostpath"])
                 XCTAssertEqual("300x250", bidResponse.customKeywords["hb_size_rubicon"])
@@ -302,7 +303,7 @@ class BidManagerTests: XCTestCase {
         requestStub.responseBody = baseResponse
         PBHTTPStubbingManager.shared().add(requestStub)
     }
-    
+
     func stubRubiconRequestWithResponse(_ responseName: String?) {
         let currentBundle = Bundle(for: type(of: self))
         let baseResponse = try? String(contentsOfFile: currentBundle.path(forResource: responseName, ofType: "json") ?? "", encoding: .utf8)
@@ -316,7 +317,6 @@ class BidManagerTests: XCTestCase {
     func testTimeoutMillisUpdate() {
         let loadAdSuccesfulException = expectation(description: "\(#function)")
         stubAppNexusRequestWithResponse("noBidResponseAppNexus")
-        Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
         XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
@@ -333,7 +333,6 @@ class BidManagerTests: XCTestCase {
     func testTimeoutMillisUpdate2() {
         let loadAdSuccesfulException = expectation(description: "\(#function)")
         stubAppNexusRequestWithResponse("noBidResponseNoTmax")
-        Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
         XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
@@ -350,7 +349,6 @@ class BidManagerTests: XCTestCase {
     func testTimeoutMillisUpdate3() {
         let loadAdSuccesfulException = expectation(description: "\(#function)")
         stubAppNexusRequestWithResponse("noBidResponseTmaxTooLarge")
-        Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
         XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
@@ -367,7 +365,6 @@ class BidManagerTests: XCTestCase {
     func testTimeoutMillisUpdate4() {
         let loadAdSuccesfulException = expectation(description: "\(#function)")
         stubAppNexusRequestWithResponse("noBidResponseNoTmaxEdite")
-        Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         Prebid.shared.timeoutMillis = 1000
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
         XCTAssertTrue(Prebid.shared.timeoutMillis == 1000)


### PR DESCRIPTION
Currently the test `testRubiconBidManagerRequestForNoBidResponse` is failing silently, because the assertions pass when an invalid request is provided. 

Furthermore the tests can't be run individual because the default `PrebidHost` is custom (so empty, which results in an invalid host exception), but they succeed when executed in bulk/on travis because `Prebid.shared.prebidServerHost` is set in another test. 

This would make debugging easier! 