### PR TITLE
Video signals improvement

### DIFF
--- a/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
@@ -109,9 +109,15 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
         
         let parameters = VideoBaseAdUnit.Parameters()
         parameters.mimes = ["video/mp4"]
+        
         parameters.protocols = [Signals.Protocols.VAST_2_0]
+        // parameters.protocols = [Signals.Protocols(2)]
+        
         parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOff]
+        // parameters.playbackMethod = [Signals.PlaybackMethod(2)]
+        
         parameters.placement = Signals.Placement.InBanner
+        // parameters.placement = Signals.Placement(2)
         
         adUnit.parameters = parameters
         

--- a/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
@@ -105,12 +105,13 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
         Prebid.shared.prebidServerAccountId = "1001"
         Prebid.shared.storedAuctionResponse = "sample_video_response"
         
-        let adUnit = VideoAdUnit(configId: "1001-1", size: CGSize(width: 300, height: 250), type: .inBanner)
+        let adUnit = VideoAdUnit(configId: "1001-1", size: CGSize(width: 300, height: 250))
         
         let parameters = VideoBaseAdUnit.Parameters()
         parameters.mimes = ["video/mp4"]
         parameters.protocols = [Protocols.VAST_2_0]
         parameters.playbackMethod = [PlaybackMethod.AutoPlaySoundOff]
+        parameters.placement = Placement.InBanner
         
         adUnit.parameters = parameters
         

--- a/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
@@ -109,9 +109,9 @@ class BannerController: UIViewController, GADBannerViewDelegate, MPAdViewDelegat
         
         let parameters = VideoBaseAdUnit.Parameters()
         parameters.mimes = ["video/mp4"]
-        parameters.protocols = [Protocols.VAST_2_0]
-        parameters.playbackMethod = [PlaybackMethod.AutoPlaySoundOff]
-        parameters.placement = Placement.InBanner
+        parameters.protocols = [Signals.Protocols.VAST_2_0]
+        parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOff]
+        parameters.placement = Signals.Placement.InBanner
         
         adUnit.parameters = parameters
         

--- a/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
@@ -115,8 +115,8 @@ class InterstitialViewController: UIViewController, GADInterstitialDelegate, MPI
         let adUnit = VideoInterstitialAdUnit(configId: "1001-1")
         let parameters = VideoBaseAdUnit.Parameters()
         parameters.mimes = ["video/mp4"]
-        parameters.protocols = [Protocols.VAST_2_0]
-        parameters.playbackMethod = [PlaybackMethod.AutoPlaySoundOff]
+        parameters.protocols = [Signals.Protocols.VAST_2_0]
+        parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOff]
         
         adUnit.parameters = parameters
         

--- a/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
@@ -115,8 +115,12 @@ class InterstitialViewController: UIViewController, GADInterstitialDelegate, MPI
         let adUnit = VideoInterstitialAdUnit(configId: "1001-1")
         let parameters = VideoBaseAdUnit.Parameters()
         parameters.mimes = ["video/mp4"]
+        
         parameters.protocols = [Signals.Protocols.VAST_2_0]
+        // parameters.protocols = [Signals.Protocols(2)]
+        
         parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOff]
+        // parameters.playbackMethod = [Signals.PlaybackMethod(2)]
         
         adUnit.parameters = parameters
         

--- a/Example/PrebidDemo/PrebidDemoSwift/RewardedVideoController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/RewardedVideoController.swift
@@ -70,8 +70,8 @@ class RewardedVideoController: UIViewController, GADRewardedAdDelegate, MPReward
         
         let parameters = VideoBaseAdUnit.Parameters()
         parameters.mimes = ["video/mp4"]
-        parameters.protocols = [Protocols.VAST_2_0]
-        parameters.playbackMethod = [PlaybackMethod.AutoPlaySoundOff]
+        parameters.protocols = [Signals.Protocols.VAST_2_0]
+        parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOff]
         
         adUnit.parameters = parameters
         

--- a/Example/PrebidDemo/PrebidDemoSwift/RewardedVideoController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/RewardedVideoController.swift
@@ -70,8 +70,12 @@ class RewardedVideoController: UIViewController, GADRewardedAdDelegate, MPReward
         
         let parameters = VideoBaseAdUnit.Parameters()
         parameters.mimes = ["video/mp4"]
+        
         parameters.protocols = [Signals.Protocols.VAST_2_0]
+        // parameters.protocols = [Signals.Protocols(2)]
+        
         parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOff]
+        //parameters.playbackMethod = [Signals.PlaybackMethod(2)]
         
         adUnit.parameters = parameters
         

--- a/Source/AdUnits/Signals.swift
+++ b/Source/AdUnits/Signals.swift
@@ -222,3 +222,48 @@ public class StartDelay: SingleContainerInt {
     public static let GenericPostRoll = StartDelay(-2)
     
 }
+
+/**
+# OpenRTB - Video Placement Types #
+```
+| Value | Description                  |
+|-------|------------------------------|
+| 1     | In-Stream                    |
+| 2     | In-Banner                    |
+| 3     | In-Article                   |
+| 4     | In-Feed                      |
+| 5     | Interstitial/Slider/Floating |
+```
+*/
+@objc(PBPlacement)
+public class Placement: SingleContainerInt {
+    
+    /// In-Stream
+    @objc
+    public static let InStream = Placement(1)
+    
+    /// In-Banner
+    @objc
+    public static let InBanner = Placement(2)
+    
+    /// In-Article
+    @objc
+    public static let InArticle = Placement(3)
+    
+    /// In-Feed
+    @objc
+    public static let InFeed = Placement(4)
+    
+    /// Interstitial
+    @objc
+    public static let Interstitial = Placement(5)
+    
+    /// Slider
+    @objc
+    public static let Slider = Placement(5)
+    
+    /// Floating
+    @objc
+    public static let Floating = Placement(5)
+    
+}

--- a/Source/AdUnits/Signals.swift
+++ b/Source/AdUnits/Signals.swift
@@ -51,7 +51,7 @@ public class SingleContainerInt: NSObject, ExpressibleByIntegerLiteral {
     }
 }
 /**
- # OpenRTB #
+ # OpenRTB - API Frameworks #
  ```
  | Value | Description |
  |-------|-------------|
@@ -66,78 +66,137 @@ public class SingleContainerInt: NSObject, ExpressibleByIntegerLiteral {
 @objc(PBApi)
 public class Api: SingleContainerInt {
     
+    /// VPAID 1.0
     @objc
     public static let VPAID_1 = Api(1)
+    
+    /// VPAID 2.0
     @objc
     public static let VPAID_2 = Api(2)
+    
+    /// MRAID-1
     @objc
     public static let MRAID_1 = Api(3)
+    
+    /// ORMMA
     @objc
     public static let ORMMA = Api(4)
+    
+    /// MRAID-2
     @objc
     public static let MARAID_2 = Api(5)
+    
+    /// MRAID-3
     @objc
     public static let MARAID_3 = Api(6)
 }
 
 /**
-# OpenRTB #
+# OpenRTB - Playback Methods #
 ```
-| Value | Description         |
-|-------|---------------------|
-| 1     | Auto-Play Sound On  |
-| 2     | Auto-Play Sound Off |
-| 3     | Click-to-Play       |
-| 4     | Mouse-Over          |
+| Value | Description                                              |
+|-------|----------------------------------------------------------|
+| 1     | Initiates on Page Load with Sound On                     |
+| 2     | Initiates on Page Load with Sound Off by Default         |
+| 3     | Initiates on Click with Sound On                         |
+| 4     | Initiates on Mouse-Over with Sound On                    |
+| 5     | Initiates on Entering Viewport with Sound On             |
+| 6     | Initiates on Entering Viewport with Sound Off by Default |
 ```
 */
 @objc(PBPlaybackMethod)
 public class PlaybackMethod: SingleContainerInt {
 
+    /// Initiates on Page Load with Sound On
     @objc
     public static let AutoPlaySoundOn = PlaybackMethod(1)
+    
+    /// Initiates on Page Load with Sound Off by Default
     @objc
     public static let AutoPlaySoundOff = PlaybackMethod(2)
+    
+    /// Initiates on Click with Sound On
     @objc
     public static let ClickToPlay = PlaybackMethod(3)
+    
+    /// Initiates on Mouse-Over with Sound On
     @objc
     public static let MouseOver = PlaybackMethod(4)
+    
+    /// Initiates on Entering Viewport with Sound On
+    @objc
+    public static let EnterSoundOn = PlaybackMethod(5)
+    
+    /// Initiates on Entering Viewport with Sound Off by Default
+    @objc
+    public static let EnterSoundOff = PlaybackMethod(6)
 
 }
 
 /**
-# OpenRTB #
+# OpenRTB - Protocols #
 ```
-| Value | Description      |
-|-------|------------------|
-| 1     | VAST 1.0         |
-| 2     | VAST 2.0         |
-| 3     | VAST 3.0         |
-| 4     | VAST 1.0 Wrapper |
-| 5     | VAST 2.0 Wrapper |
-| 6     | VAST 3.0 Wrapper |
+| Value | Description       |
+|-------|-------------------|
+| 1     | VAST 1.0          |
+| 2     | VAST 2.0          |
+| 3     | VAST 3.0          |
+| 4     | VAST 1.0 Wrapper  |
+| 5     | VAST 2.0 Wrapper  |
+| 6     | VAST 3.0 Wrapper  |
+| 7     | VAST 4.0          |
+| 8     | VAST 4.0 Wrapper  |
+| 9     | DAAST 1.0         |
+| 10    | DAAST 1.0 Wrapper |
 ```
 */
 @objc(PBProtocols)
 public class Protocols: SingleContainerInt {
     
+    /// VAST 1.0
     @objc
     public static let VAST_1_0 = Protocols(1)
+    
+    /// VAST 2.0
     @objc
     public static let VAST_2_0 = Protocols(2)
+    
+    /// VAST 3.0
     @objc
     public static let VAST_3_0 = Protocols(3)
+    
+    /// VAST 1.0 Wrapper
     @objc
     public static let VAST_1_0_Wrapper = Protocols(4)
+    
+    /// VAST 2.0 Wrapper
     @objc
     public static let VAST_2_0_Wrapper = Protocols(5)
+    
+    /// VAST 3.0 Wrapper
     @objc
     public static let VAST_3_0_Wrapper = Protocols(6)
+    
+    /// VAST 4.0
+    @objc
+    public static let VAST_4_0 = Protocols(7)
+    
+    /// VAST 4.0 Wrapper
+    @objc
+    public static let VAST_4_0_Wrapper = Protocols(8)
+    
+    /// DAAST 1.0
+    @objc
+    public static let DAAST_1_0 = Protocols(9)
+    
+    /// DAAST 1.0 Wrapper
+    @objc
+    public static let DAAST_1_0_WRAPPER = Protocols(10)
     
 }
 
 /**
-# OpenRTB #
+# OpenRTB - Start Delay #
 ```
 | Value | Description                                      |
 |-------|--------------------------------------------------|
@@ -150,10 +209,15 @@ public class Protocols: SingleContainerInt {
 @objc(PBStartDelay)
 public class StartDelay: SingleContainerInt {
     
+    /// Pre-Roll
     @objc
     public static let PreRoll = StartDelay(0)
+    
+    /// Generic Mid-Roll
     @objc
     public static let GenericMidRoll = StartDelay(-1)
+    
+    /// Generic Post-Roll
     @objc
     public static let GenericPostRoll = StartDelay(-2)
     

--- a/Source/AdUnits/Signals.swift
+++ b/Source/AdUnits/Signals.swift
@@ -15,255 +15,257 @@ limitations under the License.
 
 import Foundation
 
-
-public class SingleContainerInt: NSObject, ExpressibleByIntegerLiteral {
-
-    public typealias IntegerLiteralType = Int
+public class Signals: NSObject {
     
-    @objc
-    public let value: Int
-    
-    @objc
-    public required init(integerLiteral value: Int) {
-        self.value = value
-    }
-    
-    static func == (lhs: SingleContainerInt, rhs: SingleContainerInt) -> Bool {
-        return lhs.value == rhs.value
-    }
+    public class SingleContainerInt: NSObject, ExpressibleByIntegerLiteral {
 
-    override public func isEqual(_ object: Any?) -> Bool {
-
-        if let other = object as? SingleContainerInt {
-            if self === other {
-                return true
-            } else {
-                return self.value == other.value
-            }
+        public typealias IntegerLiteralType = Int
+        
+        @objc
+        public let value: Int
+        
+        @objc
+        public required init(integerLiteral value: Int) {
+            self.value = value
+        }
+        
+        static func == (lhs: SingleContainerInt, rhs: SingleContainerInt) -> Bool {
+            return lhs.value == rhs.value
         }
 
-        return false
+        override public func isEqual(_ object: Any?) -> Bool {
+
+            if let other = object as? SingleContainerInt {
+                if self === other {
+                    return true
+                } else {
+                    return self.value == other.value
+                }
+            }
+
+            return false
+
+        }
+
+        override public var hash : Int {
+            return value.hashValue
+        }
+    }
+    /**
+     # OpenRTB - API Frameworks #
+     ```
+     | Value | Description |
+     |-------|-------------|
+     | 1     | VPAID 1.0   |
+     | 2     | VPAID 2.0   |
+     | 3     | MRAID-1     |
+     | 4     | ORMMA       |
+     | 5     | MRAID-2     |
+     | 6     | MRAID-3     |
+     ```
+     */
+    @objc(PBApi)
+    public class Api: SingleContainerInt {
+        
+        /// VPAID 1.0
+        @objc
+        public static let VPAID_1 = Api(1)
+        
+        /// VPAID 2.0
+        @objc
+        public static let VPAID_2 = Api(2)
+        
+        /// MRAID-1
+        @objc
+        public static let MRAID_1 = Api(3)
+        
+        /// ORMMA
+        @objc
+        public static let ORMMA = Api(4)
+        
+        /// MRAID-2
+        @objc
+        public static let MARAID_2 = Api(5)
+        
+        /// MRAID-3
+        @objc
+        public static let MARAID_3 = Api(6)
+    }
+
+    /**
+    # OpenRTB - Playback Methods #
+    ```
+    | Value | Description                                              |
+    |-------|----------------------------------------------------------|
+    | 1     | Initiates on Page Load with Sound On                     |
+    | 2     | Initiates on Page Load with Sound Off by Default         |
+    | 3     | Initiates on Click with Sound On                         |
+    | 4     | Initiates on Mouse-Over with Sound On                    |
+    | 5     | Initiates on Entering Viewport with Sound On             |
+    | 6     | Initiates on Entering Viewport with Sound Off by Default |
+    ```
+    */
+    @objc(PBPlaybackMethod)
+    public class PlaybackMethod: SingleContainerInt {
+
+        /// Initiates on Page Load with Sound On
+        @objc
+        public static let AutoPlaySoundOn = PlaybackMethod(1)
+        
+        /// Initiates on Page Load with Sound Off by Default
+        @objc
+        public static let AutoPlaySoundOff = PlaybackMethod(2)
+        
+        /// Initiates on Click with Sound On
+        @objc
+        public static let ClickToPlay = PlaybackMethod(3)
+        
+        /// Initiates on Mouse-Over with Sound On
+        @objc
+        public static let MouseOver = PlaybackMethod(4)
+        
+        /// Initiates on Entering Viewport with Sound On
+        @objc
+        public static let EnterSoundOn = PlaybackMethod(5)
+        
+        /// Initiates on Entering Viewport with Sound Off by Default
+        @objc
+        public static let EnterSoundOff = PlaybackMethod(6)
 
     }
 
-    override public var hash : Int {
-        return value.hashValue
+    /**
+    # OpenRTB - Protocols #
+    ```
+    | Value | Description       |
+    |-------|-------------------|
+    | 1     | VAST 1.0          |
+    | 2     | VAST 2.0          |
+    | 3     | VAST 3.0          |
+    | 4     | VAST 1.0 Wrapper  |
+    | 5     | VAST 2.0 Wrapper  |
+    | 6     | VAST 3.0 Wrapper  |
+    | 7     | VAST 4.0          |
+    | 8     | VAST 4.0 Wrapper  |
+    | 9     | DAAST 1.0         |
+    | 10    | DAAST 1.0 Wrapper |
+    ```
+    */
+    @objc(PBProtocols)
+    public class Protocols: SingleContainerInt {
+        
+        /// VAST 1.0
+        @objc
+        public static let VAST_1_0 = Protocols(1)
+        
+        /// VAST 2.0
+        @objc
+        public static let VAST_2_0 = Protocols(2)
+        
+        /// VAST 3.0
+        @objc
+        public static let VAST_3_0 = Protocols(3)
+        
+        /// VAST 1.0 Wrapper
+        @objc
+        public static let VAST_1_0_Wrapper = Protocols(4)
+        
+        /// VAST 2.0 Wrapper
+        @objc
+        public static let VAST_2_0_Wrapper = Protocols(5)
+        
+        /// VAST 3.0 Wrapper
+        @objc
+        public static let VAST_3_0_Wrapper = Protocols(6)
+        
+        /// VAST 4.0
+        @objc
+        public static let VAST_4_0 = Protocols(7)
+        
+        /// VAST 4.0 Wrapper
+        @objc
+        public static let VAST_4_0_Wrapper = Protocols(8)
+        
+        /// DAAST 1.0
+        @objc
+        public static let DAAST_1_0 = Protocols(9)
+        
+        /// DAAST 1.0 Wrapper
+        @objc
+        public static let DAAST_1_0_WRAPPER = Protocols(10)
+        
     }
-}
-/**
- # OpenRTB - API Frameworks #
- ```
- | Value | Description |
- |-------|-------------|
- | 1     | VPAID 1.0   |
- | 2     | VPAID 2.0   |
- | 3     | MRAID-1     |
- | 4     | ORMMA       |
- | 5     | MRAID-2     |
- | 6     | MRAID-3     |
- ```
- */
-@objc(PBApi)
-public class Api: SingleContainerInt {
-    
-    /// VPAID 1.0
-    @objc
-    public static let VPAID_1 = Api(1)
-    
-    /// VPAID 2.0
-    @objc
-    public static let VPAID_2 = Api(2)
-    
-    /// MRAID-1
-    @objc
-    public static let MRAID_1 = Api(3)
-    
-    /// ORMMA
-    @objc
-    public static let ORMMA = Api(4)
-    
-    /// MRAID-2
-    @objc
-    public static let MARAID_2 = Api(5)
-    
-    /// MRAID-3
-    @objc
-    public static let MARAID_3 = Api(6)
-}
 
-/**
-# OpenRTB - Playback Methods #
-```
-| Value | Description                                              |
-|-------|----------------------------------------------------------|
-| 1     | Initiates on Page Load with Sound On                     |
-| 2     | Initiates on Page Load with Sound Off by Default         |
-| 3     | Initiates on Click with Sound On                         |
-| 4     | Initiates on Mouse-Over with Sound On                    |
-| 5     | Initiates on Entering Viewport with Sound On             |
-| 6     | Initiates on Entering Viewport with Sound Off by Default |
-```
-*/
-@objc(PBPlaybackMethod)
-public class PlaybackMethod: SingleContainerInt {
+    /**
+    # OpenRTB - Start Delay #
+    ```
+    | Value | Description                                      |
+    |-------|--------------------------------------------------|
+    | > 0   | Mid-Roll (value indicates start delay in second) |
+    | 0     | Pre-Roll                                         |
+    | -1    | Generic Mid-Roll                                 |
+    | -2    | Generic Post-Roll                                |
+    ```
+    */
+    @objc(PBStartDelay)
+    public class StartDelay: SingleContainerInt {
+        
+        /// Pre-Roll
+        @objc
+        public static let PreRoll = StartDelay(0)
+        
+        /// Generic Mid-Roll
+        @objc
+        public static let GenericMidRoll = StartDelay(-1)
+        
+        /// Generic Post-Roll
+        @objc
+        public static let GenericPostRoll = StartDelay(-2)
+        
+    }
 
-    /// Initiates on Page Load with Sound On
-    @objc
-    public static let AutoPlaySoundOn = PlaybackMethod(1)
-    
-    /// Initiates on Page Load with Sound Off by Default
-    @objc
-    public static let AutoPlaySoundOff = PlaybackMethod(2)
-    
-    /// Initiates on Click with Sound On
-    @objc
-    public static let ClickToPlay = PlaybackMethod(3)
-    
-    /// Initiates on Mouse-Over with Sound On
-    @objc
-    public static let MouseOver = PlaybackMethod(4)
-    
-    /// Initiates on Entering Viewport with Sound On
-    @objc
-    public static let EnterSoundOn = PlaybackMethod(5)
-    
-    /// Initiates on Entering Viewport with Sound Off by Default
-    @objc
-    public static let EnterSoundOff = PlaybackMethod(6)
-
-}
-
-/**
-# OpenRTB - Protocols #
-```
-| Value | Description       |
-|-------|-------------------|
-| 1     | VAST 1.0          |
-| 2     | VAST 2.0          |
-| 3     | VAST 3.0          |
-| 4     | VAST 1.0 Wrapper  |
-| 5     | VAST 2.0 Wrapper  |
-| 6     | VAST 3.0 Wrapper  |
-| 7     | VAST 4.0          |
-| 8     | VAST 4.0 Wrapper  |
-| 9     | DAAST 1.0         |
-| 10    | DAAST 1.0 Wrapper |
-```
-*/
-@objc(PBProtocols)
-public class Protocols: SingleContainerInt {
-    
-    /// VAST 1.0
-    @objc
-    public static let VAST_1_0 = Protocols(1)
-    
-    /// VAST 2.0
-    @objc
-    public static let VAST_2_0 = Protocols(2)
-    
-    /// VAST 3.0
-    @objc
-    public static let VAST_3_0 = Protocols(3)
-    
-    /// VAST 1.0 Wrapper
-    @objc
-    public static let VAST_1_0_Wrapper = Protocols(4)
-    
-    /// VAST 2.0 Wrapper
-    @objc
-    public static let VAST_2_0_Wrapper = Protocols(5)
-    
-    /// VAST 3.0 Wrapper
-    @objc
-    public static let VAST_3_0_Wrapper = Protocols(6)
-    
-    /// VAST 4.0
-    @objc
-    public static let VAST_4_0 = Protocols(7)
-    
-    /// VAST 4.0 Wrapper
-    @objc
-    public static let VAST_4_0_Wrapper = Protocols(8)
-    
-    /// DAAST 1.0
-    @objc
-    public static let DAAST_1_0 = Protocols(9)
-    
-    /// DAAST 1.0 Wrapper
-    @objc
-    public static let DAAST_1_0_WRAPPER = Protocols(10)
-    
-}
-
-/**
-# OpenRTB - Start Delay #
-```
-| Value | Description                                      |
-|-------|--------------------------------------------------|
-| > 0   | Mid-Roll (value indicates start delay in second) |
-| 0     | Pre-Roll                                         |
-| -1    | Generic Mid-Roll                                 |
-| -2    | Generic Post-Roll                                |
-```
-*/
-@objc(PBStartDelay)
-public class StartDelay: SingleContainerInt {
-    
-    /// Pre-Roll
-    @objc
-    public static let PreRoll = StartDelay(0)
-    
-    /// Generic Mid-Roll
-    @objc
-    public static let GenericMidRoll = StartDelay(-1)
-    
-    /// Generic Post-Roll
-    @objc
-    public static let GenericPostRoll = StartDelay(-2)
-    
-}
-
-/**
-# OpenRTB - Video Placement Types #
-```
-| Value | Description                  |
-|-------|------------------------------|
-| 1     | In-Stream                    |
-| 2     | In-Banner                    |
-| 3     | In-Article                   |
-| 4     | In-Feed                      |
-| 5     | Interstitial/Slider/Floating |
-```
-*/
-@objc(PBPlacement)
-public class Placement: SingleContainerInt {
-    
-    /// In-Stream
-    @objc
-    public static let InStream = Placement(1)
-    
-    /// In-Banner
-    @objc
-    public static let InBanner = Placement(2)
-    
-    /// In-Article
-    @objc
-    public static let InArticle = Placement(3)
-    
-    /// In-Feed
-    @objc
-    public static let InFeed = Placement(4)
-    
-    /// Interstitial
-    @objc
-    public static let Interstitial = Placement(5)
-    
-    /// Slider
-    @objc
-    public static let Slider = Placement(5)
-    
-    /// Floating
-    @objc
-    public static let Floating = Placement(5)
-    
+    /**
+    # OpenRTB - Video Placement Types #
+    ```
+    | Value | Description                  |
+    |-------|------------------------------|
+    | 1     | In-Stream                    |
+    | 2     | In-Banner                    |
+    | 3     | In-Article                   |
+    | 4     | In-Feed                      |
+    | 5     | Interstitial/Slider/Floating |
+    ```
+    */
+    @objc(PBPlacement)
+    public class Placement: SingleContainerInt {
+        
+        /// In-Stream
+        @objc
+        public static let InStream = Placement(1)
+        
+        /// In-Banner
+        @objc
+        public static let InBanner = Placement(2)
+        
+        /// In-Article
+        @objc
+        public static let InArticle = Placement(3)
+        
+        /// In-Feed
+        @objc
+        public static let InFeed = Placement(4)
+        
+        /// Interstitial
+        @objc
+        public static let Interstitial = Placement(5)
+        
+        /// Slider
+        @objc
+        public static let Slider = Placement(5)
+        
+        /// Floating
+        @objc
+        public static let Floating = Placement(5)
+        
+    }
 }

--- a/Source/AdUnits/VideoAdUnit.swift
+++ b/Source/AdUnits/VideoAdUnit.swift
@@ -17,8 +17,14 @@ import Foundation
 
 public class VideoAdUnit: VideoBaseAdUnit {
 
-    let type: PlacementType
+    @available(iOS, deprecated)
+    var type: PlacementType?
 
+    public init(configId: String, size: CGSize) {
+        super.init(configId: configId, size: size)
+    }
+    
+    @available(iOS, deprecated, message: "Replaced by VideoAdUnit(String, int, int)")
     public init(configId: String, size: CGSize, type: PlacementType) {
         self.type = type
         super.init(configId: configId, size: size)
@@ -28,10 +34,16 @@ public class VideoAdUnit: VideoBaseAdUnit {
         super.adSizes += sizes
     }
 
+    @available(iOS, deprecated, message: "Replaced by Signals.Placement")
     @objc(PBVideoPlacementType)
     public enum PlacementType: Int {
+        @available(iOS, deprecated)
         case inBanner = 2
+        
+        @available(iOS, deprecated)
         case inArticle = 3
+        
+        @available(iOS, deprecated)
         case inFeed = 4
     }
 

--- a/Source/AdUnits/VideoBaseAdUnit.swift
+++ b/Source/AdUnits/VideoBaseAdUnit.swift
@@ -26,33 +26,24 @@ public class VideoBaseAdUnit: AdUnit {
     @objc(PBVideoAdUnitParameters)
     public class Parameters: NSObject {
         
-        /**
-        List of supported API frameworks for this impression. If an API is not explicitly listed, it is assumed not to be supported.
-        */
+        /// List of supported API frameworks for this impression. If an API is not explicitly listed, it is assumed not to be supported.
         @objc
         public var api: [Api]?
 
-        /**
-        Maximum bit rate in Kbps.
-        */
+        /// Maximum bit rate in Kbps.
         @objc
         public var maxBitrate: SingleContainerInt?
         
-        /**
-        Maximum bit rate in Kbps.
-        */
+        /// Maximum bit rate in Kbps.
         @objc
         public var minBitrate: SingleContainerInt?
         
-        /**
-        Maximum video ad duration in seconds.
-        */
+        /// Maximum video ad duration in seconds.
         @objc
         public var maxDuration: SingleContainerInt?
         
-        /**
-        Minimum video ad duration in seconds.
-        */
+
+        /// Minimum video ad duration in seconds.
         @objc
         public var minDuration: SingleContainerInt?
         
@@ -66,23 +57,21 @@ public class VideoBaseAdUnit: AdUnit {
         @objc
         public var mimes: [String]?
         
-        /**
-        Allowed playback methods. If none specified, assume all are allowed.
-        */
+        /// Allowed playback methods. If none specified, assume all are allowed.
         @objc
         public var playbackMethod: [PlaybackMethod]?
         
-        /**
-        Array of supported video bid response protocols.
-        */
+        /// Array of supported video bid response protocols.
         @objc
         public var protocols: [Protocols]?
         
-        /**
-        Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements.
-        */
+        /// Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements.
         @objc
         public var startDelay: StartDelay?
+        
+        /// Placement type for the impression.
+        @objc
+        public var placement: Placement?
         
     }
 }

--- a/Source/AdUnits/VideoBaseAdUnit.swift
+++ b/Source/AdUnits/VideoBaseAdUnit.swift
@@ -28,24 +28,24 @@ public class VideoBaseAdUnit: AdUnit {
         
         /// List of supported API frameworks for this impression. If an API is not explicitly listed, it is assumed not to be supported.
         @objc
-        public var api: [Api]?
+        public var api: [Signals.Api]?
 
         /// Maximum bit rate in Kbps.
         @objc
-        public var maxBitrate: SingleContainerInt?
+        public var maxBitrate: Signals.SingleContainerInt?
         
         /// Maximum bit rate in Kbps.
         @objc
-        public var minBitrate: SingleContainerInt?
+        public var minBitrate: Signals.SingleContainerInt?
         
         /// Maximum video ad duration in seconds.
         @objc
-        public var maxDuration: SingleContainerInt?
+        public var maxDuration: Signals.SingleContainerInt?
         
 
         /// Minimum video ad duration in seconds.
         @objc
-        public var minDuration: SingleContainerInt?
+        public var minDuration: Signals.SingleContainerInt?
         
         /**
         Content MIME types supported
@@ -59,19 +59,19 @@ public class VideoBaseAdUnit: AdUnit {
         
         /// Allowed playback methods. If none specified, assume all are allowed.
         @objc
-        public var playbackMethod: [PlaybackMethod]?
+        public var playbackMethod: [Signals.PlaybackMethod]?
         
         /// Array of supported video bid response protocols.
         @objc
-        public var protocols: [Protocols]?
+        public var protocols: [Signals.Protocols]?
         
         /// Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements.
         @objc
-        public var startDelay: StartDelay?
+        public var startDelay: Signals.StartDelay?
         
         /// Placement type for the impression.
         @objc
-        public var placement: Placement?
+        public var placement: Signals.Placement?
         
     }
 }

--- a/Source/CollectionExtension.swift
+++ b/Source/CollectionExtension.swift
@@ -132,7 +132,7 @@ extension Dictionary where Key == String, Value == String {
     }
 }
 
-extension Array where Element: SingleContainerInt {
+extension Array where Element: Signals.SingleContainerInt {
     func toIntArray() -> [Int] {
         
         var result: [Int] = []

--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -194,6 +194,8 @@ class RequestBuilder: NSObject {
 
             var video: [AnyHashable: Any] = [:]
             
+            var placementValue: Int?
+            
             if let parameters = adUnit.parameters {
                 video["api"] = parameters.api?.toIntArray()
                 video["maxbitrate"] = parameters.maxBitrate?.value
@@ -204,25 +206,21 @@ class RequestBuilder: NSObject {
                 video["playbackmethod"] = parameters.playbackMethod?.toIntArray()
                 video["protocols"] = parameters.protocols?.toIntArray()
                 video["startdelay"] = parameters.startDelay?.value
+                
+                placementValue = parameters.placement?.value
             }
             
             let adSize = adUnit.adSizes[0]
             video["w"] = adSize.width
             video["h"] = adSize.height
             
-            let placement: Int?
-
-            switch adUnit {
-            case let videoAdUnit as VideoAdUnit:
-                placement = videoAdUnit.type.rawValue
-            case is VideoInterstitialAdUnit:
-                placement = 5
-            case is RewardedVideoAdUnit:
-                placement = 5
-            default: placement = nil
+            if (adUnit is VideoInterstitialAdUnit || adUnit is RewardedVideoAdUnit) {
+                if (placementValue == nil) {
+                    placementValue = 5
+                }
             }
 
-            video["placement"] = placement
+            video["placement"] = placementValue
 
             video["linearity"] = 1
             

--- a/Tests/AdUnitTests/AdUnitSuccessorObjCTests.m
+++ b/Tests/AdUnitTests/AdUnitSuccessorObjCTests.m
@@ -64,6 +64,12 @@ NSString * const configId = @"1001-1";
 //MARK: - VideoAdUnit
 - (void)testVideoAdUnitCreation {
     //when
+    AdUnit *adunit = [[VideoAdUnit alloc] initWithConfigId:configId size:CGSizeMake(300, 250)];
+    XCTAssertNotNil(adunit);
+}
+
+- (void)testVideoAdUnitCreationDeprecated {
+    //when
     AdUnit *adunit = [[VideoAdUnit alloc] initWithConfigId:configId size:CGSizeMake(300, 250) type:PBVideoPlacementTypeInBanner];
     XCTAssertNotNil(adunit);
 }

--- a/Tests/AdUnitTests/AdUnitSuccessorTests.swift
+++ b/Tests/AdUnitTests/AdUnitSuccessorTests.swift
@@ -60,6 +60,14 @@ class AdUnitSuccessorTests: XCTestCase {
     //MARK: - VideoAdUnit
     func testVideoAdUnitCreation() {
         //when
+        let adUnit = VideoAdUnit(configId: Constants.configID1, size: CGSize(width: Constants.width1, height: Constants.height1))
+        
+        //then
+        checkDefault(adUnit: adUnit)
+    }
+    
+    func testVideoAdUnitCreationDeprecated() {
+        //when
         let adUnit = VideoAdUnit(configId: Constants.configID1, size: CGSize(width: Constants.width1, height: Constants.height1), type: .inBanner)
         
         //then
@@ -90,7 +98,7 @@ class AdUnitSuccessorTests: XCTestCase {
     func testVideoParametersCreation() {
         
         //given
-        let videoAdUnit = VideoAdUnit(configId: Constants.configID1, size: CGSize(width: Constants.width2, height: Constants.height2), type: .inBanner)
+        let videoAdUnit = VideoAdUnit(configId: Constants.configID1, size: CGSize(width: Constants.width2, height: Constants.height2))
         let videoInterstitialAdUnit = VideoInterstitialAdUnit(configId: Constants.configID1)
         let rewardedVideoAdUnit = RewardedVideoAdUnit(configId: Constants.configID1)
         

--- a/Tests/AdUnitTests/AdUnitSuccessorTests.swift
+++ b/Tests/AdUnitTests/AdUnitSuccessorTests.swift
@@ -120,15 +120,15 @@ class AdUnitSuccessorTests: XCTestCase {
     private func checkVideoParametersHelper(_ videoBaseAdUnit: VideoBaseAdUnit) {
         
         let parameters = VideoAdUnit.Parameters()
-        parameters.api = [Api.VPAID_1, Api.VPAID_2]
+        parameters.api = [Signals.Api.VPAID_1, Signals.Api.VPAID_2]
         parameters.maxBitrate = 1500
         parameters.minBitrate = 300
         parameters.maxDuration = 30
         parameters.minDuration = 5
         parameters.mimes = ["video/x-flv", "video/mp4"]
-        parameters.playbackMethod = [PlaybackMethod.AutoPlaySoundOn, PlaybackMethod.ClickToPlay]
-        parameters.protocols = [Protocols.VAST_2_0, Protocols.VAST_3_0]
-        parameters.startDelay = StartDelay.PreRoll
+        parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOn, Signals.PlaybackMethod.ClickToPlay]
+        parameters.protocols = [Signals.Protocols.VAST_2_0, Signals.Protocols.VAST_3_0]
+        parameters.startDelay = Signals.StartDelay.PreRoll
         
         videoBaseAdUnit.parameters = parameters;
         

--- a/Tests/AdUnitTests/VideoAdUnitObjCTests.m
+++ b/Tests/AdUnitTests/VideoAdUnitObjCTests.m
@@ -30,7 +30,7 @@ limitations under the License.
 - (void) testVideoParametersCreation {
     
     //given
-    VideoAdUnit *videoAdUnit = [[VideoAdUnit alloc] initWithConfigId:@"6ace8c7d-88c0-4623-8117-75bc3f0a2e45" size:CGSizeMake(300, 250) type: PBVideoPlacementTypeInBanner];
+    VideoAdUnit *videoAdUnit = [[VideoAdUnit alloc] initWithConfigId:@"6ace8c7d-88c0-4623-8117-75bc3f0a2e45" size:CGSizeMake(300, 250)];
     VideoInterstitialAdUnit *videoInterstitialAdUnit = [[VideoInterstitialAdUnit alloc] initWithConfigId:@"6ace8c7d-88c0-4623-8117-75bc3f0a2e45"];
     RewardedVideoAdUnit *rewardedVideoAdUnit = [[RewardedVideoAdUnit alloc] initWithConfigId:@"6ace8c7d-88c0-4623-8117-75bc3f0a2e45"];
 

--- a/Tests/FetchingLogictests/RequestBuilderTests.swift
+++ b/Tests/FetchingLogictests/RequestBuilderTests.swift
@@ -1179,16 +1179,16 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
 
         let parameters = VideoBaseAdUnit.Parameters()
 
-        parameters.api = [Api.VPAID_1, Api.VPAID_2]
+        parameters.api = [Signals.Api.VPAID_1, Signals.Api.VPAID_2]
         parameters.maxBitrate = 1500
         parameters.minBitrate = 300
         parameters.maxDuration = 30
         parameters.minDuration = 5
         parameters.mimes = ["video/x-flv", "video/mp4"]
-        parameters.playbackMethod = [PlaybackMethod.AutoPlaySoundOn, PlaybackMethod.ClickToPlay]
-        parameters.protocols = [Protocols.VAST_2_0, Protocols.VAST_3_0]
-        parameters.startDelay = StartDelay.PreRoll
-        parameters.placement = Placement.InBanner
+        parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOn, Signals.PlaybackMethod.ClickToPlay]
+        parameters.protocols = [Signals.Protocols.VAST_2_0, Signals.Protocols.VAST_3_0]
+        parameters.startDelay = Signals.StartDelay.PreRoll
+        parameters.placement = Signals.Placement.InBanner
 
         adUnit.parameters = parameters
 

--- a/Tests/FetchingLogictests/RequestBuilderTests.swift
+++ b/Tests/FetchingLogictests/RequestBuilderTests.swift
@@ -1055,7 +1055,7 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
     func testVideoAdUnit() throws {
         //given
         Prebid.shared.prebidServerAccountId = "12345"
-        let adUnit = VideoAdUnit(configId: Constants.configID1, size: CGSize(width: 300, height: 250), type: .inBanner)
+        let adUnit = VideoAdUnit(configId: Constants.configID1, size: CGSize(width: 300, height: 250))
 
         //when
         let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
@@ -1175,7 +1175,7 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
     func testVideoBaseAdUnit() throws {
         //given
         Prebid.shared.prebidServerAccountId = "12345"
-        let adUnit = VideoAdUnit(configId: Constants.configID1, size: CGSize(width: 300, height: 250), type: .inBanner)
+        let adUnit = VideoAdUnit(configId: Constants.configID1, size: CGSize(width: 300, height: 250))
 
         let parameters = VideoBaseAdUnit.Parameters()
 
@@ -1188,6 +1188,7 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         parameters.playbackMethod = [PlaybackMethod.AutoPlaySoundOn, PlaybackMethod.ClickToPlay]
         parameters.protocols = [Protocols.VAST_2_0, Protocols.VAST_3_0]
         parameters.startDelay = StartDelay.PreRoll
+        parameters.placement = Placement.InBanner
 
         adUnit.parameters = parameters
 
@@ -1206,7 +1207,8 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
             let mimes = video["mimes"] as? [String],
             let playbackMethod = video["playbackmethod"] as? [Int],
             let protocols = video["protocols"] as? [Int],
-            let startDelay = video["startdelay"] as? Int
+            let startDelay = video["startdelay"] as? Int,
+            let placement = video["placement"] as? Int
 
             else {
                 XCTFail("parsing fail")
@@ -1227,6 +1229,7 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         XCTAssertEqual(2, protocols.count)
         XCTAssert(protocols.contains(2) && protocols.contains(3))
         XCTAssertEqual(0, startDelay)
+        XCTAssertEqual(2, placement)
 
     }
 

--- a/Tests/UnitTests/CollectionExtensionTest.swift
+++ b/Tests/UnitTests/CollectionExtensionTest.swift
@@ -120,7 +120,7 @@ class CollectionExtensionTest: XCTestCase {
     
     func testSingleContainerIntToIntArray() {
         //given
-        let array: [SingleContainerInt] = [1, 2, 5]
+        let array: [Signals.SingleContainerInt] = [1, 2, 5]
         
         //when
         let intArray = array.toIntArray()


### PR DESCRIPTION
**Git**
A tail of #292 

**Changes**
`Signals` class was added as outer class for Swift

``` Swift
//VPAID 1.0
let vpaid_1 = Signals.Api.VPAID_1
let vpaid_1 = Signals.Api(1)

//Page Load with Sound On
let autoPlaySoundOn = Signals.PlaybackMethod.AutoPlaySoundOn
let autoPlaySoundOn = Signals.PlaybackMethod(1)

//VAST 1.0
let vast_1 = Signals.Protocols.VAST_1_0
let vast_1 = Signals.Protocols(1)

//Pre-Roll
let preRoll = Signals.StartDelay.PreRoll
let preRoll = Signals.StartDelay(0)
```

`Signals.Placement` class was added to replace `PlacementType`

**API**
There are two ways to create a `Signal` object:
1. Use predefined constants
2. Manually construct a new instance

``` Swift
//Interstitial
let interstitial = Signals.Placement.Interstitial;
let interstitial = Signals.Placement(5);
```

Example
``` Swift
let adUnit = VideoInterstitialAdUnit(configId: "1001-1")
let parameters = VideoAdUnit.Parameters()

parameters.placement = Signals.Placement.Interstitial;

adUnit.videoParameters = parameters
```

**Notes:**
If publisher does not set `placement` for `VideoInterstitialAdUnit` or `RewardedVideoAdUnit`, value `5` is used by default

**Deprecated**
``` Swift
//Enums
VideoAdUnit.PlacementType

//Constructors
VideoAdUnit(configId:, size:, type:)
```