### PR TITLE
Support for stored auction and bid response ids

### DIFF
--- a/src/PrebidMobile/PrebidMobile/Prebid.swift
+++ b/src/PrebidMobile/PrebidMobile/Prebid.swift
@@ -79,4 +79,16 @@ import Foundation
             Host.shared.setHostURL = url
         }
     }
+    
+    public var storedAuctionResponse: String! = ""
+    
+    public var storedBidResponses: [String: String]! = [:]
+    
+    public func addStoredBidResponse(bidder: String, responseId: String) {
+        storedBidResponses[bidder] = responseId
+    }
+    
+    public func clearStoredBidResponses() {
+        storedBidResponses.removeAll()
+    }
 }

--- a/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
+++ b/src/PrebidMobile/PrebidMobile/RequestBuilder.swift
@@ -131,6 +131,23 @@ import AdSupport
         if let anId = adUnit?.prebidConfigId {
             prebidAdUnitExt["storedrequest"] = ["id": anId]
         }
+        
+        if !Prebid.shared.storedAuctionResponse.isEmpty {
+            prebidAdUnitExt["storedauctionresponse"] = ["id": Prebid.shared.storedAuctionResponse]
+        }
+        
+        if !Prebid.shared.storedBidResponses.isEmpty {
+            var storedBidResponses: [Any] = []
+            
+            for(bidder, responseId) in Prebid.shared.storedBidResponses {
+                var storedBidResponse: [String: String] = [:]
+                storedBidResponse["bidder"] = bidder
+                storedBidResponse["id"] = responseId
+                storedBidResponses.append(storedBidResponse)
+            }
+            
+            prebidAdUnitExt["storedbidresponse"] = storedBidResponses
+        }
 
         var adUnitExt: [AnyHashable: Any] = [:]
         adUnitExt["prebid"] = prebidAdUnitExt

--- a/src/PrebidMobile/PrebidMobileTests/PrebidTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/PrebidTests.swift
@@ -58,4 +58,16 @@ class PrebidTests: XCTestCase {
         XCTAssertThrowsError(try Prebid.shared.setCustomPrebidServer(url: "abc"))
     }
 
+    func testStoredAuctionResponse() {
+        Prebid.shared.storedAuctionResponse = "111122223333"
+        XCTAssertEqual(Prebid.shared.storedAuctionResponse, "111122223333")
+    }
+    
+    func testStoredBidResponses() {
+        Prebid.shared.addStoredBidResponse(bidder: "appnexus", responseId: "221144")
+        Prebid.shared.addStoredBidResponse(bidder: "rubicon", responseId: "221155")
+        XCTAssertFalse(Prebid.shared.storedBidResponses.isEmpty)
+        Prebid.shared.clearStoredBidResponses()
+        XCTAssertTrue(Prebid.shared.storedBidResponses.isEmpty)
+    }
 }


### PR DESCRIPTION
Github issue #228 

This PR contains the following changes:
- Add methods on **Prebid** to set stored auction id and stored bid responses ids.
- If present, add these params into the **ext** object of the impression on the OpenRTB request to Prebid server.

**Setting Stored Auction Id**

``` Swift
Prebid.shared.storedAuctionResponse = "111122223333"
```

Will generate on the request:

``` JSON
"imp": [
    {
        "id": "a",
        "ext": {
            "prebid": { 
                "storedauctionresponse": { 
                    "id": "111122223333" 
                 } 
             } 
        }
    }
]
```

**Setting Stored Bid Responses Ids**

``` Swift
Prebid.shared.addStoredBidResponse(bidder: "appnexus", responseId: "221144")
Prebid.shared.addStoredBidResponse(bidder: "rubicon", responseId: "221155")
```

Will generate on the request:

``` JSON
"imp": [
    {
      "id": "a",
      "ext": {
          "prebid": {
            "storedbidresponse": [
                  { "bidder": "appnexus", "id": "221144" },
                  { "bidder": "rubicon", "id": "221155" },
             ]
           } 
      }
    }
  ]
```

This method was created to clear the stored bid response ids:

``` Swift
Prebid.shared.clearStoredBidResponses()
```