### PR TITLE
Remove usage of deprecated UIWebView

### DIFF
--- a/PrebidMobile/AdUnits/Utils.swift
+++ b/PrebidMobile/AdUnits/Utils.swift
@@ -340,12 +340,6 @@ public class Utils: NSObject {
                 let html = value as! String
                 processHTMLContent(html)
             })
-        } else if webView is UIWebView {
-            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1){
-                let ui = webView as! UIWebView
-                let html = ui.stringByEvaluatingJavaScript(from: self.INNNER_HTML_SCRIPT)
-                processHTMLContent(html!)
-            }
         } else {
             processNextWebView(index)
         }


### PR DESCRIPTION
Using UIWebView in new apps prevents them from being accepted by the iOS App Store with this message:

ITMS-90809: Deprecated API Usage - New apps that use UIWebView are no longer accepted. Instead, use WKWebView for improved security and reliability. Learn more (https://developer.apple.com/documentation/uikit/uiwebview).