### PR TITLE
Fix: Cancel event is triggered to early on adUnit refresh

### DIFF
--- a/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
+++ b/src/PrebidMobile/PrebidMobile/AdUnits/AdUnit.swift
@@ -23,7 +23,7 @@ import ObjectiveC.runtime
 
     var dispatcher: Dispatcher?
 
-    var cancelWorkItem : DispatchWorkItem?;
+    var cancelWorkItem : DispatchWorkItem?
 
     private var customKeywords = [String: Set<String>]()
 


### PR DESCRIPTION
Currently if you refresh the AdUnit in 1.9 seconds the timeout is triggered 0.1 seconds later (with a 2 second timeout setting) because the previous timeout is maintained and still queued as task. 

The check `if (!self.didReceiveResponse) {` also fails in this case, because by invoking `fetchDemand` the booleans are reset too false.  

This patch makes sure that the previous timeout task is canceled and a new timeout task is created with the correct timings.