### PR TITLE
Disallow cookies in HTTP when deviceAccessConsent=false

### DIFF
--- a/Source/RequestBuilder.swift
+++ b/Source/RequestBuilder.swift
@@ -59,6 +59,13 @@ class RequestBuilder: NSObject {
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         
+        let gdprApplies = Targeting.shared.subjectToGDPR
+        let deviceAccessConsent = Targeting.shared.getDeviceAccessConsent()
+        // HTTP cookies should not be allowed when we do not have deviceAccessConsent
+        if ((deviceAccessConsent == nil && (gdprApplies == nil || gdprApplies == true)) || deviceAccessConsent == false) {
+            request.httpShouldHandleCookies = false
+        }
+        
         let stringObject = String.init(data: requestBodyJSON, encoding: String.Encoding.utf8)
         Log.info("Prebid Request post body \(stringObject ?? "nil")")
         

--- a/Tests/FetchingLogictests/RequestBuilderTests.swift
+++ b/Tests/FetchingLogictests/RequestBuilderTests.swift
@@ -395,29 +395,29 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
      gdprApplies=true         (4)Yes, read IDFA       (5)No, don’t read IDFA           (6)No, don’t read IDFA
      gdprApplies=undefined    (7)Yes, read IDFA       (8)No, don’t read IDFA           (9)Yes, read IDFA
      */
-    func testPostDataIfaPermission() throws {
+    func testIsAllowedAccessDeviceData() throws {
         //(1)
-        try! postDataIfaHelper(gdprApplies: false, purposeConsents: "100000000000000000000000", hasIfa: true)
+        try! postDeviceDataHelper(gdprApplies: false, purposeConsents: "100000000000000000000000", expected: true)
         //(2)
-        try! postDataIfaHelper(gdprApplies: false, purposeConsents: "000000000000000000000000", hasIfa: false)
+        try! postDeviceDataHelper(gdprApplies: false, purposeConsents: "000000000000000000000000", expected: false)
         //(3)
-        try! postDataIfaHelper(gdprApplies: false, purposeConsents: nil, hasIfa: true)
+        try! postDeviceDataHelper(gdprApplies: false, purposeConsents: nil, expected: true)
         //(4)
-        try! postDataIfaHelper(gdprApplies: true, purposeConsents: "100000000000000000000000", hasIfa: true)
+        try! postDeviceDataHelper(gdprApplies: true, purposeConsents: "100000000000000000000000", expected: true)
         //(5)
-        try! postDataIfaHelper(gdprApplies: true, purposeConsents: "000000000000000000000000", hasIfa: false)
+        try! postDeviceDataHelper(gdprApplies: true, purposeConsents: "000000000000000000000000", expected: false)
         //(6)
-        try! postDataIfaHelper(gdprApplies: true, purposeConsents: nil, hasIfa: false)
+        try! postDeviceDataHelper(gdprApplies: true, purposeConsents: nil, expected: false)
         //(7)
-        try! postDataIfaHelper(gdprApplies: nil, purposeConsents: "100000000000000000000000", hasIfa: true)
+        try! postDeviceDataHelper(gdprApplies: nil, purposeConsents: "100000000000000000000000", expected: true)
         //(8)
-        try! postDataIfaHelper(gdprApplies: nil, purposeConsents: "000000000000000000000000", hasIfa: false)
+        try! postDeviceDataHelper(gdprApplies: nil, purposeConsents: "000000000000000000000000", expected: false)
         //(9)
-        try! postDataIfaHelper(gdprApplies: nil, purposeConsents: nil, hasIfa: true)
+        try! postDeviceDataHelper(gdprApplies: nil, purposeConsents: nil, expected: true)
 
     }
 
-    func postDataIfaHelper(gdprApplies: Bool?, purposeConsents:String?, hasIfa: Bool) throws {
+    func postDeviceDataHelper(gdprApplies: Bool?, purposeConsents:String?, expected: Bool) throws {
         //given
         let targeting = Targeting.shared
         targeting.subjectToGDPR = gdprApplies
@@ -440,7 +440,8 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         let ifa = regs["ifa"] as? String
 
         //then
-        XCTAssertEqual(hasIfa, ifa != nil)
+        XCTAssertEqual(expected, RequestBuilder.shared.isAllowedAccessDeviceData())
+        XCTAssertEqual(expected, ifa != nil)
     }
 
     //MARK: - COPPA


### PR DESCRIPTION
## Issue
If Prebid SDK doesnot have device access consent(as per GDPR/TCF2.0), then it should not be reading/writing cookies while making HTTP requests.


## Description of Fix
Check for deviceAccessConsent and disallow cookies in the request deviceAccessConsent=false. 
Similar check already exists in Android. This is just a mirror of what is already there in Prebid Android
