### PR TITLE
Support for US Privacy flag

### DIFF
--- a/PrebidMobile.xcodeproj/project.pbxproj
+++ b/PrebidMobile.xcodeproj/project.pbxproj
@@ -97,6 +97,9 @@
 		FAD4D544235DCCAB00140012 /* VideoAdUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD4D542235DCCAB00140012 /* VideoAdUnit.swift */; };
 		FAD4D546235DCCCF00140012 /* VideoInterstitialAdUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD4D545235DCCCF00140012 /* VideoInterstitialAdUnit.swift */; };
 		FAD4D547235DCCCF00140012 /* VideoInterstitialAdUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD4D545235DCCCF00140012 /* VideoInterstitialAdUnit.swift */; };
+		FAEBF29F237EC7B1006BA972 /* StorageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEBF29E237EC7B1006BA972 /* StorageUtils.swift */; };
+		FAEBF2A0237EC7B1006BA972 /* StorageUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEBF29E237EC7B1006BA972 /* StorageUtils.swift */; };
+		FAEBF2A2237ECFEF006BA972 /* StorageUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEBF2A1237ECFEF006BA972 /* StorageUtilsTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -196,6 +199,8 @@
 		FAC837D72321583500565051 /* CollectionExtensionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionExtensionTest.swift; sourceTree = "<group>"; };
 		FAD4D542235DCCAB00140012 /* VideoAdUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoAdUnit.swift; sourceTree = "<group>"; };
 		FAD4D545235DCCCF00140012 /* VideoInterstitialAdUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoInterstitialAdUnit.swift; sourceTree = "<group>"; };
+		FAEBF29E237EC7B1006BA972 /* StorageUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageUtils.swift; sourceTree = "<group>"; };
+		FAEBF2A1237ECFEF006BA972 /* StorageUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageUtilsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -290,6 +295,7 @@
 				600072FE21BAFD2F00F4738B /* Dispatcher.swift */,
 				6013E3F12214A4CA00FEE2B1 /* Location.swift */,
 				FA7F89EB22DC95E30065B652 /* CollectionExtension.swift */,
+				FAEBF29E237EC7B1006BA972 /* StorageUtils.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -416,6 +422,7 @@
 			children = (
 				FAC837D72321583500565051 /* CollectionExtensionTest.swift */,
 				FA5AD5E32271FA4100C8F274 /* ConstantsTest.swift */,
+				FAEBF2A1237ECFEF006BA972 /* StorageUtilsTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -670,6 +677,7 @@
 				606FAC2621FFB20A008EAE5E /* TargetingTests.swift in Sources */,
 				606FAC282200AD2C008EAE5E /* PrebidTests.swift in Sources */,
 				606FAC4A2201F248008EAE5E /* AdUnitTests.swift in Sources */,
+				FAEBF2A2237ECFEF006BA972 /* StorageUtilsTests.swift in Sources */,
 				60D79301217E229B0080F428 /* PrebidMobileTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -678,6 +686,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FAEBF2A0237EC7B1006BA972 /* StorageUtils.swift in Sources */,
 				FA29A3D5232255DF00F13F61 /* Reachability.swift in Sources */,
 				FA29A3D6232255DF00F13F61 /* BidManager.swift in Sources */,
 				FA29A3D7232255DF00F13F61 /* Dispatcher.swift in Sources */,
@@ -707,6 +716,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FAEBF29F237EC7B1006BA972 /* StorageUtils.swift in Sources */,
 				FAAA00D223227F5B009DC7D6 /* Global.swift in Sources */,
 				FAAA00D823227F5B009DC7D6 /* CollectionExtension.swift in Sources */,
 				FAAA00CB23227F5B009DC7D6 /* BidManager.swift in Sources */,

--- a/Source/Constants.swift
+++ b/Source/Constants.swift
@@ -16,15 +16,6 @@
 import Foundation
 
 extension String {
-    public static let PB_COPPA_SubjectToConsent = "kPBCoppaSubjectToConsent"
-    
-    public static let PB_GDPR_ConsentString = "kPBGDPRConsentString"
-
-    public static let PB_GDPR_SubjectToConsent = "kPBGdprSubjectToConsent"
-
-    public static let IAB_GDPR_SubjectToConsent = "IABConsent_SubjectToGDPR"
-
-    public static let IAB_GDPR_ConsentString = "IABConsent_ConsentString"
 
     public static let EMPTY_String = ""
 

--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -342,22 +342,25 @@ import AdSupport
         return nil
     }
 
-    func openrtbRegs() -> [AnyHashable: Any]? {
+    func openrtbRegs() -> [AnyHashable: Any] {
 
         var regsDict: [AnyHashable: Any] = [:]
+        var ext: [AnyHashable: Any] = [:]
 
-        let gdpr = Targeting.shared.subjectToGDPR
-
-        if gdpr == true {
-            regsDict["ext"] = ["gdpr": NSNumber(value: gdpr).intValue] as NSDictionary
+        if Targeting.shared.subjectToGDPR == true {
+            ext["gdpr"] = 1
         }
+        
+        ext["us_privacy"] = StorageUtils.iabCcpa()
+        
+        regsDict["ext"] = ext
 
         let coppa = Targeting.shared.subjectToCOPPA
         if coppa == true {
             regsDict["coppa"] = NSNumber(value: coppa).intValue
         }
 
-        return regsDict.isEmpty ? nil : regsDict
+        return regsDict
     }
 
     // OpenRTB 2.5 Object: User in section 3.2.20

--- a/Source/StorageUtils.swift
+++ b/Source/StorageUtils.swift
@@ -17,7 +17,7 @@ import Foundation
 
 class StorageUtils {
     //COPPA
-    static let PB_COPPA = "kPBCoppaSubjectToConsent"
+    static let PB_COPPAKey = "kPBCoppaSubjectToConsent"
     
     //GDPR
     static let PBConsent_SubjectToGDPRKey = "kPBGdprSubjectToConsent"
@@ -35,11 +35,11 @@ class StorageUtils {
     
     //COPPA
     static func pbCoppa() -> Bool {
-        return UserDefaults.standard.bool(forKey: StorageUtils.PB_COPPA)
+        return UserDefaults.standard.bool(forKey: StorageUtils.PB_COPPAKey)
     }
     
     static func setPbCoppa(value: Bool) {
-        setUserDefaults(value: value, forKey: StorageUtils.PB_COPPA)
+        setUserDefaults(value: value, forKey: StorageUtils.PB_COPPAKey)
     }
     
     //GDPR

--- a/Source/StorageUtils.swift
+++ b/Source/StorageUtils.swift
@@ -1,0 +1,83 @@
+/*   Copyright 2018-2019 Prebid.org, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import Foundation
+
+class StorageUtils {
+    //COPPA
+    static let PB_COPPA = "kPBCoppaSubjectToConsent"
+    
+    //GDPR
+    static let PBConsent_SubjectToGDPRKey = "kPBGdprSubjectToConsent"
+    
+    static let PBConsent_ConsentStringKey = "kPBGDPRConsentString"
+
+    static let IABConsent_SubjectToGDPRKey = "IABConsent_SubjectToGDPR"
+
+    static let IABConsent_ConsentStringKey = "IABConsent_ConsentString"
+    
+    //CCPA
+    static let IABUSPrivacy_StringKey = "IABUSPrivacy_String"
+    
+    //MARK: - getters and setters
+    
+    //COPPA
+    static func pbCoppa() -> Bool {
+        return UserDefaults.standard.bool(forKey: StorageUtils.PB_COPPA)
+    }
+    
+    static func setPbCoppa(value: Bool) {
+        setUserDefaults(value: value, forKey: StorageUtils.PB_COPPA)
+    }
+    
+    //GDPR
+    static func pbGdprSubject() -> Bool? {
+        return getObjectFromUserDefaults(forKey: StorageUtils.PBConsent_SubjectToGDPRKey)
+    }
+    
+    static func setPbGdprSubject(value: Bool?) {
+        setUserDefaults(value: value, forKey: StorageUtils.PBConsent_SubjectToGDPRKey)
+    }
+    
+    static func iabGdprSubject() -> String? {
+        return getObjectFromUserDefaults(forKey: StorageUtils.IABConsent_SubjectToGDPRKey)
+    }
+    
+    static func pbGdprConsent() -> String? {
+        return getObjectFromUserDefaults(forKey: StorageUtils.PBConsent_ConsentStringKey)
+    }
+    
+    static func setPbGdprConsent(value: String?) {
+        setUserDefaults(value: value, forKey: StorageUtils.PBConsent_ConsentStringKey)
+    }
+    
+    static func iabGdprConsent() -> String? {
+        return getObjectFromUserDefaults(forKey: StorageUtils.IABConsent_ConsentStringKey)
+    }
+    
+    //CCPA
+    static func iabCcpa() -> String? {
+        return getObjectFromUserDefaults(forKey: StorageUtils.IABUSPrivacy_StringKey)
+    }
+    
+    //MARK: - private zone
+    private static func setUserDefaults(value: Any?, forKey: String) {
+        UserDefaults.standard.set(value, forKey: forKey)
+    }
+    
+    private static func getObjectFromUserDefaults<T>(forKey: String) -> T? {
+        return UserDefaults.standard.object(forKey: forKey) as? T
+    }
+}

--- a/Source/Targeting.swift
+++ b/Source/Targeting.swift
@@ -102,7 +102,7 @@ import CoreLocation
 
                 if (iabGdpr == "1" || iabGdpr == "true" || iabGdpr == "yes") {
                     gdprConsent = true
-                } else {
+                } else if (iabGdpr == "0" || iabGdpr == "false" || iabGdpr == "no") {
                     gdprConsent = false
                 }
                 

--- a/Source/Targeting.swift
+++ b/Source/Targeting.swift
@@ -32,6 +32,21 @@ import CoreLocation
     
     private var yearofbirth: Int = 0
 
+    public var storeURL: String?
+    public var domain: String?
+
+    /**
+     * The class is created as a singleton object & used
+     */
+    public static let shared = Targeting()
+
+    /**
+     * The initializer that needs to be created only once
+     */
+    private override init() {
+        gender = Gender.unknown
+    }
+    
     /**
      * This property gets the gender enum passed set by the developer
      */
@@ -40,6 +55,82 @@ import CoreLocation
 
     public var yearOfBirth: Int {
         return yearofbirth
+    }
+    
+    /**
+     * The itunes app id for targeting
+     */
+    public var itunesID: String?
+
+    /**
+     * The application location for targeting
+     */
+    public var location: CLLocation?
+
+    /**
+     * The application location precision for targeting
+     */
+    public var locationPrecision: Int?
+    
+    /**
+     * The boolean value set by the user to collect user data
+     */
+    public var subjectToCOPPA: Bool {
+        set {
+            StorageUtils.setPbCoppa(value: newValue)
+        }
+        
+        get {
+            return StorageUtils.pbCoppa()
+        }
+    }
+    
+    /**
+     * The boolean value set by the user to collect user data
+     */
+    public var subjectToGDPR: Bool? {
+        set {
+            StorageUtils.setPbGdprSubject(value: newValue)
+        }
+
+        get {
+            var gdprConsent: Bool?
+
+            if let pbGdpr = StorageUtils.pbGdprSubject() {
+                gdprConsent = pbGdpr
+            } else if let iabGdpr = StorageUtils.iabGdprSubject() {
+
+                if (iabGdpr == "1" || iabGdpr == "true" || iabGdpr == "yes") {
+                    gdprConsent = true
+                } else {
+                    gdprConsent = false
+                }
+                
+            }
+            
+            return gdprConsent
+        }
+    }
+
+    /**
+     * The consent string for sending the GDPR consent
+     */
+    public var gdprConsentString: String? {
+        set {
+            StorageUtils.setPbGdprConsent(value: newValue)
+        }
+
+        get {
+            var savedConsent: String?
+            
+            if let pbString = StorageUtils.pbGdprConsent() {
+                savedConsent = pbString
+            } else if let iabString = StorageUtils.iabGdprConsent() {
+                savedConsent = iabString
+            }
+            
+            return savedConsent
+        }
     }
     
     // MARK: - access control list (ext.prebid.data)
@@ -241,93 +332,6 @@ import CoreLocation
      */
     public func clearYearOfBirth() {
             yearofbirth = 0
-    }
-
-    /**
-     * The itunes app id for targeting
-     */
-    public var itunesID: String?
-
-    /**
-     * The application location for targeting
-     */
-    public var location: CLLocation?
-
-    /**
-     * The application location precision for targeting
-     */
-    public var locationPrecision: Int?
-
-    /**
-     * The boolean value set by the user to collect user data
-     */
-    public var subjectToCOPPA: Bool {
-        set {
-            UserDefaults.standard.set(newValue, forKey: .PB_COPPA_SubjectToConsent)
-        }
-        
-        get {
-            return UserDefaults.standard.bool(forKey: .PB_COPPA_SubjectToConsent)
-        }
-    }
-    
-    /**
-     * The boolean value set by the user to collect user data
-     */
-    public var subjectToGDPR: Bool {
-        set {
-            UserDefaults.standard.set(newValue, forKey: .PB_GDPR_SubjectToConsent)
-        }
-
-        get {
-            var gdprConsent: Bool = false
-
-            if ((UserDefaults.standard.object(forKey: .PB_GDPR_SubjectToConsent)) != nil) {
-                gdprConsent = UserDefaults.standard.bool(forKey: .PB_GDPR_SubjectToConsent)
-            } else if ((UserDefaults.standard.object(forKey: .IAB_GDPR_SubjectToConsent)) != nil) {
-                let stringValue: String = UserDefaults.standard.object(forKey: .IAB_GDPR_SubjectToConsent) as! String
-
-                gdprConsent = Bool(stringValue)!
-            }
-            return gdprConsent
-        }
-    }
-
-    /**
-     * The consent string for sending the GDPR consent
-     */
-    public var gdprConsentString: String? {
-        set {
-            UserDefaults.standard.set(newValue, forKey: .PB_GDPR_ConsentString)
-        }
-
-        get {
-            let pbString: String? = UserDefaults.standard.object(forKey: .PB_GDPR_ConsentString) as? String
-            let iabString: String? = UserDefaults.standard.object(forKey: .IAB_GDPR_ConsentString) as? String
-
-            var savedConsent: String?
-            if (pbString != nil) {
-                savedConsent = pbString
-            } else if (iabString != nil) {
-                savedConsent = iabString
-            }
-            return savedConsent
-        }
-    }
-    
-    public var storeURL: String?
-    public var domain: String?
-
-    /**
-     * The class is created as a singleton object & used
-     */
-    public static let shared = Targeting()
-
-    /**
-     * The initializer that needs to be created only once
-     */
-    private override init() {
-        gender = Gender.unknown
     }
 
 }

--- a/Tests/FetchingLogictests/RequestBuilderTests.swift
+++ b/Tests/FetchingLogictests/RequestBuilderTests.swift
@@ -120,32 +120,6 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         XCTAssertEqual("PrebidMobile", id)
     }
 
-    func testPostDataWithConsent() throws {
-
-        //given
-        let targeting = Targeting.shared
-        targeting.subjectToGDPR = true
-        defer {
-            targeting.subjectToGDPR = false
-        }
-
-        targeting.gdprConsentString = "testGDPR"
-
-        //when
-        let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
-
-        guard let user = jsonRequestBody["user"] as? [String: Any],
-            let userExt = user["ext"] as? [String: Any],
-            let consent = userExt["consent"] as? String else {
-
-                XCTFail("parsing error")
-                return
-        }
-
-        //then
-        XCTAssertEqual("testGDPR", consent)
-    }
-
     func testPostDataWithGender() throws {
 
         //given
@@ -283,7 +257,7 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         XCTAssertNil(coppa)
     }
     
-    func testPostDataWithGDPR() throws {
+    func testPostDataWithGdprSubject() throws {
 
         //given
         let targeting = Targeting.shared
@@ -307,7 +281,7 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         XCTAssertEqual(1, gdpr)
     }
 
-    func testPostDataWithoutGDPR() throws {
+    func testPostDataWithoutGdprSubject() throws {
 
         //given
         let targeting = Targeting.shared
@@ -330,6 +304,137 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
 
         //then
         XCTAssertNil(gdpr)
+    }
+    
+    func testPostDataWithGdprConsent() throws {
+
+        //given
+        let targeting = Targeting.shared
+        targeting.subjectToGDPR = true
+        defer {
+            targeting.subjectToGDPR = false
+        }
+
+        targeting.gdprConsentString = "testGDPR"
+
+        //when
+        let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
+
+        guard let regs = jsonRequestBody["regs"] as? [String: Any],
+            let regsExt = regs["ext"] as? [String: Any],
+            let gdpr = regsExt["gdpr"] as? Int,
+            //consent
+            let user = jsonRequestBody["user"] as? [String: Any],
+            let userExt = user["ext"] as? [String: Any],
+            let consent = userExt["consent"] as? String else {
+                
+                XCTFail("parsing error")
+                return
+        }
+
+        //then
+        XCTAssertEqual(1, gdpr)
+        XCTAssertEqual("testGDPR", consent)
+    }
+    
+    func testPostDataWithGdprConsentWithoutGdprSubject() throws {
+
+        //given
+        let targeting = Targeting.shared
+        targeting.subjectToGDPR = false
+
+        targeting.gdprConsentString = "testGDPR"
+
+        //when
+        let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
+
+        var gdpr: Int? = nil
+        var consent: String? = nil
+
+        if let regs = jsonRequestBody["regs"] as? [String: Any],
+            let regsExt = regs["ext"] as? [String: Any],
+            let extGdpr = regsExt["gdpr"] as? Int,
+            //consent
+            let user = jsonRequestBody["user"] as? [String: Any],
+            let userExt = user["ext"] as? [String: Any],
+            let extConsent = userExt["consent"] as? String {
+
+            gdpr = extGdpr
+            consent = extConsent
+        }
+
+        //then
+        XCTAssertNil(gdpr)
+        XCTAssertNil(consent)
+
+    }
+    
+    func testPostDataWithCCPA() throws {
+
+        //given
+        UserDefaults.standard.set("testCCPA", forKey: StorageUtils.IABUSPrivacy_StringKey)
+        defer {
+            UserDefaults.standard.removeObject(forKey: StorageUtils.IABUSPrivacy_StringKey)
+        }
+
+        //when
+        let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
+
+        guard let regs = jsonRequestBody["regs"] as? [String: Any],
+            let regsExt = regs["ext"] as? [String: Any],
+            let usPrivacy = regsExt["us_privacy"] as? String else {
+
+                XCTFail("parsing error")
+                return
+        }
+
+        //then
+        XCTAssertEqual("testCCPA", usPrivacy)
+    }
+    
+    func testPostDataWithEmptyCCPA() throws {
+
+        //given
+        UserDefaults.standard.set("", forKey: StorageUtils.IABUSPrivacy_StringKey)
+        defer {
+            UserDefaults.standard.removeObject(forKey: StorageUtils.IABUSPrivacy_StringKey)
+        }
+
+        var usPrivacy: String? = nil
+
+        //when
+        let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
+
+        if let regs = jsonRequestBody["regs"] as? [String: Any],
+            let regsExt = regs["ext"] as? [String: Any],
+            let extUsPrivacy = regsExt["us_privacy"] as? String {
+
+            usPrivacy = extUsPrivacy
+        }
+
+        //then
+        XCTAssertNil(usPrivacy)
+    }
+    
+    func testPostDataWithoutCCPA() throws {
+
+        //given
+        UserDefaults.standard.removeObject(forKey: StorageUtils.IABUSPrivacy_StringKey)
+
+        var usPrivacy: String? = nil
+
+        //when
+        let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
+
+        if let regs = jsonRequestBody["regs"] as? [String: Any],
+            let regsExt = regs["ext"] as? [String: Any],
+            let extUsPrivacy = regsExt["us_privacy"] as? String {
+
+            usPrivacy = extUsPrivacy
+        }
+
+        //then
+        XCTAssertNil(usPrivacy)
     }
 
     func testPostDataWithCustomKeyword() throws {

--- a/Tests/TargetingTests.swift
+++ b/Tests/TargetingTests.swift
@@ -64,18 +64,68 @@ class TargetingTests: XCTestCase {
         XCTAssertEqual(2, Targeting.shared.locationPrecision)
     }
 
-    func testGDPRConsentString() {
-        Targeting.shared.gdprConsentString = "testconsent"
-        let value = Targeting.shared.gdprConsentString
+    func testPbGrprSubject() {
+        //given
+        Targeting.shared.subjectToGDPR = true
+        defer {
+            Targeting.shared.subjectToGDPR = false
+        }
+        
+        //when
+        let pbGdprSubject = Targeting.shared.subjectToGDPR
 
-        XCTAssertTrue((value == "testconsent"))
+        //then
+        XCTAssertEqual(true, pbGdprSubject)
     }
+    
+    func testIabGrprSubject() {
+        //given
+        Targeting.shared.subjectToGDPR = nil
+        UserDefaults.standard.set("1", forKey: StorageUtils.IABConsent_SubjectToGDPRKey)
+        defer {
+            UserDefaults.standard.removeObject(forKey: StorageUtils.IABConsent_SubjectToGDPRKey)
+        }
+        
+        //when
+        let iabGdprSubject = Targeting.shared.subjectToGDPR
 
-    func testGDPREnable() {
-        Targeting.shared.subjectToGDPR = false
-        let testGDPR = Targeting.shared.subjectToGDPR
+        //then
+        XCTAssertEqual(true, iabGdprSubject)
+        
+        //when
+        UserDefaults.standard.set("true", forKey: StorageUtils.IABConsent_SubjectToGDPRKey)
+        
+        //then
+        XCTAssertEqual(true, iabGdprSubject)
+    }
+    
+    func testPbGdprConsent() {
+        //given
+        Targeting.shared.gdprConsentString = "testconsent PB"
+        defer {
+            Targeting.shared.gdprConsentString = nil
+        }
+        
+        //when
+        let pbGdprConsent = Targeting.shared.gdprConsentString
 
-        XCTAssertFalse(testGDPR)
+        //then
+        XCTAssertEqual("testconsent PB", pbGdprConsent)
+    }
+    
+    func testIabGdprConsent() {
+        //given
+        Targeting.shared.gdprConsentString = nil
+        UserDefaults.standard.set("testconsent IAB", forKey: StorageUtils.IABConsent_ConsentStringKey)
+        defer {
+            UserDefaults.standard.removeObject(forKey: StorageUtils.IABConsent_ConsentStringKey)
+        }
+        
+        //when
+        let iabGdprConsent = Targeting.shared.gdprConsentString
+
+        //then
+        XCTAssertEqual("testconsent IAB", iabGdprConsent)
     }
 
     func testItuneIDTargeting() {

--- a/Tests/UnitTests/StorageUtilsTests.swift
+++ b/Tests/UnitTests/StorageUtilsTests.swift
@@ -1,0 +1,205 @@
+/*   Copyright 2018-2019 Prebid.org, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+import XCTest
+
+@testable import PrebidMobile
+
+class StorageUtilsTests: XCTestCase {
+    
+    override func setUp() {
+        
+    }
+    
+    override func tearDown() {
+        
+    }
+    
+    func testIABUSPrivacy_StringKey() {
+        XCTAssertEqual("IABUSPrivacy_String", StorageUtils.IABUSPrivacy_StringKey)
+    }
+    
+    func testIABConsent_SubjectToGDPRKey() {
+        XCTAssertEqual("IABConsent_SubjectToGDPR", StorageUtils.IABConsent_SubjectToGDPRKey)
+    }
+    
+    func testIABConsent_ConsentStringKey() {
+        XCTAssertEqual("IABConsent_ConsentString", StorageUtils.IABConsent_ConsentStringKey)
+    }
+    
+    func testPBConsent_SubjectToGDPRKey() {
+        XCTAssertEqual("kPBGdprSubjectToConsent", StorageUtils.PBConsent_SubjectToGDPRKey)
+    }
+    
+    func testPBConsent_ConsentStringKey() {
+        XCTAssertEqual("kPBGDPRConsentString", StorageUtils.PBConsent_ConsentStringKey)
+    }
+    
+    func testPbCoppa() {
+        //given
+        StorageUtils.setPbCoppa(value: true)
+        defer {
+            StorageUtils.setPbCoppa(value: false)
+        }
+        
+        //when
+        let coppa = StorageUtils.pbCoppa()
+        
+        //then
+        XCTAssertEqual(true, coppa)
+    }
+    
+    func testPbGdprSubject() {
+        //given
+        StorageUtils.setPbGdprSubject(value: true)
+        defer {
+            StorageUtils.setPbGdprSubject(value: nil)
+        }
+        
+        //when
+        let pbGdprSubject = StorageUtils.pbGdprSubject()
+        
+        //then
+        XCTAssertEqual(true, pbGdprSubject)
+    }
+    
+    func testPbGdprSubjectNotExists() {
+        //given
+        StorageUtils.setPbGdprSubject(value: nil)
+        
+        //when
+        let pbGdprSubject = StorageUtils.pbGdprSubject()
+        
+        //then
+        XCTAssertNil(pbGdprSubject)
+    }
+    
+    func testIabGdprSubjectNotExists() {
+        //given
+        UserDefaults.standard.removeObject(forKey: StorageUtils.IABConsent_SubjectToGDPRKey)
+        
+        //when
+        let iabGdprSubject = StorageUtils.iabGdprSubject()
+        
+        //then
+        XCTAssertNil(iabGdprSubject)
+    }
+    
+    func testIabGdprSubjectFilled() {
+        UserDefaults.standard.set("testIabGdprSubject", forKey: StorageUtils.IABConsent_SubjectToGDPRKey)
+        defer {
+            UserDefaults.standard.removeObject(forKey: StorageUtils.IABConsent_SubjectToGDPRKey)
+        }
+        
+        //when
+        let iabGdprSubject = StorageUtils.iabGdprSubject()
+        
+        //then
+        XCTAssertEqual("testIabGdprSubject", iabGdprSubject)
+    }
+    
+    func testPbGdprConsent() {
+        //given
+        StorageUtils.setPbGdprConsent(value: "testPbGdprConsent")
+        defer {
+            StorageUtils.setPbGdprConsent(value: nil)
+        }
+        
+        //when
+        let pbGdprConsent = StorageUtils.pbGdprConsent()
+        
+        //then
+        XCTAssertEqual("testPbGdprConsent", pbGdprConsent)
+    }
+    
+    func testPbGdprConsentNotExists() {
+        //given
+        StorageUtils.setPbGdprConsent(value: nil)
+        
+        //when
+        let pbGdprConsent = StorageUtils.pbGdprConsent()
+        
+        //then
+        XCTAssertNil(pbGdprConsent)
+    }
+    
+    func testIabGdprConsentNotExists() {
+        //given
+        UserDefaults.standard.removeObject(forKey: StorageUtils.IABConsent_ConsentStringKey)
+        
+        //when
+        let iabGdprConsent = StorageUtils.iabGdprSubject()
+        
+        //then
+        XCTAssertNil(iabGdprConsent)
+    }
+    
+    func testIabGdprConsentFilled() {
+        UserDefaults.standard.set("testIabGdprConsentFilled", forKey: StorageUtils.IABConsent_ConsentStringKey)
+        defer {
+            UserDefaults.standard.removeObject(forKey: StorageUtils.IABConsent_ConsentStringKey)
+        }
+        
+        //when
+        let iabGdprConsent = StorageUtils.iabGdprConsent()
+        
+        //then
+        XCTAssertEqual("testIabGdprConsentFilled", iabGdprConsent)
+    }
+    
+    func testIabCcpaNotExist() {
+        
+        //given
+        UserDefaults.standard.removeObject(forKey: StorageUtils.IABUSPrivacy_StringKey)
+        
+        //when
+        let ccpa = StorageUtils.iabCcpa()
+        
+        //then
+        XCTAssertNil(ccpa)
+    }
+    
+    func testIabCcpaFilled() {
+        
+        //given
+        UserDefaults.standard.set("testCCPA", forKey: StorageUtils.IABUSPrivacy_StringKey)
+        defer {
+            UserDefaults.standard.removeObject(forKey: StorageUtils.IABUSPrivacy_StringKey)
+        }
+        
+        //when
+        let ccpa = StorageUtils.iabCcpa()
+        
+        //then
+        XCTAssertEqual("testCCPA", ccpa)
+    }
+    
+    func testIabCcpaEmpry() {
+        
+        //given
+        UserDefaults.standard.set("", forKey: StorageUtils.IABUSPrivacy_StringKey)
+        defer {
+            UserDefaults.standard.removeObject(forKey: StorageUtils.IABUSPrivacy_StringKey)
+        }
+        
+        //when
+        let ccpa = StorageUtils.iabCcpa()
+        
+        //then
+        XCTAssertEqual("", ccpa)
+    }
+    
+}


### PR DESCRIPTION
1. CCPA was added #250
API:
``` Swift
//add
UserDefaults.standard.set("1YN", forKey: "IABUSPrivacy_String")

//remove
UserDefaults.standard.removeObject(forKey: "IABUSPrivacy_String")
```

OpenRTB request:
``` XML
"regs": {
  "ext": {
   "us_privacy": "1YN"
  }
}
```

2. fixed GDPR exception #243
3. `subjectToGDPR` can be assign to `nil` to get an IAB value
``` Swift
Targeting.shared.subjectToGDPR = nil
```
4. refactoring
5. tests were added