### PR TITLE
Pass app:content:url property into bid request

### DIFF
--- a/PrebidMobile/AdUnits/AdUnit.swift
+++ b/PrebidMobile/AdUnits/AdUnit.swift
@@ -280,15 +280,15 @@ import ObjectiveC.runtime
     func getAppContent() -> ContentObject? {
         return self.appContent
     }
-    
-    /// Describes an [OpenRTB](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) app: content object
-    
-    @objc(PBAdUnitContentObject)
-    public class ContentObject: NSObject {
-        
-        @objc
-        public var url: String?
-        
-    }
 
+}
+
+/// Describes an [OpenRTB](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) app: content object
+
+@objc(PBAdUnitContentObject)
+public class ContentObject: NSObject {
+    
+    @objc
+    public var url: String?
+    
 }

--- a/PrebidMobile/AdUnits/AdUnit.swift
+++ b/PrebidMobile/AdUnits/AdUnit.swift
@@ -44,6 +44,8 @@ import ObjectiveC.runtime
 
     //notification flag set to determine if delegate call needs to be made after timeout delegate is sent
     var timeOutSignalSent: Bool! = false
+    
+    private var appContent: ContentObject?
 
     init(configId: String, size: CGSize?) {
         prebidConfigId = configId
@@ -269,6 +271,24 @@ import ObjectiveC.runtime
 
         dispatcher.stop()
         self.dispatcher = nil
+    }
+    
+    public func setAppContent(appContent: ContentObject) {
+        self.appContent = appContent
+    }
+    
+    func getAppContent() -> ContentObject? {
+        return self.appContent
+    }
+    
+    /// Describes an [OpenRTB](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) app: content object
+    
+    @objc(PBAdUnitContentObject)
+    public class ContentObject: NSObject {
+        
+        @objc
+        public var url: String?
+        
     }
 
 }

--- a/PrebidMobile/RequestBuilder.swift
+++ b/PrebidMobile/RequestBuilder.swift
@@ -78,7 +78,7 @@ class RequestBuilder: NSObject {
 
         requestDict["id"] = UUID().uuidString
         requestDict["source"] = openrtbSource()
-        requestDict["app"] = openrtbApp()
+        requestDict["app"] = openrtbApp(adUnit: adUnit)
         requestDict["device"] = openrtbDevice(adUnit: adUnit)
         requestDict["regs"] = openrtbRegs()
         requestDict["user"] = openrtbUser(adUnit: adUnit)
@@ -264,7 +264,7 @@ class RequestBuilder: NSObject {
 
     // OpenRTB 2.5 Object: App in section 3.2.14
 
-    func openrtbApp() -> [AnyHashable: Any]? {
+    func openrtbApp(adUnit: AdUnit?) -> [AnyHashable: Any]? {
         var app: [AnyHashable: Any] = [:]
 
         let itunesID: String? = Targeting.shared.itunesID
@@ -302,7 +302,11 @@ class RequestBuilder: NSObject {
         if let domain = Targeting.shared.domain, !domain.isEmpty {
             app["domain"] = domain
         }
-
+        
+        if let appContent = adUnit?.getAppContent(), let url = appContent.url, !url.isEmpty {
+            app["content"] = ["url": url]
+        }
+        
         return app
     }
 

--- a/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
+++ b/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
@@ -1514,6 +1514,30 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         //then
         XCTAssertEqual("/1111111/homepage/med-rect-2", adslot)
     }
+    
+    func testOpenRtbAppObjectWithContentUrl() throws {
+        //given
+        let adUnit = BannerAdUnit(configId: Constants.configID1, size: CGSize(width: 300, height: 250))
+        let expectedUrl = "https://corresponding.section.publishers.website"
+        
+        let appContent = ContentObject()
+        appContent.url = expectedUrl
+        
+        adUnit.setAppContent(appContent: appContent)
+        
+        //when
+        let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
+        
+        guard let app = jsonRequestBody["app"] as? [String: Any],
+              let content = app["content"] as? [String: Any],
+              let actualUrl = content["url"] as? String else {
+            XCTFail("parsing error")
+            return
+        }
+        
+        //then
+        XCTAssertEqual(expectedUrl, actualUrl)
+    }
 
     private func getPostDataHelper(adUnit: AdUnit) throws -> (urlRequest: URLRequest, jsonRequestBody: [AnyHashable: Any]) {
         var resultUrlRequest: URLRequest? = nil


### PR DESCRIPTION
This PR aims to provide more precise targeting information with bid request. When PBS asks for bids for an ad slot, bidders have very little information about the user. This is caused by latest developments where users choose to opt-out of sharing their IDFA and such.

We can at least supply bidders with some context, like what content the user is looking at when they see an ad. Google ad manager calls this technique content mapping: https://support.google.com/admanager/answer/11050896?hl=en

Publishers roughly map views in their apps to pages on their websites. Then the targeting information already collected for pages on publisher’s website can be used to better target ad slots that appear in the apps. For this to work bidders needs to receive information which page would this ad slot appear on if this was a website and not an app. This page’s URL is set into ContentUrl property. Google’s ad manager has already implemented this property: https://developers.google.com/ad-manager/mobile-ads-sdk/ios/targeting#content_url

Our Prebid server is connected to a couple DSPs that are able to target their bids based on contentUrl. We identified an OpenRTB property that could carry this data. See Bid request -> App -> Content -> Url in https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf

Unfortunately we could not find a way to pass this property to the PBS using the SDK. This PR is an attempt to fix it. We would like to be able to pass this from the SDK because it would allow to re-use the same ad slot on different views with different content within an app.