### PR TITLE
Log prebid version instead of printing it

### DIFF
--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -269,10 +269,10 @@ class RequestBuilder: NSObject {
         //if installed from cocoapods & uses frameworks then use this
         if let version = Bundle(identifier: "org.cocoapods.PrebidMobile")?.infoDictionary?["CFBundleShortVersionString"] as? String {
             app["ver"] = version
-            print(version)
+            Log.info("Prebid version: \(version)")
         } else if let version = Bundle(identifier: "org.prebid.mobile")?.infoDictionary?["CFBundleShortVersionString"] as? String {
             app["ver"] = version
-            print(version)
+            Log.info("Prebid version: \(version)")
         }
         app["publisher"] = ["id": Prebid.shared.prebidServerAccountId ?? 0] as NSDictionary
 


### PR DESCRIPTION
Proposing that we log version of Prebid instead of printing it. This way we can control whether we want to see it in console or not. If you feel this is unnecessary information that is just hanging there by mistake, please consider to drop these two lines altogether.