### PR TITLE
`bidderNames` were exposed for Objective-C code

### DIFF
--- a/src/PrebidMobile/PrebidMobile/Constants.swift
+++ b/src/PrebidMobile/PrebidMobile/Constants.swift
@@ -43,10 +43,6 @@ extension String {
     public static let MoPub_Object_Name = "MPAdView"
 
     public static let MoPub_Interstitial_Name = "MPInterstitialAdController"
-
-    public static let bidderNameAppNexus = "appnexus"
-
-    public static let bidderNameRubiconProject = "rubicon"
 }
 
 extension Double {

--- a/src/PrebidMobile/PrebidMobile/Prebid.swift
+++ b/src/PrebidMobile/PrebidMobile/Prebid.swift
@@ -16,6 +16,10 @@
 import Foundation
 
 @objcMembers public class Prebid: NSObject {
+    
+    public static let bidderNameAppNexus = "appnexus"
+    public static let bidderNameRubiconProject = "rubicon"
+    
     public var timeoutMillis: Int = .PB_Request_Timeout {
         didSet {
             timeoutMillisDynamic = timeoutMillis

--- a/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
+++ b/src/PrebidMobile/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
@@ -278,7 +278,7 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
     
     func testPostDataWithAccessControlList() {
         let targeting = Targeting.shared
-        targeting.addBidderToAccessControlList(.bidderNameRubiconProject)
+        targeting.addBidderToAccessControlList(Prebid.bidderNameRubiconProject)
         
         do {
             try RequestBuilder.shared.buildPrebidRequest(adUnit: adUnit) { (urlRequest) in
@@ -290,7 +290,7 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
                 }
                 
                 XCTAssertNotNil(bidders.count == 1)
-                XCTAssertEqual(bidders[0], .bidderNameRubiconProject)
+                XCTAssertEqual(bidders[0], Prebid.bidderNameRubiconProject)
                 
                 self.validationResponse(jsonRequestBody: jsonRequestBody)
             }


### PR DESCRIPTION
Objective-C code does not have an access to the bidder name constants. 

This PR fixes this issue