### PR TITLE
`String index is out of bounds` for getPurposeConsent() was fixed

### DIFF
--- a/Source/Targeting.swift
+++ b/Source/Targeting.swift
@@ -220,7 +220,7 @@ import CoreLocation
     func getPurposeConsent(index: Int) -> Bool? {
 
         var purposeConsent: Bool? = nil
-        if let savedPurposeConsents = purposeConsents {
+        if let savedPurposeConsents = purposeConsents, index >= 0, index < savedPurposeConsents.count {
             let char = savedPurposeConsents[savedPurposeConsents.index(savedPurposeConsents.startIndex, offsetBy: index)]
 
             if char == "1" {

--- a/Tests/TargetingTests.swift
+++ b/Tests/TargetingTests.swift
@@ -322,6 +322,17 @@ class TargetingTests: XCTestCase {
         XCTAssertFalse(purpose2!)
         XCTAssertTrue(purpose3!)
     }
+    
+    func testGetPurposeConsentEmpty() throws {
+        //given
+        Targeting.shared.purposeConsents = ""
+
+        //when
+        let purpose1 = Targeting.shared.getPurposeConsent(index: 0)
+
+        //then
+        XCTAssertNil(purpose1)
+    }
 
     // MARK: - access control list (ext.prebid.data)
     func testAddBidderToAccessControlList() {


### PR DESCRIPTION
cause: 
```
Targeting.shared.purposeConsents = ""
```