### PR TITLE
UIWebView was removed

### DIFF
--- a/Example/PrebidDemo/PrebidDemoObjectiveC/Info.plist
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/Info.plist
@@ -41,8 +41,6 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>GADIsAdManagerApp</key>
-	<true/>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -50,5 +48,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+
+    <key>GADIsAdManagerApp</key>
+    <true/>
+    <key>gad_preferred_webview</key>
+    <string>wkwebview</string>
+
 </dict>
 </plist>

--- a/Example/PrebidDemo/PrebidDemoSwift/Info.plist
+++ b/Example/PrebidDemo/PrebidDemoSwift/Info.plist
@@ -56,7 +56,11 @@
 	<string>Need to use location for better ad targeting</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Need to use location for better ad targeting</string>
+
     <key>GADIsAdManagerApp</key>
     <true/>
+    <key>gad_preferred_webview</key>
+    <string>wkwebview</string>
+    
 </dict>
 </plist>

--- a/Tests/addendum/AdViewUtilsTests.swift
+++ b/Tests/addendum/AdViewUtilsTests.swift
@@ -136,14 +136,7 @@ class AdViewUtilsTests: XCTestCase {
         
         let uiView = UIView()
         
-        findSizeInViewFailureHelper(uiView, expectedErrorCode: PbFindSizeErrorFactory.noWebViewCode)
-    }
-    
-    func testFailureFindSizeInViewIfUiWebViewWithoutHTML() {
-        
-        let uiWebView = UIWebView()
-        
-        findSizeInViewFailureHelper(uiWebView, expectedErrorCode: PbFindSizeErrorFactory.noHtmlCode)
+        findSizeInViewFailureHelper(uiView, expectedErrorCode: PbFindSizeErrorFactory.noWKWebViewCode)
     }
     
     func testFailureFindSizeInViewIfWkWebViewWithoutHTML() {
@@ -157,7 +150,7 @@ class AdViewUtilsTests: XCTestCase {
         
         let uiView = UIView()
         
-        findSizeInViewFailureHelper(uiView, expectedErrorCode: PbFindSizeErrorFactory.noWebViewCode)
+        findSizeInViewFailureHelper(uiView, expectedErrorCode: PbFindSizeErrorFactory.noWKWebViewCode)
     }
     
     class TestingWKNavigationDelegate: NSObject, WKNavigationDelegate {
@@ -175,26 +168,6 @@ class AdViewUtilsTests: XCTestCase {
                 }
                 self.loadSuccesfulException.fulfill()
             }
-        }
-    }
-    
-    class TestingUIWebViewDelegate: NSObject, UIWebViewDelegate {
-        let loadSuccesfulException: XCTestExpectation
-        
-        init(_ loadSuccesfulException: XCTestExpectation) {
-            self.loadSuccesfulException = loadSuccesfulException
-        }
-        
-        func webViewDidFinishLoad(_ webView: UIWebView) {
-            loadSuccesfulException.fulfill()
-            return
-        }
-        
-        func webView(_ webView: UIWebView, didFailLoadWithError error: Error) {
-            XCTFail("TestingUIWebViewDelegate error: \(error)")
-            loadSuccesfulException.fulfill()
-            return
-            
         }
     }
     
@@ -222,23 +195,6 @@ class AdViewUtilsTests: XCTestCase {
         findSizeInViewSuccessHelper(wkWebView, expectedSize: CGSize(width: 728, height: 90))
     }
     
-    func testSuccessFindSizeInUiWebView() {
-        let uiWebView = UIWebView()
-        
-        setHtmlIntoUiWebView(successHtmlWithSize728x90, uiWebView)
-        findSizeInViewSuccessHelper(uiWebView, expectedSize: CGSize(width: 728, height: 90))
-    }
-    
-    func testSuccessFindSizeInViewWithUiWebView() {
-        
-        let uiView = UIView()
-        let uiWebView = UIWebView()
-        uiView.addSubview(uiWebView)
-        
-        setHtmlIntoUiWebView(successHtmlWithSize728x90, uiWebView)
-        findSizeInViewSuccessHelper(uiWebView, expectedSize: CGSize(width: 728, height: 90))
-    }
-    
     func setHtmlIntoWkWebView(_ html: String, _ wkWebView: WKWebView) {
         let loadSuccesfulException = expectation(description: "\(#function)")
         
@@ -249,18 +205,6 @@ class AdViewUtilsTests: XCTestCase {
         
         waitForExpectations(timeout: 5, handler: nil)
         wkWebView.navigationDelegate = nil
-    }
-    
-    func setHtmlIntoUiWebView(_ html: String, _ uiWebView: UIWebView) {
-        let loadSuccesfulException = expectation(description: "\(#function)")
-        
-        let testingUIWebViewDelegate = TestingUIWebViewDelegate(loadSuccesfulException)
-        uiWebView.delegate = testingUIWebViewDelegate
-        
-        uiWebView.loadHTMLString(html, baseURL: nil)
-        
-        waitForExpectations(timeout: 5, handler: nil)
-        uiWebView.delegate = nil
     }
     
     func findSizeInViewFailureHelper(_ view: UIView, expectedErrorCode: Int) {

--- a/tools/PrebidValidator/Dr.Prebid/Common/PBViewTool.h
+++ b/tools/PrebidValidator/Dr.Prebid/Common/PBViewTool.h
@@ -22,7 +22,5 @@
 + (void) checkMPAdViewContainsPBMAd:(MPAdView *)view
               withCompletionHandler:(void(^)(BOOL result))completionHandler;
 
-+ (BOOL) checkDFPAdViewContainsPBMAd:(GADBannerView *)view;
-
 @end
 

--- a/tools/PrebidValidator/Dr.Prebid/Common/PBViewTool.m
+++ b/tools/PrebidValidator/Dr.Prebid/Common/PBViewTool.m
@@ -45,23 +45,4 @@
     }
 }
 
-+ (BOOL) checkDFPAdViewContainsPBMAd:(GADBannerView *)view{
-    for (UIView *level1 in view.subviews){
-        NSArray *level2s = level1.subviews;
-        for(UIView *level2 in level2s){
-            for (UIView *level3 in level2.subviews){
-                if([level3 isKindOfClass:[UIWebView class]])
-                {
-                    UIWebView *wv = (UIWebView *)level3;
-                    NSString *content = [wv stringByEvaluatingJavaScriptFromString:@"document.body.innerHTML"];
-                    if ([content containsString:@"prebid/pbm.js"] || [content containsString:@"creative.js"]) {
-                        return true;
-                    }
-                }
-            }
-        }
-    }
-    return false;
-}
-
 @end

--- a/tools/PrebidValidator/Dr.Prebid/Info.plist
+++ b/tools/PrebidValidator/Dr.Prebid/Info.plist
@@ -18,8 +18,6 @@
 	<string>2.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
-	<key>GADIsAdManagerApp</key>
-	<true/>
 	<key>LSApplicationCategoryType</key>
 	<dict/>
 	<key>LSRequiresIPhoneOS</key>
@@ -60,5 +58,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    
+    <key>GADIsAdManagerApp</key>
+    <true/>
+    <key>gad_preferred_webview</key>
+    <string>wkwebview</string>
+
 </dict>
 </plist>


### PR DESCRIPTION
>ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of apps that use UIWebView APIs . See https://developer.apple.com/documentation/uikit/uiwebview for more information.

1. `UIWebView` was removed from SDK
2. `WKWebView` was set by default for AM SDK

**AdManager**
[AdManager Release notes](https://developers.google.com/ad-manager/mobile-ads-sdk/ios/rel-notes)
> 7.55.0 | 2020‑02‑04 | Removed all references to UIWebView. UIWebView is no longer supported.

**MoPub**
[MoPub issue](https://github.com/mopub/mopub-ios-sdk/issues/285)
[MoPub Release notes](https://developers.mopub.com/publishers/ios/changelog/)
>Version 5.9.0 (September 16, 2019) Totally remove UIWebView


`AdViewUtils.findPrebidCreativeSize` works only with `WKWebView`.
`AdManager`: `gad_preferred_webview` key with `wkwebview` value or v7.55.0(or higher)
```
//Info.plist 
<key>gad_preferred_webview</key>
<string>wkwebview</string>
```
`MoPub`: v5.9.0(or higher)





