### PR TITLE
PrebidSDK always uses SignificantLocationChanges

### DIFF
--- a/Source/Location.swift
+++ b/Source/Location.swift
@@ -37,7 +37,6 @@ class Location: NSObject, CLLocationManagerDelegate {
         locationManager.delegate = self
         locationManager.distanceFilter = kCLDistanceFilterNone
         locationManager.desiredAccuracy = kCLLocationAccuracyKilometer
-        locationManager.startMonitoringSignificantLocationChanges()
     }
 
     func startCapture () {


### PR DESCRIPTION
`SignificantLocationChanges()` was removed because of using `startUpdatingLocation`