### PR TITLE
Prebid timeout editable

### DIFF
--- a/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
+++ b/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
@@ -96,7 +96,7 @@ import ObjectiveC.runtime
             }
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(.PB_Request_Timeout), execute: {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(Prebid.shared.timeoutMillisDynamic), execute: {
             if (!self.didReceiveResponse) {
                 self.timeOutSignalSent = true
                 completion(ResultCode.prebidDemandTimedOut)

--- a/src/PrebidMobile/PrebidMobile/BidManager.swift
+++ b/src/PrebidMobile/PrebidMobile/BidManager.swift
@@ -46,7 +46,7 @@ import Foundation
                     if (!Prebid.shared.timeoutUpdated) {
                         let tmax = self.getTmaxRequest(data!)
                         if (tmax > 0) {
-                            Prebid.shared.timeoutMillis = min(Int(demandFetchEndTime - demandFetchStartTime) + tmax + 200, .PB_Request_Timeout)
+                            Prebid.shared.timeoutMillisDynamic = min(Int(demandFetchEndTime - demandFetchStartTime) + tmax + 200, Prebid.shared.timeoutMillis)
                             Prebid.shared.timeoutUpdated = true
                         }
                     }

--- a/src/PrebidMobile/PrebidMobile/Prebid.swift
+++ b/src/PrebidMobile/PrebidMobile/Prebid.swift
@@ -16,7 +16,13 @@
 import Foundation
 
 @objcMembers public class Prebid: NSObject {
-    public var timeoutMillis: Int = .PB_Request_Timeout
+    public var timeoutMillis: Int = .PB_Request_Timeout {
+        didSet {
+            timeoutMillisDynamic = timeoutMillis
+        }
+    }
+    
+    var timeoutMillisDynamic: Int
     var timeoutUpdated: Bool = false
 
     public var prebidServerAccountId: String! = ""
@@ -42,7 +48,7 @@ import Foundation
 
     public var prebidServerHost: PrebidHost = PrebidHost.Custom {
         didSet {
-            timeoutMillis = .PB_Request_Timeout
+            timeoutMillisDynamic = timeoutMillis
             timeoutUpdated = false
         }
     }
@@ -61,6 +67,8 @@ import Foundation
      * The initializer that needs to be created only once
      */
     private override init() {
+        timeoutMillisDynamic = timeoutMillis
+        
         super.init()
         if (RequestBuilder.myUserAgent == "") {
             RequestBuilder.UserAgent {(userAgentString) in

--- a/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
+++ b/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
@@ -47,7 +47,7 @@ import AdSupport
     func buildRequest(adUnit: AdUnit?) throws -> URLRequest? {
 
             let hostUrl: String = try Host.shared.getHostURL(host: Prebid.shared.prebidServerHost)
-        var request: URLRequest = URLRequest(url: URL(string: hostUrl)!, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: TimeInterval(Prebid.shared.timeoutMillis))
+        var request: URLRequest = URLRequest(url: URL(string: hostUrl)!, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: TimeInterval(Prebid.shared.timeoutMillisDynamic))
             request.httpMethod = "POST"
             let requestBody: [String: Any] = openRTBRequestBody(adUnit: adUnit)!
 

--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/BidManagerTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/BidManagerTests.swift
@@ -324,12 +324,12 @@ class BidManagerTests: XCTestCase {
         stubAppNexusRequestWithResponse("noBidResponseAppNexus")
         Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-        XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
+        XCTAssertTrue(Prebid.shared.timeoutMillisDynamic == Prebid.shared.timeoutMillis)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit { (_, _) in
             XCTAssertTrue(Prebid.shared.timeoutUpdated)
-            XCTAssertTrue(Prebid.shared.timeoutMillis > 700 && Prebid.shared.timeoutMillis < 800)
+            XCTAssertTrue(Prebid.shared.timeoutMillisDynamic > 700 && Prebid.shared.timeoutMillisDynamic < 800)
             loadAdSuccesfulException.fulfill()
         }
 
@@ -341,12 +341,12 @@ class BidManagerTests: XCTestCase {
         stubAppNexusRequestWithResponse("noBidResponseNoTmax")
         Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-        XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
+        XCTAssertTrue(Prebid.shared.timeoutMillisDynamic == Prebid.shared.timeoutMillis)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit { (_, _) in
             XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-            XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
+            XCTAssertTrue(Prebid.shared.timeoutMillisDynamic == Prebid.shared.timeoutMillis)
             loadAdSuccesfulException.fulfill()
         }
 
@@ -358,12 +358,12 @@ class BidManagerTests: XCTestCase {
         stubAppNexusRequestWithResponse("noBidResponseTmaxTooLarge")
         Prebid.shared.prebidServerHost = PrebidHost.Appnexus
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-        XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
+        XCTAssertTrue(Prebid.shared.timeoutMillisDynamic == Prebid.shared.timeoutMillis)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit { (_, _) in
             XCTAssertTrue(Prebid.shared.timeoutUpdated)
-            XCTAssertTrue(Prebid.shared.timeoutMillis == 2000)
+            XCTAssertTrue(Prebid.shared.timeoutMillisDynamic == Prebid.shared.timeoutMillis)
             loadAdSuccesfulException.fulfill()
         }
 
@@ -377,11 +377,12 @@ class BidManagerTests: XCTestCase {
         Prebid.shared.timeoutMillis = 1000
         XCTAssertTrue(!Prebid.shared.timeoutUpdated)
         XCTAssertTrue(Prebid.shared.timeoutMillis == 1000)
+        XCTAssertTrue(Prebid.shared.timeoutMillisDynamic == 1000)
         let bannerUnit = BannerAdUnit(configId: "6ace8c7d-88c0-4623-8117-75bc3f0a2e45", size: CGSize(width: 300, height: 250))
         let manager: BidManager = BidManager(adUnit: bannerUnit)
         manager.requestBidsForAdUnit { (_, _) in
             XCTAssertTrue(!Prebid.shared.timeoutUpdated)
-            XCTAssertTrue(Prebid.shared.timeoutMillis == 1000)
+            XCTAssertTrue(Prebid.shared.timeoutMillisDynamic == 1000)
             loadAdSuccesfulException.fulfill()
         }
 


### PR DESCRIPTION
GitHub issue #226 

Previous logic relied on `.PB_Request_Timeout` constant that did not allow a client to set timeout.

In the current realization you can find:
1. `.PB_Request_Timeout`  - a default value that is equals 2000 milliseconds and is used by `timeoutMillis `
2. `timeoutMillis` - a public property that can be used a publisher to change a default timeout value. This value is used by `timeoutMillisDynamic`
3. `timeoutMillisDynamic` - an internal property of PrebidSDK that has `timeoutMillis` value by default but can be changed in runtime based on internal calculations. This value is used by PrebidSDK to throw timeout error