### PR TITLE
Add cases for Rendering into Swift and ObjctiveC Demo Aps

### DIFF
--- a/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
+++ b/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
@@ -18,6 +18,7 @@ import GoogleMobileAds
 
 import PrebidMobile
 
+@objcMembers
 public class GAMBannerEventHandler :
     NSObject,
     BannerEventHandler,

--- a/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMInterstitialEventHandler.swift
+++ b/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMInterstitialEventHandler.swift
@@ -18,6 +18,7 @@ import GoogleMobileAds
 
 import PrebidMobile
 
+@objcMembers
 public class GAMInterstitialEventHandler :
     NSObject,
     InterstitialEventHandlerProtocol,

--- a/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMRewardedEventHandler.swift
+++ b/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMRewardedEventHandler.swift
@@ -18,6 +18,7 @@ import GoogleMobileAds
 
 import PrebidMobile
 
+@objcMembers
 public class GAMRewardedAdEventHandler :
     NSObject,
     RewardedEventHandlerProtocol,

--- a/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
+++ b/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5BA4CF6F273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5BA4CF70273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; };
 		5BA4CF71273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5BD798952742483700CE9385 /* RenderingInterstitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */; };
 		5BD98F0A273EB4190030ACC3 /* RenderingBannerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */; };
 		5BD98F0C273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */; };
 		5BD98F0D273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -150,6 +151,8 @@
 		55EA1793258A4B187A300E8E /* Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig"; path = "Target Support Files/Pods-PrebidDemoSwift-PrebidDemoSwiftTests/Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig"; sourceTree = "<group>"; };
 		5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileGAMEventHandlers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileMoPubAdapters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BD798922742483700CE9385 /* RenderingInterstitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingInterstitialViewController.h; sourceTree = "<group>"; };
+		5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingInterstitialViewController.m; sourceTree = "<group>"; };
 		5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingBannerViewController.h; sourceTree = "<group>"; };
 		5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingBannerViewController.m; sourceTree = "<group>"; };
 		5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileGAMEventHandlers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -285,6 +288,8 @@
 		5BD98F07273EB4190030ACC3 /* RenderingVC */ = {
 			isa = PBXGroup;
 			children = (
+				5BD798922742483700CE9385 /* RenderingInterstitialViewController.h */,
+				5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */,
 				5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */,
 				5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */,
 				5BD98F11273EC47B0030ACC3 /* IntegrationKind.h */,
@@ -708,6 +713,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5BD798952742483700CE9385 /* RenderingInterstitialViewController.m in Sources */,
 				38018908255AC5560089CA84 /* NativeAdView.swift in Sources */,
 				FA12E4FD231EB99D00CAA05B /* ViewController.m in Sources */,
 				FA12E511231EBC8E00CAA05B /* PrebidNavigationController.m in Sources */,

--- a/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
+++ b/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		5BA4CF70273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; };
 		5BA4CF71273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5BD98F0A273EB4190030ACC3 /* RenderingBannerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */; };
+		5BD98F0C273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */; };
+		5BD98F0D273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5BD98F0F273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0E273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework */; };
+		5BD98F10273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0E273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6069716C25224655000EE732 /* InstreamVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6069716B25224655000EE732 /* InstreamVideoViewController.swift */; };
 		609C52C32395F17F001FA5BD /* NativeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609C52C22395F17F001FA5BD /* NativeViewController.swift */; };
 		7A5EF9716CD8081552A53A2C /* Pods_PrebidDemoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9062CC2EEBA1A7F525A4D3AA /* Pods_PrebidDemoSwift.framework */; };
@@ -107,7 +111,9 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				5BD98F0D273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */,
 				FA282EAC2327EC2800C9D477 /* PrebidMobile.framework in Embed Frameworks */,
+				5BD98F10273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -146,6 +152,8 @@
 		5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileMoPubAdapters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingBannerViewController.h; sourceTree = "<group>"; };
 		5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingBannerViewController.m; sourceTree = "<group>"; };
+		5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileGAMEventHandlers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BD98F0E273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileMoPubAdapters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CA527E4B4E05598C6D7B462 /* Pods-PrebidDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoTests.debug.xcconfig"; path = "Target Support Files/Pods-PrebidDemoTests/Pods-PrebidDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6069716B25224655000EE732 /* InstreamVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InstreamVideoViewController.swift; path = ../../../example/PrebidDemo/PrebidDemoSwift/InstreamVideoViewController.swift; sourceTree = "<group>"; };
 		609C52C22395F17F001FA5BD /* NativeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NativeViewController.swift; path = ../../../example/PrebidDemo/PrebidDemoSwift/NativeViewController.swift; sourceTree = "<group>"; };
@@ -217,8 +225,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5BD98F0F273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework in Frameworks */,
 				FA282EAB2327EC2800C9D477 /* PrebidMobile.framework in Frameworks */,
 				9292C6B7506986A7F501E561 /* Pods_PrebidDemoObjectiveC.framework in Frameworks */,
+				5BD98F0C273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -283,6 +293,8 @@
 		99D7F73A394177471348CDD1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5BD98F0E273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework */,
+				5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */,
 				5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */,
 				5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */,
 				FAEE508F263075D700AD9966 /* XCPrebidMobile.xcframework */,

--- a/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
+++ b/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		5BA4CF70273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; };
 		5BA4CF71273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5BD798952742483700CE9385 /* RenderingInterstitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */; };
+		5BD7989827425B4900CE9385 /* IntegrationKindUtilites.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD7989727425B4900CE9385 /* IntegrationKindUtilites.m */; };
 		5BD98F0A273EB4190030ACC3 /* RenderingBannerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */; };
 		5BD98F0C273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */; };
 		5BD98F0D273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -153,6 +154,8 @@
 		5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileMoPubAdapters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BD798922742483700CE9385 /* RenderingInterstitialViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingInterstitialViewController.h; sourceTree = "<group>"; };
 		5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingInterstitialViewController.m; sourceTree = "<group>"; };
+		5BD7989627425B4900CE9385 /* IntegrationKindUtilites.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntegrationKindUtilites.h; sourceTree = "<group>"; };
+		5BD7989727425B4900CE9385 /* IntegrationKindUtilites.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IntegrationKindUtilites.m; sourceTree = "<group>"; };
 		5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingBannerViewController.h; sourceTree = "<group>"; };
 		5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingBannerViewController.m; sourceTree = "<group>"; };
 		5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileGAMEventHandlers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -292,7 +295,6 @@
 				5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */,
 				5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */,
 				5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */,
-				5BD98F11273EC47B0030ACC3 /* IntegrationKind.h */,
 			);
 			path = RenderingVC;
 			sourceTree = "<group>";
@@ -380,6 +382,7 @@
 			isa = PBXGroup;
 			children = (
 				5BD98F07273EB4190030ACC3 /* RenderingVC */,
+				5BD98F11273EC47B0030ACC3 /* IntegrationKind.h */,
 				FA12E50E231EBC8E00CAA05B /* PrebidNavigationController.h */,
 				FA12E510231EBC8E00CAA05B /* PrebidNavigationController.m */,
 				FA12E4F8231EB99D00CAA05B /* AppDelegate.h */,
@@ -391,6 +394,8 @@
 				FA12E503231EB99E00CAA05B /* LaunchScreen.storyboard */,
 				FA12E506231EB99E00CAA05B /* Info.plist */,
 				FA12E507231EB99E00CAA05B /* main.m */,
+				5BD7989627425B4900CE9385 /* IntegrationKindUtilites.h */,
+				5BD7989727425B4900CE9385 /* IntegrationKindUtilites.m */,
 			);
 			path = PrebidDemoObjectiveC;
 			sourceTree = "<group>";
@@ -714,6 +719,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5BD798952742483700CE9385 /* RenderingInterstitialViewController.m in Sources */,
+				5BD7989827425B4900CE9385 /* IntegrationKindUtilites.m in Sources */,
 				38018908255AC5560089CA84 /* NativeAdView.swift in Sources */,
 				FA12E4FD231EB99D00CAA05B /* ViewController.m in Sources */,
 				FA12E511231EBC8E00CAA05B /* PrebidNavigationController.m in Sources */,

--- a/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
+++ b/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingBannerViewController.m; sourceTree = "<group>"; };
 		5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileGAMEventHandlers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BD98F0E273EC0D60030ACC3 /* PrebidMobileMoPubAdapters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileMoPubAdapters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BD98F11273EC47B0030ACC3 /* IntegrationKind.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntegrationKind.h; sourceTree = "<group>"; };
 		5CA527E4B4E05598C6D7B462 /* Pods-PrebidDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoTests.debug.xcconfig"; path = "Target Support Files/Pods-PrebidDemoTests/Pods-PrebidDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6069716B25224655000EE732 /* InstreamVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InstreamVideoViewController.swift; path = ../../../example/PrebidDemo/PrebidDemoSwift/InstreamVideoViewController.swift; sourceTree = "<group>"; };
 		609C52C22395F17F001FA5BD /* NativeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NativeViewController.swift; path = ../../../example/PrebidDemo/PrebidDemoSwift/NativeViewController.swift; sourceTree = "<group>"; };
@@ -286,6 +287,7 @@
 			children = (
 				5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */,
 				5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */,
+				5BD98F11273EC47B0030ACC3 /* IntegrationKind.h */,
 			);
 			path = RenderingVC;
 			sourceTree = "<group>";

--- a/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
+++ b/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		383E9CA525712879006FA6F4 /* NativeAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38018905255AC5560089CA84 /* NativeAdView.swift */; };
 		383E9CA62571287C006FA6F4 /* NativeAdView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 38018906255AC5560089CA84 /* NativeAdView.xib */; };
 		38450A6225514EA6000DCF6D /* NativeInAppViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38450A6125514EA6000DCF6D /* NativeInAppViewController.swift */; };
+		5BA4CF6E273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */; };
+		5BA4CF6F273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5BA4CF70273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; };
+		5BA4CF71273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6069716C25224655000EE732 /* InstreamVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6069716B25224655000EE732 /* InstreamVideoViewController.swift */; };
 		609C52C32395F17F001FA5BD /* NativeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609C52C22395F17F001FA5BD /* NativeViewController.swift */; };
 		7A5EF9716CD8081552A53A2C /* Pods_PrebidDemoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9062CC2EEBA1A7F525A4D3AA /* Pods_PrebidDemoSwift.framework */; };
@@ -113,7 +117,9 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				5BA4CF6F273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */,
 				FAC9E217232800DB00113B04 /* PrebidMobile.framework in Embed Frameworks */,
+				5BA4CF71273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -135,6 +141,8 @@
 		3C3DD5560D8F19EE9F2158E7 /* Pods-PrebidDemoSwift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoSwift.debug.xcconfig"; path = "Target Support Files/Pods-PrebidDemoSwift/Pods-PrebidDemoSwift.debug.xcconfig"; sourceTree = "<group>"; };
 		5197A13C51AEAF0782B64F40 /* Pods-PrebidDemoPodCoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoPodCoreTests.debug.xcconfig"; path = "Target Support Files/Pods-PrebidDemoPodCoreTests/Pods-PrebidDemoPodCoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		55EA1793258A4B187A300E8E /* Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig"; path = "Target Support Files/Pods-PrebidDemoSwift-PrebidDemoSwiftTests/Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig"; sourceTree = "<group>"; };
+		5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileGAMEventHandlers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileMoPubAdapters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CA527E4B4E05598C6D7B462 /* Pods-PrebidDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoTests.debug.xcconfig"; path = "Target Support Files/Pods-PrebidDemoTests/Pods-PrebidDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6069716B25224655000EE732 /* InstreamVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InstreamVideoViewController.swift; path = ../../../example/PrebidDemo/PrebidDemoSwift/InstreamVideoViewController.swift; sourceTree = "<group>"; };
 		609C52C22395F17F001FA5BD /* NativeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NativeViewController.swift; path = ../../../example/PrebidDemo/PrebidDemoSwift/NativeViewController.swift; sourceTree = "<group>"; };
@@ -187,8 +195,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5BA4CF70273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Frameworks */,
 				FAC9E216232800DB00113B04 /* PrebidMobile.framework in Frameworks */,
 				7A5EF9716CD8081552A53A2C /* Pods_PrebidDemoSwift.framework in Frameworks */,
+				5BA4CF6E273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -261,6 +271,8 @@
 		99D7F73A394177471348CDD1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */,
+				5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */,
 				FAEE508F263075D700AD9966 /* XCPrebidMobile.xcframework */,
 				022C426932D62F4F7C3973DB /* Pods_PrebidDemoObjectiveC.framework */,
 				9062CC2EEBA1A7F525A4D3AA /* Pods_PrebidDemoSwift.framework */,

--- a/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
+++ b/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		5BA4CF6F273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5BA4CF70273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; };
 		5BA4CF71273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5BD98F0A273EB4190030ACC3 /* RenderingBannerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */; };
 		6069716C25224655000EE732 /* InstreamVideoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6069716B25224655000EE732 /* InstreamVideoViewController.swift */; };
 		609C52C32395F17F001FA5BD /* NativeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 609C52C22395F17F001FA5BD /* NativeViewController.swift */; };
 		7A5EF9716CD8081552A53A2C /* Pods_PrebidDemoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9062CC2EEBA1A7F525A4D3AA /* Pods_PrebidDemoSwift.framework */; };
@@ -143,6 +144,8 @@
 		55EA1793258A4B187A300E8E /* Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig"; path = "Target Support Files/Pods-PrebidDemoSwift-PrebidDemoSwiftTests/Pods-PrebidDemoSwift-PrebidDemoSwiftTests.release.xcconfig"; sourceTree = "<group>"; };
 		5BA4CF6C273AE27E00197C62 /* PrebidMobileGAMEventHandlers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileGAMEventHandlers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileMoPubAdapters.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingBannerViewController.h; sourceTree = "<group>"; };
+		5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingBannerViewController.m; sourceTree = "<group>"; };
 		5CA527E4B4E05598C6D7B462 /* Pods-PrebidDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PrebidDemoTests.debug.xcconfig"; path = "Target Support Files/Pods-PrebidDemoTests/Pods-PrebidDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		6069716B25224655000EE732 /* InstreamVideoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = InstreamVideoViewController.swift; path = ../../../example/PrebidDemo/PrebidDemoSwift/InstreamVideoViewController.swift; sourceTree = "<group>"; };
 		609C52C22395F17F001FA5BD /* NativeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NativeViewController.swift; path = ../../../example/PrebidDemo/PrebidDemoSwift/NativeViewController.swift; sourceTree = "<group>"; };
@@ -268,6 +271,15 @@
 			path = ../../Pods;
 			sourceTree = "<group>";
 		};
+		5BD98F07273EB4190030ACC3 /* RenderingVC */ = {
+			isa = PBXGroup;
+			children = (
+				5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */,
+				5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */,
+			);
+			path = RenderingVC;
+			sourceTree = "<group>";
+		};
 		99D7F73A394177471348CDD1 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -348,6 +360,7 @@
 		FA12E4F7231EB99D00CAA05B /* PrebidDemoObjectiveC */ = {
 			isa = PBXGroup;
 			children = (
+				5BD98F07273EB4190030ACC3 /* RenderingVC */,
 				FA12E50E231EBC8E00CAA05B /* PrebidNavigationController.h */,
 				FA12E510231EBC8E00CAA05B /* PrebidNavigationController.m */,
 				FA12E4F8231EB99D00CAA05B /* AppDelegate.h */,
@@ -686,6 +699,7 @@
 				FA12E511231EBC8E00CAA05B /* PrebidNavigationController.m in Sources */,
 				FA12E508231EB99E00CAA05B /* main.m in Sources */,
 				FA12E4FA231EB99D00CAA05B /* AppDelegate.m in Sources */,
+				5BD98F0A273EB4190030ACC3 /* RenderingBannerViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
+++ b/Example/PrebidDemo/PrebidDemo.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		5BA4CF71273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BA4CF6D273AE27E00197C62 /* PrebidMobileMoPubAdapters.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5BD798952742483700CE9385 /* RenderingInterstitialViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */; };
 		5BD7989827425B4900CE9385 /* IntegrationKindUtilites.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD7989727425B4900CE9385 /* IntegrationKindUtilites.m */; };
+		5BD7989B2742A9C500CE9385 /* RenderingRewardedViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD798992742A9C400CE9385 /* RenderingRewardedViewController.m */; };
 		5BD98F0A273EB4190030ACC3 /* RenderingBannerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */; };
 		5BD98F0C273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */; };
 		5BD98F0D273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -156,6 +157,8 @@
 		5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingInterstitialViewController.m; sourceTree = "<group>"; };
 		5BD7989627425B4900CE9385 /* IntegrationKindUtilites.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntegrationKindUtilites.h; sourceTree = "<group>"; };
 		5BD7989727425B4900CE9385 /* IntegrationKindUtilites.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IntegrationKindUtilites.m; sourceTree = "<group>"; };
+		5BD798992742A9C400CE9385 /* RenderingRewardedViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingRewardedViewController.m; sourceTree = "<group>"; };
+		5BD7989A2742A9C400CE9385 /* RenderingRewardedViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingRewardedViewController.h; sourceTree = "<group>"; };
 		5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RenderingBannerViewController.h; sourceTree = "<group>"; };
 		5BD98F09273EB4190030ACC3 /* RenderingBannerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RenderingBannerViewController.m; sourceTree = "<group>"; };
 		5BD98F0B273EC0D00030ACC3 /* PrebidMobileGAMEventHandlers.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = PrebidMobileGAMEventHandlers.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -291,6 +294,8 @@
 		5BD98F07273EB4190030ACC3 /* RenderingVC */ = {
 			isa = PBXGroup;
 			children = (
+				5BD7989A2742A9C400CE9385 /* RenderingRewardedViewController.h */,
+				5BD798992742A9C400CE9385 /* RenderingRewardedViewController.m */,
 				5BD798922742483700CE9385 /* RenderingInterstitialViewController.h */,
 				5BD798942742483700CE9385 /* RenderingInterstitialViewController.m */,
 				5BD98F08273EB4190030ACC3 /* RenderingBannerViewController.h */,
@@ -720,6 +725,7 @@
 			files = (
 				5BD798952742483700CE9385 /* RenderingInterstitialViewController.m in Sources */,
 				5BD7989827425B4900CE9385 /* IntegrationKindUtilites.m in Sources */,
+				5BD7989B2742A9C500CE9385 /* RenderingRewardedViewController.m in Sources */,
 				38018908255AC5560089CA84 /* NativeAdView.swift in Sources */,
 				FA12E4FD231EB99D00CAA05B /* ViewController.m in Sources */,
 				FA12E511231EBC8E00CAA05B /* PrebidNavigationController.m in Sources */,

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/Base.lproj/Main.storyboard
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/Base.lproj/Main.storyboard
@@ -129,6 +129,21 @@
             </objects>
             <point key="canvasLocation" x="-1898" y="-130"/>
         </scene>
+        <!--Rendering Interstitial View Controller-->
+        <scene sceneID="1Q0-XA-aHu">
+            <objects>
+                <viewController storyboardIdentifier="RenderingInterstitialVC" id="dMs-W8-gKd" customClass="RenderingInterstitialViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="oSk-YK-kI8">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="m1s-S1-JCL"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Wlx-FM-j3R" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-220" y="1261"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="systemBackgroundColor">

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/Base.lproj/Main.storyboard
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/Base.lproj/Main.storyboard
@@ -144,6 +144,21 @@
             </objects>
             <point key="canvasLocation" x="-220" y="1261"/>
         </scene>
+        <!--Rendering Rewarded View Controller-->
+        <scene sceneID="MGg-lk-ewg">
+            <objects>
+                <viewController storyboardIdentifier="RenderingRewardedVC" id="DLv-4v-qQI" customClass="RenderingRewardedViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="72k-Cq-SZA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="TyL-s5-hfa"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="oPL-ae-cDY" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-220" y="1964"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="systemBackgroundColor">

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/Base.lproj/Main.storyboard
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="J2c-DA-xgU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="J2c-DA-xgU">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -52,6 +52,38 @@
             </objects>
             <point key="canvasLocation" x="-223" y="-131"/>
         </scene>
+        <!--Rendering Banner View Controller-->
+        <scene sceneID="tQo-KI-sHN">
+            <objects>
+                <viewController storyboardIdentifier="RenderingBannerVC" id="sp3-fi-hDD" customClass="RenderingBannerViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Tf0-Oi-iYg">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qSs-V0-6w8" colorLabel="IBBuiltInLabel-Red">
+                                <rect key="frame" x="27.5" y="20" width="320" height="50"/>
+                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="320" id="n7b-gv-q3x"/>
+                                    <constraint firstAttribute="height" constant="50" id="qUs-k4-kH3"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="WZM-Se-Ivu"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="qSs-V0-6w8" firstAttribute="top" secondItem="WZM-Se-Ivu" secondAttribute="top" constant="20" id="KEB-ZO-XqF"/>
+                            <constraint firstItem="qSs-V0-6w8" firstAttribute="centerX" secondItem="Tf0-Oi-iYg" secondAttribute="centerX" id="o2K-gL-0K0"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="adView" destination="qSs-V0-6w8" id="kcq-gb-4ai"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="8bp-qK-7tw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-219" y="568"/>
+        </scene>
         <!--Prebid Demo-->
         <scene sceneID="kJN-vV-5x8">
             <objects>
@@ -62,7 +94,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" id="Im7-hr-d5n">
-                                <rect key="frame" x="0.0" y="28" width="375" height="43.5"/>
+                                <rect key="frame" x="0.0" y="44.5" width="375" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Im7-hr-d5n" id="FaX-Ec-ecT">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -101,6 +133,9 @@
     <resources>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372549019611" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/Info.plist
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -20,13 +25,6 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
-		<true/>
-	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -48,11 +46,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-
-    <key>GADIsAdManagerApp</key>
-    <true/>
-    <key>gad_preferred_webview</key>
-    <string>wkwebview</string>
-
+	<key>GADIsAdManagerApp</key>
+	<true/>
+	<key>gad_preferred_webview</key>
+	<string>wkwebview</string>
 </dict>
 </plist>

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/IntegrationKind.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/IntegrationKind.h
@@ -10,17 +10,25 @@
 #define IntegrationKind_h
 
 typedef NS_ENUM(NSUInteger, IntegrationKind) {
-    IntegrationKind_Undefined = 0,
+    IntegrationKind_OriginalGAM,
+    IntegrationKind_OriginalMoPub,
     
     IntegrationKind_InApp,
     IntegrationKind_RenderingGAM,
     IntegrationKind_RenderingMoPub
 };
 
-typedef NS_ENUM(NSUInteger, AdFormat) {
-    AdFormat_Display,
-    AdFormat_Video
+typedef NS_ENUM(NSUInteger, IntegrationAdFormat) {
+    IntegrationAdFormat_Banner,
+    
+    IntegrationAdFormat_Interstitial,
+    IntegrationAdFormat_InterstitialVideo,
+    
+    IntegrationAdFormat_NativeInApp,
+    
+    IntegrationAdFormat_Rewarded
 };
 
 
 #endif /* IntegrationKind_h */
+

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/IntegrationKindUtilites.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/IntegrationKindUtilites.h
@@ -1,0 +1,31 @@
+//
+//  IntegrationKindUtilites.h
+//  PrebidDemoObjectiveC
+//
+//  Created by Yuriy Velichko on 15.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "IntegrationKind.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface IntegrationKindUtilites : NSObject
+
++ (NSArray *)IntegrationKindAllCases;
++ (NSDictionary *)IntegrationKindDescr;
+
++ (NSArray *)IntegrationAdFormatAllCases;
++ (NSDictionary *)IntegrationAdFormatDescr;
+
++ (NSArray *)IntegrationAdFormatFor:(IntegrationKind) integrationKind;
+
++ (NSArray *)IntegrationAdFormatOriginal;
++ (NSArray *)IntegrationAdFormatRendering;
+
++ (BOOL)isRenderingIntegrationKind:(IntegrationKind) integrationKind;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/IntegrationKindUtilites.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/IntegrationKindUtilites.m
@@ -1,0 +1,86 @@
+//
+//  IntegrationKindUtilites.m
+//  PrebidDemoObjectiveC
+//
+//  Created by Yuriy Velichko on 15.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#import "IntegrationKindUtilites.h"
+#import "IntegrationKind.h"
+
+
+@implementation IntegrationKindUtilites
+
++ (NSArray *)IntegrationKindAllCases {
+    return @[
+        [NSNumber numberWithInteger:IntegrationKind_OriginalGAM],
+        [NSNumber numberWithInteger:IntegrationKind_OriginalMoPub],
+             
+        [NSNumber numberWithInteger:IntegrationKind_InApp],
+        [NSNumber numberWithInteger:IntegrationKind_RenderingGAM],
+        [NSNumber numberWithInteger:IntegrationKind_RenderingMoPub]
+    ];
+}
+
++ (NSDictionary *)IntegrationKindDescr {
+    return @{
+        [NSNumber numberWithInteger:IntegrationKind_OriginalGAM]        : @"Original GAM",
+        [NSNumber numberWithInteger:IntegrationKind_OriginalMoPub]      : @"Original MoPub",
+             
+        [NSNumber numberWithInteger:IntegrationKind_InApp]              : @"In-App",
+        [NSNumber numberWithInteger:IntegrationKind_RenderingGAM]       : @"Rendering GAM",
+        [NSNumber numberWithInteger:IntegrationKind_RenderingMoPub]     : @"Rendering MoPub"
+    };
+}
+
++ (NSArray *)IntegrationAdFormatAllCases {
+    return @[
+        [NSNumber numberWithInteger:IntegrationAdFormat_Banner],
+        [NSNumber numberWithInteger:IntegrationAdFormat_Interstitial],
+        [NSNumber numberWithInteger:IntegrationAdFormat_InterstitialVideo],
+        [NSNumber numberWithInteger:IntegrationAdFormat_Rewarded],
+        [NSNumber numberWithInteger:IntegrationAdFormat_NativeInApp]
+    ];
+}
+
++ (NSDictionary *)IntegrationAdFormatDescr {
+    return @{
+        [NSNumber numberWithInteger:IntegrationAdFormat_Banner]             : @"Banner",
+        [NSNumber numberWithInteger:IntegrationAdFormat_Interstitial]       : @"Interstitial",
+        [NSNumber numberWithInteger:IntegrationAdFormat_InterstitialVideo]  : @"Interstitial Video",
+        [NSNumber numberWithInteger:IntegrationAdFormat_Rewarded]           : @"Rewarded",
+        [NSNumber numberWithInteger:IntegrationAdFormat_NativeInApp]        : @"Native In-App"
+    };
+}
+
++ (NSArray *)IntegrationAdFormatFor:(IntegrationKind) integrationKind {
+    return [IntegrationKindUtilites isRenderingIntegrationKind:integrationKind] ?
+        [IntegrationKindUtilites IntegrationAdFormatRendering] :
+        [IntegrationKindUtilites IntegrationAdFormatOriginal];
+}
+
++ (NSArray *)IntegrationAdFormatOriginal {
+    return @[
+        [NSNumber numberWithInteger:IntegrationAdFormat_Banner],
+        [NSNumber numberWithInteger:IntegrationAdFormat_Interstitial],
+        [NSNumber numberWithInteger:IntegrationAdFormat_NativeInApp]
+    ];
+}
++ (NSArray *)IntegrationAdFormatRendering {
+    return @[
+        [NSNumber numberWithInteger:IntegrationAdFormat_Banner],
+        [NSNumber numberWithInteger:IntegrationAdFormat_Interstitial],
+        [NSNumber numberWithInteger:IntegrationAdFormat_InterstitialVideo],
+        [NSNumber numberWithInteger:IntegrationAdFormat_Rewarded],
+    ];
+}
+
++ (BOOL)isRenderingIntegrationKind:(IntegrationKind) integrationKind {
+    return
+        integrationKind == IntegrationKind_InApp ||
+        integrationKind == IntegrationKind_RenderingGAM ||
+        integrationKind == IntegrationKind_RenderingMoPub;
+}
+
+@end

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
@@ -18,6 +18,7 @@
 #import "RenderingBannerViewController.h"
 #import "RenderingInterstitialViewController.h"
 #import "IntegrationKindUtilites.h"
+#import "RenderingRewardedViewController.h"
 
 @interface PrebidNavigationController ()
 
@@ -80,48 +81,63 @@
         viewController.adUnit = (IntegrationAdFormat) [IntegrationKindUtilites.IntegrationAdFormatOriginal[indexPath.row] intValue];
         [self.navigationController pushViewController:viewController animated:YES];
     } else if (indexPath.section == IntegrationKind_InApp) {
-        if (indexPath.row == IntegrationAdFormat_Banner) {
+        IntegrationAdFormat integrationAdFormat = [IntegrationKindUtilites.IntegrationAdFormatRendering[indexPath.row] intValue];
+        if (integrationAdFormat == IntegrationAdFormat_Banner) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_InApp;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == IntegrationAdFormat_Interstitial) {
+        } else if (integrationAdFormat == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_InApp;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == IntegrationAdFormat_InterstitialVideo) {
+        } else if (integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_InApp;
             viewController.integrationAdFormat = IntegrationAdFormat_InterstitialVideo;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (integrationAdFormat == IntegrationAdFormat_Rewarded) {
+            RenderingRewardedViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingRewardedVC"];
+            viewController.integrationKind = IntegrationKind_InApp;
             [self.navigationController pushViewController:viewController animated:YES];
         }
     } else if (indexPath.section == IntegrationKind_RenderingGAM) {
-        if (indexPath.row == IntegrationAdFormat_Banner) {
+        IntegrationAdFormat integrationAdFormat = [IntegrationKindUtilites.IntegrationAdFormatRendering[indexPath.row] intValue];
+        if (integrationAdFormat == IntegrationAdFormat_Banner) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_RenderingGAM;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == IntegrationAdFormat_Interstitial) {
+        } else if (integrationAdFormat == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_RenderingGAM;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == IntegrationAdFormat_InterstitialVideo) {
+        } else if (integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_RenderingGAM;
             viewController.integrationAdFormat = IntegrationAdFormat_InterstitialVideo;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (integrationAdFormat == IntegrationAdFormat_Rewarded) {
+            RenderingRewardedViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingRewardedVC"];
+            viewController.integrationKind = IntegrationKind_RenderingGAM;
             [self.navigationController pushViewController:viewController animated:YES];
         }
     } else if (indexPath.section == IntegrationKind_RenderingMoPub) {
-        if (indexPath.row == IntegrationAdFormat_Banner) {
+        IntegrationAdFormat integrationAdFormat = [IntegrationKindUtilites.IntegrationAdFormatRendering[indexPath.row] intValue];
+        if (integrationAdFormat == IntegrationAdFormat_Banner) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_RenderingMoPub;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == IntegrationAdFormat_Interstitial) {
+        } else if (integrationAdFormat == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_RenderingMoPub;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == IntegrationAdFormat_InterstitialVideo) {
+        } else if (integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_RenderingMoPub;
             viewController.integrationAdFormat = IntegrationAdFormat_InterstitialVideo;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (integrationAdFormat == IntegrationAdFormat_Rewarded) {
+            RenderingRewardedViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingRewardedVC"];
+            viewController.integrationKind = IntegrationKind_RenderingMoPub;
             [self.navigationController pushViewController:viewController animated:YES];
         }
     }

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
@@ -15,6 +15,7 @@
 
 #import "PrebidNavigationController.h"
 #import "ViewController.h"
+#import "RenderingBannerViewController.h"
 
 @interface PrebidNavigationController ()
 
@@ -32,7 +33,7 @@
     
     self.title = @"Prebid Demo";
     
-    self.adServerList = @[@"DFP", @"MoPub", @"In-App"];
+    self.adServerList = @[@"DFP", @"MoPub", @"In-App", @"Rendering GAM", @"Rendering MoPub"];
     self.adUnitList = @[@"Banner", @"Interstitial", @"InAppNative"];
 }
 
@@ -70,9 +71,16 @@
         viewController.adUnit = [self.adUnitList objectAtIndex:indexPath.row];
         [self.navigationController pushViewController:viewController animated:YES];
     } else if (indexPath.section == 2) {
-        ViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
-        viewController.adServer = [self.adServerList objectAtIndex:indexPath.section];
-        viewController.adUnit = [self.adUnitList objectAtIndex:indexPath.row];
+        RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
+        viewController.integrationKind = IntegrationKind_InApp;
+        [self.navigationController pushViewController:viewController animated:YES];
+    } else if (indexPath.section == 3) {
+        RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
+        viewController.integrationKind = IntegrationKind_RenderingGAM;
+        [self.navigationController pushViewController:viewController animated:YES];
+    } else if (indexPath.section == 4) {
+        RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
+        viewController.integrationKind = IntegrationKind_RenderingMoPub;
         [self.navigationController pushViewController:viewController animated:YES];
     }
 }

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
@@ -16,6 +16,7 @@
 #import "PrebidNavigationController.h"
 #import "ViewController.h"
 #import "RenderingBannerViewController.h"
+#import "RenderingInterstitialViewController.h"
 
 @interface PrebidNavigationController ()
 
@@ -71,17 +72,35 @@
         viewController.adUnit = [self.adUnitList objectAtIndex:indexPath.row];
         [self.navigationController pushViewController:viewController animated:YES];
     } else if (indexPath.section == 2) {
-        RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
-        viewController.integrationKind = IntegrationKind_InApp;
-        [self.navigationController pushViewController:viewController animated:YES];
+        if (indexPath.row == 0) {
+            RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
+            viewController.integrationKind = IntegrationKind_InApp;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (indexPath.row == 1) {
+            RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
+            viewController.integrationKind = IntegrationKind_InApp;
+            [self.navigationController pushViewController:viewController animated:YES];
+        }
     } else if (indexPath.section == 3) {
-        RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
-        viewController.integrationKind = IntegrationKind_RenderingGAM;
-        [self.navigationController pushViewController:viewController animated:YES];
+        if (indexPath.row == 0) {
+            RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
+            viewController.integrationKind = IntegrationKind_RenderingGAM;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (indexPath.row == 1) {
+            RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
+            viewController.integrationKind = IntegrationKind_RenderingGAM;
+            [self.navigationController pushViewController:viewController animated:YES];
+        }
     } else if (indexPath.section == 4) {
-        RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
-        viewController.integrationKind = IntegrationKind_RenderingMoPub;
-        [self.navigationController pushViewController:viewController animated:YES];
+        if (indexPath.row == 0) {
+            RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
+            viewController.integrationKind = IntegrationKind_RenderingMoPub;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (indexPath.row == 1) {
+            RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
+            viewController.integrationKind = IntegrationKind_RenderingMoPub;
+            [self.navigationController pushViewController:viewController animated:YES];
+        }
     }
 }
 @end

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
@@ -32,7 +32,7 @@
     
     self.title = @"Prebid Demo";
     
-    self.adServerList = @[@"DFP", @"MoPub"];
+    self.adServerList = @[@"DFP", @"MoPub", @"In-App"];
     self.adUnitList = @[@"Banner", @"Interstitial", @"InAppNative"];
 }
 
@@ -64,9 +64,16 @@
 -(void) tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSString * storyboardName = @"Main";
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:storyboardName bundle: nil];
-    ViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"viewController"];
-    viewController.adServer = [self.adServerList objectAtIndex:indexPath.section];
-    viewController.adUnit = [self.adUnitList objectAtIndex:indexPath.row];
-    [self.navigationController pushViewController:viewController animated:YES];
+    if (indexPath.section < 2) {
+        ViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"viewController"];
+        viewController.adServer = [self.adServerList objectAtIndex:indexPath.section];
+        viewController.adUnit = [self.adUnitList objectAtIndex:indexPath.row];
+        [self.navigationController pushViewController:viewController animated:YES];
+    } else if (indexPath.section == 2) {
+        ViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
+        viewController.adServer = [self.adServerList objectAtIndex:indexPath.section];
+        viewController.adUnit = [self.adUnitList objectAtIndex:indexPath.row];
+        [self.navigationController pushViewController:viewController animated:YES];
+    }
 }
 @end

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
@@ -89,6 +89,7 @@
         } else if (integrationAdFormat == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_InApp;
+            viewController.integrationAdFormat = IntegrationAdFormat_Interstitial;
             [self.navigationController pushViewController:viewController animated:YES];
         } else if (integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
@@ -109,6 +110,7 @@
         } else if (integrationAdFormat == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_RenderingGAM;
+            viewController.integrationAdFormat = IntegrationAdFormat_Interstitial;
             [self.navigationController pushViewController:viewController animated:YES];
         } else if (integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
@@ -129,6 +131,7 @@
         } else if (integrationAdFormat == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_RenderingMoPub;
+            viewController.integrationAdFormat = IntegrationAdFormat_Interstitial;
             [self.navigationController pushViewController:viewController animated:YES];
         } else if (integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
@@ -80,33 +80,48 @@
         viewController.adUnit = (IntegrationAdFormat) [IntegrationKindUtilites.IntegrationAdFormatOriginal[indexPath.row] intValue];
         [self.navigationController pushViewController:viewController animated:YES];
     } else if (indexPath.section == IntegrationKind_InApp) {
-        if (indexPath.row == 0) {
+        if (indexPath.row == IntegrationAdFormat_Banner) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_InApp;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == 1) {
+        } else if (indexPath.row == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_InApp;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (indexPath.row == IntegrationAdFormat_InterstitialVideo) {
+            RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
+            viewController.integrationKind = IntegrationKind_InApp;
+            viewController.integrationAdFormat = IntegrationAdFormat_InterstitialVideo;
             [self.navigationController pushViewController:viewController animated:YES];
         }
     } else if (indexPath.section == IntegrationKind_RenderingGAM) {
-        if (indexPath.row == 0) {
+        if (indexPath.row == IntegrationAdFormat_Banner) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_RenderingGAM;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == 1) {
+        } else if (indexPath.row == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_RenderingGAM;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (indexPath.row == IntegrationAdFormat_InterstitialVideo) {
+            RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
+            viewController.integrationKind = IntegrationKind_RenderingGAM;
+            viewController.integrationAdFormat = IntegrationAdFormat_InterstitialVideo;
             [self.navigationController pushViewController:viewController animated:YES];
         }
     } else if (indexPath.section == IntegrationKind_RenderingMoPub) {
-        if (indexPath.row == 0) {
+        if (indexPath.row == IntegrationAdFormat_Banner) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_RenderingMoPub;
             [self.navigationController pushViewController:viewController animated:YES];
-        } else if (indexPath.row == 1) {
+        } else if (indexPath.row == IntegrationAdFormat_Interstitial) {
             RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
             viewController.integrationKind = IntegrationKind_RenderingMoPub;
+            [self.navigationController pushViewController:viewController animated:YES];
+        } else if (indexPath.row == IntegrationAdFormat_InterstitialVideo) {
+            RenderingInterstitialViewController *viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingInterstitialVC"];
+            viewController.integrationKind = IntegrationKind_RenderingMoPub;
+            viewController.integrationAdFormat = IntegrationAdFormat_InterstitialVideo;
             [self.navigationController pushViewController:viewController animated:YES];
         }
     }

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/PrebidNavigationController.m
@@ -17,11 +17,12 @@
 #import "ViewController.h"
 #import "RenderingBannerViewController.h"
 #import "RenderingInterstitialViewController.h"
+#import "IntegrationKindUtilites.h"
 
 @interface PrebidNavigationController ()
 
-@property (nonatomic, strong) NSArray *adServerList;
-@property (nonatomic, strong) NSArray *adUnitList;
+@property (nonatomic, strong) NSArray *integrationsList;
+@property (nonatomic, strong) NSDictionary *integrationsDescr;
 
 @end
 
@@ -34,30 +35,36 @@
     
     self.title = @"Prebid Demo";
     
-    self.adServerList = @[@"DFP", @"MoPub", @"In-App", @"Rendering GAM", @"Rendering MoPub"];
-    self.adUnitList = @[@"Banner", @"Interstitial", @"InAppNative"];
+    self.integrationsList = [IntegrationKindUtilites IntegrationKindAllCases];
+    self.integrationsDescr = [IntegrationKindUtilites IntegrationKindDescr];
 }
 
 #pragma mark - Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
-    return self.adServerList.count;
+    return self.integrationsList.count;
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return self.adUnitList.count;
+    return [IntegrationKindUtilites isRenderingIntegrationKind:section] ?
+    [IntegrationKindUtilites IntegrationAdFormatRendering].count :
+    [IntegrationKindUtilites IntegrationAdFormatOriginal].count;
 }
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
 {
-    return [self.adServerList objectAtIndex:section];
+    return self.integrationsDescr[self.integrationsList[section]];
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell" forIndexPath:indexPath];
     
-    NSString *adUnit = [self.adUnitList objectAtIndex:indexPath.row];
+    NSArray *adFormats = [IntegrationKindUtilites IntegrationAdFormatFor:indexPath.section];
+    IntegrationAdFormat adFormat = [adFormats[indexPath.row] intValue];
+    NSDictionary *descr = [IntegrationKindUtilites IntegrationAdFormatDescr];
+    
+    NSString *adUnit = descr[[NSNumber numberWithInteger:adFormat]];
     cell.textLabel.text = adUnit;
     
     return cell;
@@ -66,12 +73,13 @@
 -(void) tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
     NSString * storyboardName = @"Main";
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:storyboardName bundle: nil];
-    if (indexPath.section < 2) {
+    if (indexPath.section == IntegrationKind_OriginalGAM || indexPath.section == IntegrationKind_OriginalMoPub) {
         ViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"viewController"];
-        viewController.adServer = [self.adServerList objectAtIndex:indexPath.section];
-        viewController.adUnit = [self.adUnitList objectAtIndex:indexPath.row];
+        NSNumber *num = (NSNumber *) self.integrationsList[indexPath.section];
+        viewController.adServer = (IntegrationKind) [num intValue];
+        viewController.adUnit = (IntegrationAdFormat) [IntegrationKindUtilites.IntegrationAdFormatOriginal[indexPath.row] intValue];
         [self.navigationController pushViewController:viewController animated:YES];
-    } else if (indexPath.section == 2) {
+    } else if (indexPath.section == IntegrationKind_InApp) {
         if (indexPath.row == 0) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_InApp;
@@ -81,7 +89,7 @@
             viewController.integrationKind = IntegrationKind_InApp;
             [self.navigationController pushViewController:viewController animated:YES];
         }
-    } else if (indexPath.section == 3) {
+    } else if (indexPath.section == IntegrationKind_RenderingGAM) {
         if (indexPath.row == 0) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_RenderingGAM;
@@ -91,7 +99,7 @@
             viewController.integrationKind = IntegrationKind_RenderingGAM;
             [self.navigationController pushViewController:viewController animated:YES];
         }
-    } else if (indexPath.section == 4) {
+    } else if (indexPath.section == IntegrationKind_RenderingMoPub) {
         if (indexPath.row == 0) {
             RenderingBannerViewController * viewController = [storyboard instantiateViewControllerWithIdentifier:@"RenderingBannerVC"];
             viewController.integrationKind = IntegrationKind_RenderingMoPub;

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/IntegrationKind.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/IntegrationKind.h
@@ -1,0 +1,26 @@
+//
+//  IntegrationKind.h
+//  PrebidDemo
+//
+//  Created by Yuriy Velichko on 12.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#ifndef IntegrationKind_h
+#define IntegrationKind_h
+
+typedef NS_ENUM(NSUInteger, IntegrationKind) {
+    IntegrationKind_Undefined = 0,
+    
+    IntegrationKind_InApp,
+    IntegrationKind_RenderingGAM,
+    IntegrationKind_RenderingMoPub
+};
+
+typedef NS_ENUM(NSUInteger, AdFormat) {
+    AdFormat_Display,
+    AdFormat_Video
+};
+
+
+#endif /* IntegrationKind_h */

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.h
@@ -7,13 +7,13 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "IntegrationKind.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RenderingBannerViewController : UIViewController
 
-@property (nonatomic, strong) NSString *adServer;
-@property (nonatomic, strong) NSString *adUnit;
+@property (nonatomic) IntegrationKind integrationKind;
 
 @end
 

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.h
@@ -1,0 +1,20 @@
+//
+//  RenderingBannerViewController.h
+//  PrebidDemoObjectiveC
+//
+//  Created by Yuriy Velichko on 12.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RenderingBannerViewController : UIViewController
+
+@property (nonatomic, strong) NSString *adServer;
+@property (nonatomic, strong) NSString *adUnit;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.m
@@ -1,0 +1,82 @@
+//
+//  RenderingBannerViewController.m
+//  PrebidDemoObjectiveC
+//
+//  Created by Yuriy Velichko on 12.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#import "RenderingBannerViewController.h"
+
+@import PrebidMobile;
+
+@interface RenderingBannerViewController () <BannerViewDelegate>
+
+@property (weak, nonatomic) IBOutlet UIView *adView;
+
+@property (strong, nullable) BannerView *bannerView;
+
+@end
+
+@implementation RenderingBannerViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    
+    [self initRendering];
+    
+    [self loadInAppBanner];
+}
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+#pragma mar - Load Ad
+
+- (void)initRendering {
+    PrebidRenderingConfig.shared.accountID = @"0689a263-318d-448b-a3d4-b02e8a709d9d";
+    [PrebidRenderingConfig.shared setCustomPrebidServerWithUrl:@"https://prebid.openx.net/openrtb2/auction" error:nil];
+    
+    [NSUserDefaults.standardUserDefaults setValue:@"123" forKey:@"IABTCF_CmpSdkID"];
+    [NSUserDefaults.standardUserDefaults setValue:@"0" forKey:@"IABTCF_gdprApplies"];
+}
+
+- (void)loadInAppBanner {
+    const CGSize size = CGSizeMake(320, 50);
+    const CGRect frame = CGRectMake(0, 0, size.width, size.height);
+    
+    self.bannerView = [[BannerView alloc] initWithFrame:frame
+                                               configID:@"50699c03-0910-477c-b4a4-911dbe2b9d42"
+                                                 adSize:size];
+    
+    [self.bannerView loadAd];
+    self.bannerView.delegate = self;
+    
+    [self.adView addSubview:self.bannerView];
+}
+
+#pragma mark - BannerViewDelegate
+
+- (UIViewController * _Nullable)bannerViewPresentationController {
+    return self;
+}
+
+- (void)bannerView:(BannerView *)bannerView didReceiveAdWithAdSize:(CGSize)adSize {
+    NSLog(@"InApp bannerView:didReceiveAdWithAdSize");
+}
+
+- (void)bannerView:(BannerView *)bannerView didFailToReceiveAdWith:(NSError *)error {
+    NSLog(@"InApp bannerView:didFailToReceiveAdWith: %@", [error localizedDescription]);
+
+}
+
+
+@end

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.m
@@ -16,6 +16,9 @@
 
 @property (weak, nonatomic) IBOutlet UIView *adView;
 
+@property (nonatomic) CGSize size;
+@property (nonatomic) CGRect frame;
+
 @property (strong, nullable) BannerView *bannerView;
 
 @end
@@ -26,9 +29,20 @@
     [super viewDidLoad];
     // Do any additional setup after loading the view.
     
+    self.size = CGSizeMake(320, 50);
+    self.frame = CGRectMake(0, 0, self.size.width, self.size.height);
+    
     [self initRendering];
     
-    [self loadInAppBanner];
+    switch (self.integrationKind) {
+        case IntegrationKind_InApp          : [self loadInAppBanner]            ; break;
+        case IntegrationKind_RenderingGAM   : [self loadGAMRenderingBanner]     ; break;
+        case IntegrationKind_RenderingMoPub : [self loadMoPubRenderingBanner]   ; break;
+
+        default:
+            break;
+    }
+    
 }
 
 /*
@@ -52,17 +66,36 @@
 }
 
 - (void)loadInAppBanner {
-    const CGSize size = CGSizeMake(320, 50);
-    const CGRect frame = CGRectMake(0, 0, size.width, size.height);
     
-    self.bannerView = [[BannerView alloc] initWithFrame:frame
+    
+    self.bannerView = [[BannerView alloc] initWithFrame:self.frame
                                                configID:@"50699c03-0910-477c-b4a4-911dbe2b9d42"
-                                                 adSize:size];
+                                                 adSize:self.size];
     
     [self.bannerView loadAd];
     self.bannerView.delegate = self;
     
     [self.adView addSubview:self.bannerView];
+}
+
+- (void)loadGAMRenderingBanner {
+    
+    GAMBannerEventHandler *eventHandler = [[GAMBannerEventHandler alloc] initWithAdUnitID:@"/21808260008/prebid_oxb_320x50_banner"
+                                                                          validGADAdSizes:@[[NSValue valueWithCGSize:self.size]]];
+    
+    self.bannerView = [[BannerView alloc] initWithFrame:self.frame
+                                               configID:@"50699c03-0910-477c-b4a4-911dbe2b9d42"
+                                                 adSize:self.size
+                                           eventHandler:eventHandler];
+    
+    [self.bannerView loadAd];
+    self.bannerView.delegate = self;
+    
+    [self.adView addSubview:self.bannerView];
+}
+
+- (void)loadMoPubRenderingBanner {
+    
 }
 
 #pragma mark - BannerViewDelegate

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.m
@@ -9,6 +9,8 @@
 #import "RenderingBannerViewController.h"
 
 @import PrebidMobile;
+@import PrebidMobileGAMEventHandlers;
+@import PrebidMobileMoPubAdapters;
 
 @interface RenderingBannerViewController () <BannerViewDelegate>
 

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingBannerViewController.m
@@ -12,7 +12,9 @@
 @import PrebidMobileGAMEventHandlers;
 @import PrebidMobileMoPubAdapters;
 
-@interface RenderingBannerViewController () <BannerViewDelegate>
+@import MoPubSDK;
+
+@interface RenderingBannerViewController () <BannerViewDelegate, MPAdViewDelegate>
 
 @property (weak, nonatomic) IBOutlet UIView *adView;
 
@@ -20,6 +22,9 @@
 @property (nonatomic) CGRect frame;
 
 @property (strong, nullable) BannerView *bannerView;
+@property (strong, nullable) MoPubBannerAdUnit *mopubBannerAdUnit;
+
+@property (strong, nullable) MPAdView *mopubBannerView;
 
 @end
 
@@ -67,7 +72,6 @@
 
 - (void)loadInAppBanner {
     
-    
     self.bannerView = [[BannerView alloc] initWithFrame:self.frame
                                                configID:@"50699c03-0910-477c-b4a4-911dbe2b9d42"
                                                  adSize:self.size];
@@ -95,7 +99,14 @@
 }
 
 - (void)loadMoPubRenderingBanner {
+    self.mopubBannerView = [[MPAdView alloc] initWithAdUnitId:@"0df35635801e4110b65e762a62437698" size:self.size];
+    self.mopubBannerView.delegate = self;
+    [self.adView addSubview:self.mopubBannerView];
     
+    self.mopubBannerAdUnit = [[MoPubBannerAdUnit alloc] initWithConfigID:@"50699c03-0910-477c-b4a4-911dbe2b9d42" size:self.size];
+    [self.mopubBannerAdUnit fetchDemandWith:_mopubBannerView completion:^(FetchDemandResult result) {
+        [self.mopubBannerView loadAd];
+    }];
 }
 
 #pragma mark - BannerViewDelegate
@@ -110,8 +121,22 @@
 
 - (void)bannerView:(BannerView *)bannerView didFailToReceiveAdWith:(NSError *)error {
     NSLog(@"InApp bannerView:didFailToReceiveAdWith: %@", [error localizedDescription]);
-
 }
 
+#pragma mark - MPAdViewDelegate
+
+- (UIViewController *)viewControllerForPresentingModalView {
+    return self;
+}
+
+- (void)adViewDidLoadAd:(MPAdView *)view adSize:(CGSize)adSize {
+    NSLog(@"MoPub adViewDidLoadAd:");
+}
+
+- (void)adView:(MPAdView *)view didFailToLoadAdWithError:(NSError *)error {
+    NSLog(@"MoPub adView:didFailToLoadAdWithError: %@", [error localizedDescription]);
+}
 
 @end
+
+

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.h
@@ -1,0 +1,20 @@
+//
+//  RenderingBannerViewController.h
+//  PrebidDemoObjectiveC
+//
+//  Created by Yuriy Velichko on 12.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "IntegrationKind.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RenderingInterstitialViewController : UIViewController
+
+@property (nonatomic) IntegrationKind integrationKind;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RenderingInterstitialViewController : UIViewController
 
 @property (nonatomic) IntegrationKind integrationKind;
+@property (nonatomic) IntegrationAdFormat integrationAdFormat;
 
 @end
 

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.m
@@ -1,0 +1,159 @@
+//
+//  RenderingInterstitialViewController.m
+//  PrebidDemoObjectiveC
+//
+//  Created by Yuriy Velichko on 12.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#import "RenderingInterstitialViewController.h"
+
+@import PrebidMobile;
+@import PrebidMobileGAMEventHandlers;
+@import PrebidMobileMoPubAdapters;
+
+@import MoPubSDK;
+
+@interface RenderingInterstitialViewController () <InterstitialAdUnitDelegate, MPInterstitialAdControllerDelegate, BannerViewDelegate, MPAdViewDelegate>
+
+@property (weak, nonatomic) IBOutlet UIView *adView;
+
+@property (nonatomic) CGSize size;
+@property (nonatomic) CGRect frame;
+
+@property (strong, nullable) BannerView *bannerView;
+@property (strong, nullable) InterstitialRenderingAdUnit *interstitialAdUnit;
+
+@property (strong, nullable) MoPubBannerAdUnit *mopubBannerAdUnit;
+@property (strong, nullable) MoPubInterstitialAdUnit *mopubInterstitialAdUnit;
+
+@property (strong, nullable) MPAdView *mopubBannerView;
+@property (strong, nullable) MPInterstitialAdController *mopubInterstitial;
+
+@end
+
+@implementation RenderingInterstitialViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+    
+    self.size = CGSizeMake(320, 50);
+    self.frame = CGRectMake(0, 0, self.size.width, self.size.height);
+    
+    [self initRendering];
+    
+    switch (self.integrationKind) {
+        case IntegrationKind_InApp          : [self loadInAppInterstitial]            ; break;
+        case IntegrationKind_RenderingGAM   : [self loadGAMRenderingInterstitial]     ; break;
+        case IntegrationKind_RenderingMoPub : [self loadMoPubRenderingInterstitial]   ; break;
+
+        default:
+            break;
+    }
+    
+}
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+#pragma mar - Load Ad
+
+- (void)initRendering {
+    PrebidRenderingConfig.shared.accountID = @"0689a263-318d-448b-a3d4-b02e8a709d9d";
+    [PrebidRenderingConfig.shared setCustomPrebidServerWithUrl:@"https://prebid.openx.net/openrtb2/auction" error:nil];
+    
+    [NSUserDefaults.standardUserDefaults setValue:@"123" forKey:@"IABTCF_CmpSdkID"];
+    [NSUserDefaults.standardUserDefaults setValue:@"0" forKey:@"IABTCF_gdprApplies"];
+}
+
+- (void)loadInAppInterstitial {
+    
+    self.interstitialAdUnit = [[InterstitialRenderingAdUnit alloc] initWithConfigID:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"];
+    self.interstitialAdUnit.delegate = self;
+    
+    [self.interstitialAdUnit loadAd];
+}
+
+- (void)loadGAMRenderingInterstitial {
+    
+    GAMInterstitialEventHandler *eventHandler = [[GAMInterstitialEventHandler alloc] initWithAdUnitID:@"/21808260008/prebid_oxb_html_interstitial"];
+    
+    self.interstitialAdUnit = [[InterstitialRenderingAdUnit alloc] initWithConfigID:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"
+                                                                  minSizePercentage:CGSizeMake(30, 30)
+                                                                       eventHandler:eventHandler];
+    self.interstitialAdUnit.delegate = self;
+    
+    [self.interstitialAdUnit loadAd];
+}
+
+- (void)loadMoPubRenderingInterstitial {
+    
+    self.mopubInterstitial = [MPInterstitialAdController interstitialAdControllerForAdUnitId:@"e979c52714434796909993e21c8fc8da"];
+    self.mopubInterstitial.delegate = self;
+    
+    self.mopubInterstitialAdUnit = [[MoPubInterstitialAdUnit alloc] initWithConfigId:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"];
+    [self.mopubInterstitialAdUnit fetchDemandWith:self.mopubInterstitial completion:^(FetchDemandResult result) {
+        [self.mopubInterstitial loadAd];
+    }];
+    
+}
+
+#pragma mark - InterstitialAdUnitDelegate
+
+- (void)interstitialDidReceiveAd:(InterstitialRenderingAdUnit *)interstitial {
+    [interstitial showFrom:self];
+}
+
+- (void)interstitial:(InterstitialRenderingAdUnit *)interstitial didFailToReceiveAdWithError:(NSError *)error {
+    NSLog(@"InApp interstitial:didFailToReceiveAdWith: %@", [error localizedDescription]);
+}
+
+#pragma mark - MPInterstitialAdControllerDelegate
+
+- (void)interstitialDidLoadAd:(MPInterstitialAdController *)interstitial {
+    [interstitial showFromViewController:self];
+}
+
+- (void)interstitialDidFailToLoadAd:(MPInterstitialAdController *)interstitial withError:(NSError *)error {
+    NSLog(@"MoPub interstitialDidFailToLoadAd: %@", [error localizedDescription]);
+}
+
+#pragma mark - BannerViewDelegate
+
+- (UIViewController * _Nullable)bannerViewPresentationController {
+    return self;
+}
+
+- (void)bannerView:(BannerView *)bannerView didReceiveAdWithAdSize:(CGSize)adSize {
+    NSLog(@"InApp bannerView:didReceiveAdWithAdSize");
+}
+
+- (void)bannerView:(BannerView *)bannerView didFailToReceiveAdWith:(NSError *)error {
+    NSLog(@"InApp bannerView:didFailToReceiveAdWith: %@", [error localizedDescription]);
+}
+
+#pragma mark - MPAdViewDelegate
+
+- (UIViewController *)viewControllerForPresentingModalView {
+    return self;
+}
+
+- (void)adViewDidLoadAd:(MPAdView *)view adSize:(CGSize)adSize {
+    NSLog(@"MoPub adViewDidLoadAd:");
+}
+
+- (void)adView:(MPAdView *)view didFailToLoadAdWithError:(NSError *)error {
+    NSLog(@"MoPub adView:didFailToLoadAdWithError: %@", [error localizedDescription]);
+}
+
+@end
+
+

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.m
@@ -76,7 +76,14 @@
 
 - (void)loadInAppInterstitial {
     
-    self.interstitialAdUnit = [[InterstitialRenderingAdUnit alloc] initWithConfigID:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"];
+    if (self.integrationAdFormat == IntegrationAdFormat_Interstitial) {
+        self.interstitialAdUnit = [[InterstitialRenderingAdUnit alloc] initWithConfigID:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"];
+       
+    } else if (self.integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
+        self.interstitialAdUnit = [[InterstitialRenderingAdUnit alloc] initWithConfigID:@"12f58bc2-b664-4672-8d19-638bcc96fd5c"];
+        self.interstitialAdUnit.adFormat = AdFormatVideo;
+    }
+    
     self.interstitialAdUnit.delegate = self;
     
     [self.interstitialAdUnit loadAd];
@@ -84,11 +91,23 @@
 
 - (void)loadGAMRenderingInterstitial {
     
-    GAMInterstitialEventHandler *eventHandler = [[GAMInterstitialEventHandler alloc] initWithAdUnitID:@"/21808260008/prebid_oxb_html_interstitial"];
+    if (self.integrationAdFormat == IntegrationAdFormat_Interstitial) {
+
+        GAMInterstitialEventHandler *eventHandler = [[GAMInterstitialEventHandler alloc] initWithAdUnitID:@"/21808260008/prebid_oxb_html_interstitial"];
+        
+        self.interstitialAdUnit = [[InterstitialRenderingAdUnit alloc] initWithConfigID:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"
+                                                                      minSizePercentage:CGSizeMake(30, 30)
+                                                                           eventHandler:eventHandler];
+
+    } else if (self.integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
+        GAMInterstitialEventHandler *eventHandler = [[GAMInterstitialEventHandler alloc] initWithAdUnitID:@"/21808260008/prebid_oxb_interstitial_video"];
+        
+        self.interstitialAdUnit = [[InterstitialRenderingAdUnit alloc] initWithConfigID:@"12f58bc2-b664-4672-8d19-638bcc96fd5c"
+                                                                      minSizePercentage:CGSizeMake(30, 30)
+                                                                           eventHandler:eventHandler];
+        self.interstitialAdUnit.adFormat = AdFormatVideo;
+    }
     
-    self.interstitialAdUnit = [[InterstitialRenderingAdUnit alloc] initWithConfigID:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"
-                                                                  minSizePercentage:CGSizeMake(30, 30)
-                                                                       eventHandler:eventHandler];
     self.interstitialAdUnit.delegate = self;
     
     [self.interstitialAdUnit loadAd];
@@ -96,14 +115,21 @@
 
 - (void)loadMoPubRenderingInterstitial {
     
-    self.mopubInterstitial = [MPInterstitialAdController interstitialAdControllerForAdUnitId:@"e979c52714434796909993e21c8fc8da"];
-    self.mopubInterstitial.delegate = self;
+    if (self.integrationAdFormat == IntegrationAdFormat_Interstitial) {
+        self.mopubInterstitial = [MPInterstitialAdController interstitialAdControllerForAdUnitId:@"e979c52714434796909993e21c8fc8da"];
+        self.mopubInterstitial.delegate = self;
+        
+        self.mopubInterstitialAdUnit = [[MoPubInterstitialAdUnit alloc] initWithConfigId:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"];
+    } else if (self.integrationAdFormat == IntegrationAdFormat_InterstitialVideo) {
+        self.mopubInterstitial = [MPInterstitialAdController interstitialAdControllerForAdUnitId:@"7e3146fc0c744afebc8547a4567da895"];
+        self.mopubInterstitial.delegate = self;
+        
+        self.mopubInterstitialAdUnit = [[MoPubInterstitialAdUnit alloc] initWithConfigId:@"12f58bc2-b664-4672-8d19-638bcc96fd5c"];
+    }
     
-    self.mopubInterstitialAdUnit = [[MoPubInterstitialAdUnit alloc] initWithConfigId:@"5a4b8dcf-f984-4b04-9448-6529908d6cb6"];
     [self.mopubInterstitialAdUnit fetchDemandWith:self.mopubInterstitial completion:^(FetchDemandResult result) {
         [self.mopubInterstitial loadAd];
     }];
-    
 }
 
 #pragma mark - InterstitialAdUnitDelegate

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.m
@@ -42,7 +42,6 @@
         default:
             break;
     }
-    
 }
 
 /*

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingInterstitialViewController.m
@@ -14,20 +14,14 @@
 
 @import MoPubSDK;
 
-@interface RenderingInterstitialViewController () <InterstitialAdUnitDelegate, MPInterstitialAdControllerDelegate, BannerViewDelegate, MPAdViewDelegate>
+@interface RenderingInterstitialViewController () <InterstitialAdUnitDelegate, MPInterstitialAdControllerDelegate>
 
 @property (weak, nonatomic) IBOutlet UIView *adView;
 
-@property (nonatomic) CGSize size;
-@property (nonatomic) CGRect frame;
-
-@property (strong, nullable) BannerView *bannerView;
 @property (strong, nullable) InterstitialRenderingAdUnit *interstitialAdUnit;
 
-@property (strong, nullable) MoPubBannerAdUnit *mopubBannerAdUnit;
 @property (strong, nullable) MoPubInterstitialAdUnit *mopubInterstitialAdUnit;
 
-@property (strong, nullable) MPAdView *mopubBannerView;
 @property (strong, nullable) MPInterstitialAdController *mopubInterstitial;
 
 @end
@@ -37,9 +31,6 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
-    
-    self.size = CGSizeMake(320, 50);
-    self.frame = CGRectMake(0, 0, self.size.width, self.size.height);
     
     [self initRendering];
     
@@ -150,34 +141,6 @@
 
 - (void)interstitialDidFailToLoadAd:(MPInterstitialAdController *)interstitial withError:(NSError *)error {
     NSLog(@"MoPub interstitialDidFailToLoadAd: %@", [error localizedDescription]);
-}
-
-#pragma mark - BannerViewDelegate
-
-- (UIViewController * _Nullable)bannerViewPresentationController {
-    return self;
-}
-
-- (void)bannerView:(BannerView *)bannerView didReceiveAdWithAdSize:(CGSize)adSize {
-    NSLog(@"InApp bannerView:didReceiveAdWithAdSize");
-}
-
-- (void)bannerView:(BannerView *)bannerView didFailToReceiveAdWith:(NSError *)error {
-    NSLog(@"InApp bannerView:didFailToReceiveAdWith: %@", [error localizedDescription]);
-}
-
-#pragma mark - MPAdViewDelegate
-
-- (UIViewController *)viewControllerForPresentingModalView {
-    return self;
-}
-
-- (void)adViewDidLoadAd:(MPAdView *)view adSize:(CGSize)adSize {
-    NSLog(@"MoPub adViewDidLoadAd:");
-}
-
-- (void)adView:(MPAdView *)view didFailToLoadAdWithError:(NSError *)error {
-    NSLog(@"MoPub adView:didFailToLoadAdWithError: %@", [error localizedDescription]);
 }
 
 @end

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingRewardedViewController.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingRewardedViewController.h
@@ -1,0 +1,20 @@
+//
+//  RenderingRewardedViewController.h
+//  PrebidDemoObjectiveC
+//
+//  Created by Yuriy Velichko on 12.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "IntegrationKind.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RenderingRewardedViewController : UIViewController
+
+@property (nonatomic) IntegrationKind integrationKind;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingRewardedViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/RenderingVC/RenderingRewardedViewController.m
@@ -1,0 +1,124 @@
+//
+//  RenderingRewardedViewController.m
+//  PrebidDemoObjectiveC
+//
+//  Created by Yuriy Velichko on 12.11.2021.
+//  Copyright © 2021 Prebid. All rights reserved.
+//
+
+#import "RenderingRewardedViewController.h"
+
+@import PrebidMobile;
+@import PrebidMobileGAMEventHandlers;
+@import PrebidMobileMoPubAdapters;
+
+@import MoPubSDK;
+
+@interface RenderingRewardedViewController () <RewardedAdUnitDelegate, MPRewardedAdsDelegate, InterstitialAdUnitDelegate, MPInterstitialAdControllerDelegate>
+
+@property (weak, nonatomic) IBOutlet UIView *adView;
+
+@property (strong, nullable) RewardedAdUnit *rewardedAdUnit;
+@property (strong, nullable) MoPubRewardedAdUnit *mopubRewardedAdUnit;
+
+@end
+
+@implementation RenderingRewardedViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+
+    [self initRendering];
+    
+    switch (self.integrationKind) {
+        case IntegrationKind_InApp          : [self loadInAppRewarded]              ; break;
+        case IntegrationKind_RenderingGAM   : [self loadGAMRenderingRewarded]       ; break;
+        case IntegrationKind_RenderingMoPub : [self loadMoPubRenderingRewarded]     ; break;
+
+        default:
+            break;
+    }
+}
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+#pragma mar - Load Ad
+
+- (void)initRendering {
+    PrebidRenderingConfig.shared.accountID = @"0689a263-318d-448b-a3d4-b02e8a709d9d";
+    [PrebidRenderingConfig.shared setCustomPrebidServerWithUrl:@"https://prebid.openx.net/openrtb2/auction" error:nil];
+    
+    [NSUserDefaults.standardUserDefaults setValue:@"123" forKey:@"IABTCF_CmpSdkID"];
+    [NSUserDefaults.standardUserDefaults setValue:@"0" forKey:@"IABTCF_gdprApplies"];
+}
+
+- (void)loadInAppRewarded {
+    
+    GAMRewardedAdEventHandler *eventHandler = [[GAMRewardedAdEventHandler alloc] initWithAdUnitID:@"/21808260008/prebid_oxb_rewarded_video_test"];
+    
+    self.rewardedAdUnit = [[RewardedAdUnit alloc] initWithConfigID:@"12f58bc2-b664-4672-8d19-638bcc96fd5c"
+                                                      eventHandler: eventHandler];
+    self.rewardedAdUnit.delegate = self;
+    
+    [self.rewardedAdUnit loadAd];
+}
+
+- (void)loadGAMRenderingRewarded {
+    
+    self.rewardedAdUnit = [[RewardedAdUnit alloc] initWithConfigID:@"12f58bc2-b664-4672-8d19-638bcc96fd5c"];
+    self.rewardedAdUnit.delegate = self;
+    
+    [self.rewardedAdUnit loadAd];
+}
+
+- (void)loadMoPubRenderingRewarded {
+    
+    self.mopubRewardedAdUnit = [[MoPubRewardedAdUnit alloc] initWithConfigId:@"12f58bc2-b664-4672-8d19-638bcc96fd5c"];
+    MoPubBidInfoWrapper *bidInfoWrapper = [[MoPubBidInfoWrapper alloc] init];
+    
+    [self.mopubRewardedAdUnit fetchDemandWith:bidInfoWrapper completion:^(FetchDemandResult result) {
+        [MPRewardedAds setDelegate:self forAdUnitId:@"7538cc74d2984c348bc14caafa3e3395"];
+        
+        [MPRewardedAds loadRewardedAdWithAdUnitID:@"7538cc74d2984c348bc14caafa3e3395"
+                                         keywords:bidInfoWrapper.keywords
+                                 userDataKeywords:nil
+                                       customerId:@"testCustomerId"
+                                mediationSettings:@[]
+                                      localExtras:bidInfoWrapper.localExtras];
+    }];
+}
+
+#pragma mark - RewardedAdUnitDelegate
+
+- (void)rewardedAdDidReceiveAd:(RewardedAdUnit *)rewardedAd {
+    [rewardedAd showFrom:self];
+}
+
+- (void)rewardedAd:(RewardedAdUnit *)rewardedAd didFailToReceiveAdWithError:(NSError *)error {
+    NSLog(@"InApp rewardedAddidFailToReceiveAdWithError: %@", [error localizedDescription]);
+}
+
+#pragma mark - MPRewardedAdsDelegate
+
+- (void)rewardedAdDidLoadForAdUnitID:(NSString *)adUnitID {
+    [MPRewardedAds presentRewardedAdForAdUnitID:adUnitID
+                             fromViewController:self
+                                     withReward:nil];
+}
+
+- (void)rewardedAdDidFailToLoadForAdUnitID:(NSString *)adUnitID error:(NSError *)error {
+    NSLog(@"MoPub rewardedAdDidFailToLoadForAdUnitID: %@", [error localizedDescription]);
+}
+
+@end
+
+

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/ViewController.h
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/ViewController.h
@@ -14,12 +14,13 @@
  */
 
 #import <UIKit/UIKit.h>
+#import "IntegrationKind.h"
 
 @interface ViewController : UIViewController
 
-@property (nonatomic, strong) NSString *adServer;
+@property (nonatomic) IntegrationKind adServer;
 
-@property (nonatomic, strong) NSString *adUnit;
+@property (nonatomic) IntegrationAdFormat adUnit;
 
 
 @end

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/ViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/ViewController.m
@@ -97,7 +97,6 @@
 }
     
     
-    
 -(void) loadDFPBanner {
     
     [self.bannerUnit setAutoRefreshMillisWithTime:35000];

--- a/Example/PrebidDemo/PrebidDemoObjectiveC/ViewController.m
+++ b/Example/PrebidDemo/PrebidDemoObjectiveC/ViewController.m
@@ -63,28 +63,28 @@
 //    [self setStoredResponse];
 //    [self setRequestTimeoutMillis];//
     
-    if([self.adUnit isEqualToString:@"Banner"]) {
+    if(self.adUnit == IntegrationAdFormat_Banner) {
         self.bannerView.hidden = false;
         self.adContainerView.hidden = true;
-        if ([self.adServer isEqualToString:@"DFP"]) {
+        if (self.adServer == IntegrationKind_OriginalGAM) {
             [self loadDFPBanner];
-        } else if ([self.adServer isEqualToString:@"MoPub"]) {
+        } else if (self.adServer == IntegrationKind_OriginalMoPub) {
             [self loadMoPubBanner];
         }
-    } else if ([self.adUnit isEqualToString:@"Interstitial"]) {
+    } else if (self.adUnit == IntegrationAdFormat_Interstitial) {
         self.bannerView.hidden = false;
         self.adContainerView.hidden = true;
-        if ([self.adServer isEqualToString:@"DFP"]) {
+        if (self.adServer == IntegrationKind_OriginalGAM) {
             [self loadDFPInterstitial];
-        } else if ([self.adServer isEqualToString:@"MoPub"]) {
+        } else if (self.adServer == IntegrationKind_OriginalMoPub) {
             [self loadMoPubInterstitial];
         }
-    } else if ([self.adUnit isEqualToString:@"InAppNative"]) {
+    } else if (self.adUnit == IntegrationAdFormat_NativeInApp) {
         self.bannerView.hidden = true;
         self.adContainerView.hidden = false;
-        if ([self.adServer isEqualToString:@"DFP"]) {
+        if (self.adServer == IntegrationKind_OriginalGAM) {
             [self loadDFPPrebidNative];
-        } else if ([self.adServer isEqualToString:@"MoPub"]) {
+        } else if (self.adServer == IntegrationKind_OriginalMoPub) {
             [self loadMopubPrebidNative];
         }
     }

--- a/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
@@ -22,7 +22,7 @@ import GoogleMobileAds
 import MoPubSDK
 import PrebidMobileGAMEventHandlers
 
-enum BannerFormat: Int {
+enum AdFormat: Int {
     case html
     case vast
 }
@@ -42,7 +42,7 @@ class BannerController:
     
     // MARK: - Public Properties
 
-    var bannerFormat    : BannerFormat = .html
+    var bannerFormat    : AdFormat = .html
     var integrationKind : IntegrationKind = .undefined
     
     // MARK: - Private Properties

--- a/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
@@ -50,19 +50,19 @@ class BannerController:
     let width = 300
     let height = 250
     
+    // Prebid Original
+    private var prebidAdUnit: AdUnit!
+    
     // GAM
     private let gamRequest = GAMRequest()
     private var gamBanner: GAMBannerView!
     
     // MoPub
     private var mpBanner: MPAdView!
-
-    // Prebid Original
-    private var prebidAdUnit: AdUnit!
     
     // Prebid Rendering
-    private var prebidBannerView: BannerView!
-    private var prebidMoPubAdUnit: MoPubBannerAdUnit!
+    private var prebidBannerView: BannerView!           // (In-App and GAM)
+    private var prebidMoPubAdUnit: MoPubBannerAdUnit!   // (MoPub)
     
     // MARK: - UIViewController
 
@@ -80,8 +80,6 @@ class BannerController:
             case .undefined         : assertionFailure("The integration kind is: \(integrationKind.rawValue)")
         }
 
-        
- 
 //        enableCOPPA()
 //        addFirstPartyData(adUnit: adUnit)
 //        setStoredResponse()
@@ -299,10 +297,7 @@ class BannerController:
         let size = CGSize(width: 320, height: 50)
         prebidMoPubAdUnit = MoPubBannerAdUnit(configID: "50699c03-0910-477c-b4a4-911dbe2b9d42", size: size)
 
-        // Do any additional setup after loading the view, typically from a nib.
         prebidMoPubAdUnit.fetchDemand(with: mpBanner) { [weak self] result in
-            print("Prebid demand fetch for MoPub \(result.rawValue)")
-
             self?.mpBanner.loadAd()
         }
     }

--- a/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
@@ -121,13 +121,23 @@ class BannerController:
     func setupAndLoadInAppBanner() {
         setupOpenxRenderingBanner()
         
-        loadInAppBanner()
+        switch bannerFormat {
+        case .html:
+            loadInAppBanner()
+        case .vast:
+            loadInAppVideoBanner()
+        }
     }
     
     func setupAndLoadGAMRendering() {
         setupOpenxRenderingBanner()
         
-        loadGAMRenderingBanner()
+        switch bannerFormat {
+        case .html:
+            loadGAMRenderingBanner()
+        case .vast:
+            loadGAMRenderingVideoBanner()
+        }
     }
     
     func setupAndLoadMoPubRendering() {
@@ -337,6 +347,41 @@ class BannerController:
         setupGAMBanner(width: width, height: height, adUnitId: "/5300653/test_adunit_vast_pavliuchyk")
     }
     
+    func loadInAppVideoBanner() {
+        let size = CGSize(width: 300, height: 250)
+        prebidBannerView = BannerView(frame: CGRect(origin: .zero, size: size),
+                              configID: "9007b76d-c73c-49c6-b0a8-1c7890a84b33",
+                              adSize: CGSize(width: 300, height: 250))
+        
+        prebidBannerView.adFormat = .video
+        prebidBannerView.videoPlacementType = .inBanner
+                                
+        prebidBannerView.delegate = self
+        
+        appBannerView.addSubview(prebidBannerView)
+        
+        prebidBannerView.loadAd()
+    }
+    
+    func loadGAMRenderingVideoBanner() {
+        let size = CGSize(width: 300, height: 250)
+        
+        let eventHandler = GAMBannerEventHandler(adUnitID: "/21808260008/prebid_oxb_300x250_banner", validGADAdSizes: [kGADAdSizeBanner].map(NSValueFromGADAdSize))
+        prebidBannerView = BannerView(frame: CGRect(origin: .zero, size: size),
+                              configID: "9007b76d-c73c-49c6-b0a8-1c7890a84b33",
+                              adSize: CGSize(width: 300, height: 250),
+                              eventHandler: eventHandler)
+                                
+        prebidBannerView.delegate = self
+        prebidBannerView.adFormat = .video
+        
+        appBannerView.addSubview(prebidBannerView)
+        
+        prebidBannerView.loadAd()
+    }
+    
+    // MARK: - Utils
+    
     func enableCOPPA() {
         Targeting.shared.subjectToCOPPA = true
     }
@@ -383,6 +428,14 @@ class BannerController:
     
     func bannerViewPresentationController() -> UIViewController? {
         return self
+    }
+    
+    func bannerView(_ bannerView: BannerView, didReceiveAdWithAdSize adSize: CGSize) {
+        
+    }
+    
+    func bannerView(_ bannerView: BannerView, didFailToReceiveAdWith error: Error) {
+        print(">>>>>  \(error.localizedDescription)")
     }
 
     //MARK: - GADBannerViewDelegate

--- a/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
@@ -51,7 +51,6 @@ class BannerController:
     let height = 250
     
     // GAM
-    
     private let gamRequest = GAMRequest()
     private var gamBanner: GAMBannerView!
     

--- a/Example/PrebidDemo/PrebidDemoSwift/Base.lproj/Main.storyboard
+++ b/Example/PrebidDemo/PrebidDemoSwift/Base.lproj/Main.storyboard
@@ -123,7 +123,10 @@
                     <navigationItem key="navigationItem" id="blE-VU-00S"/>
                     <connections>
                         <outlet property="adServerSegment" destination="fwP-lp-368" id="oHh-cj-Nkb"/>
+                        <outlet property="bannerNative" destination="0gT-aH-qqc" id="t2i-IV-0Ua"/>
                         <outlet property="bannerVideo" destination="2BF-DS-686" id="5Fb-nV-c6O"/>
+                        <outlet property="inAppNative" destination="8ga-uv-oWc" id="FdH-cu-eJ1"/>
+                        <outlet property="instreamVideo" destination="Xoo-vz-hax" id="P6W-qL-JZK"/>
                         <outlet property="interstitialVideo" destination="H9f-Yj-Von" id="6Af-yT-nRW"/>
                     </connections>
                 </viewController>

--- a/Example/PrebidDemo/PrebidDemoSwift/Base.lproj/Main.storyboard
+++ b/Example/PrebidDemo/PrebidDemoSwift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4Oj-qG-uCu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4Oj-qG-uCu">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -95,11 +95,13 @@
                                 </subviews>
                             </stackView>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="fwP-lp-368">
-                                <rect key="frame" x="100" y="69" width="175" height="32"/>
+                                <rect key="frame" x="20" y="69" width="335" height="32"/>
                                 <segments>
                                     <segment title="DFP"/>
                                     <segment title="MoPub"/>
                                     <segment title="In-App"/>
+                                    <segment title="GAM + Rendering"/>
+                                    <segment title="MoPub + Rendering"/>
                                 </segments>
                                 <connections>
                                     <action selector="onAdServerSwidshed:" destination="BYZ-38-t0r" eventType="valueChanged" id="j2N-Nn-Vqk"/>
@@ -110,12 +112,12 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="Jeh-3U-EHA" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="I5D-Bl-QZ5"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="fwP-lp-368" secondAttribute="trailing" constant="100" id="IjW-xZ-d3E"/>
                             <constraint firstItem="fwP-lp-368" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="25" id="TB7-Cg-dlk"/>
                             <constraint firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="TVT-40-hfI"/>
                             <constraint firstItem="Jeh-3U-EHA" firstAttribute="top" secondItem="fwP-lp-368" secondAttribute="bottom" constant="60" id="WkA-Ux-ytE"/>
+                            <constraint firstAttribute="trailing" secondItem="fwP-lp-368" secondAttribute="trailing" constant="20" id="h8d-Dz-EFS"/>
+                            <constraint firstItem="fwP-lp-368" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="u5u-MC-ShX"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Jeh-3U-EHA" secondAttribute="trailing" constant="20" id="ukx-1v-bCp"/>
-                            <constraint firstItem="fwP-lp-368" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="100" id="yte-Ky-7os"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="blE-VU-00S"/>
@@ -245,7 +247,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="V4N-fP-62I" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-710" y="844"/>
+            <point key="canvasLocation" x="-1054" y="860"/>
         </scene>
         <!--Rewarded Video Controller-->
         <scene sceneID="o2o-ve-AgX">

--- a/Example/PrebidDemo/PrebidDemoSwift/IndexController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/IndexController.swift
@@ -17,8 +17,19 @@ import Foundation
 
 import UIKit
 
+enum IntegrationKind: String, CaseIterable {
+    case originalGAM    = "GAM"
+    case originalMoPub  = "MoPub"
+    case inApp          = "In-App"
+    case renderingGAM   = "GAM + Rendering"
+    case renderingMoPub = "MoPUb + Rendering"
+    
+    case undefined      = "Undefined"
+}
+
 
 class IndexController: UIViewController {
+    
     @IBOutlet var adServerSegment: UISegmentedControl!
     @IBOutlet var bannerVideo: UIButton!
     @IBOutlet var interstitialVideo: UIButton!
@@ -27,6 +38,11 @@ class IndexController: UIViewController {
         super.viewDidLoad()
 
         self.title = "Prebid Demo"
+        
+        adServerSegment.removeAllSegments()
+        IntegrationKind.allCases.forEach {
+            adServerSegment.insertSegment(withTitle: $0.rawValue, at: adServerSegment.numberOfSegments, animated: false)
+        }
     }
     
     @IBAction func onAdServerSwidshed(_ sender: UISegmentedControl) {
@@ -56,7 +72,7 @@ class IndexController: UIViewController {
         switch segue.destination {
             
         case let vc as BannerController:
-            vc.adServerName = adServerName
+            vc.integrationKind = IntegrationKind(rawValue: adServerName) ?? .undefined
             
             if buttonText == "Banner Video" {
                 vc.bannerFormat = .vast

--- a/Example/PrebidDemo/PrebidDemoSwift/IndexController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/IndexController.swift
@@ -18,11 +18,13 @@ import Foundation
 import UIKit
 
 enum IntegrationKind: String, CaseIterable {
+    
     case originalGAM    = "GAM"
     case originalMoPub  = "MoPub"
+    
     case inApp          = "In-App"
-    case renderingGAM   = "GAM + Rendering"
-    case renderingMoPub = "MoPUb + Rendering"
+    case renderingGAM   = "GAM (R)"
+    case renderingMoPub = "MoPub (R)"
     
     case undefined      = "Undefined"
 }
@@ -40,8 +42,12 @@ class IndexController: UIViewController {
         self.title = "Prebid Demo"
         
         adServerSegment.removeAllSegments()
-        IntegrationKind.allCases.forEach {
-            adServerSegment.insertSegment(withTitle: $0.rawValue, at: adServerSegment.numberOfSegments, animated: false)
+        
+        IntegrationKind
+            .allCases
+            .filter { $0 != .undefined }
+            .forEach {
+                adServerSegment.insertSegment(withTitle: $0.rawValue, at: adServerSegment.numberOfSegments, animated: false)
         }
     }
     

--- a/Example/PrebidDemo/PrebidDemoSwift/IndexController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/IndexController.swift
@@ -69,33 +69,35 @@ class IndexController: UIViewController {
            buttonText = text
         }
         
+        let integrationKind = IntegrationKind(rawValue: adServerName) ?? .undefined
+        
         switch segue.destination {
             
         case let vc as BannerController:
-            vc.integrationKind = IntegrationKind(rawValue: adServerName) ?? .undefined
+            vc.integrationKind = integrationKind
             
             if buttonText == "Banner Video" {
                 vc.bannerFormat = .vast
             }
             
         case let vc as InterstitialViewController:
-            vc.adServerName = adServerName
+            vc.integrationKind = integrationKind
             
             if buttonText == "Interstitial Video" {
                 vc.bannerFormat = .vast
             }
             
         case let vc as NativeViewController:
-            vc.adServerName = adServerName
+            vc.integrationKind = integrationKind
             
         case let vc as RewardedVideoController:
-            vc.adServerName = adServerName
-            
+            vc.integrationKind = integrationKind
+
         case let vc as NativeInAppViewController:
-            vc.adServerName = adServerName
+            vc.integrationKind = integrationKind
 
         case let vc as InstreamVideoViewController:
-            vc.adServerName = adServerName
+            vc.integrationKind = integrationKind
 
         default:
             print("wrong controller")

--- a/Example/PrebidDemo/PrebidDemoSwift/IndexController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/IndexController.swift
@@ -33,8 +33,12 @@ enum IntegrationKind: String, CaseIterable {
 class IndexController: UIViewController {
     
     @IBOutlet var adServerSegment: UISegmentedControl!
+    
     @IBOutlet var bannerVideo: UIButton!
     @IBOutlet var interstitialVideo: UIButton!
+    @IBOutlet weak var bannerNative: UIButton!
+    @IBOutlet weak var inAppNative: UIButton!
+    @IBOutlet weak var instreamVideo: UIButton!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,21 +53,20 @@ class IndexController: UIViewController {
             .forEach {
                 adServerSegment.insertSegment(withTitle: $0.rawValue, at: adServerSegment.numberOfSegments, animated: false)
         }
+        
+        adServerSegment.selectedSegmentIndex = IntegrationKind
+            .allCases
+            .firstIndex(of: .inApp) ?? 0
+        
+        updateCasesList(for: .inApp)
     }
     
     @IBAction func onAdServerSwidshed(_ sender: UISegmentedControl) {
         let index = sender.selectedSegmentIndex
         
-        switch index {
-        case 0:
-            bannerVideo.isHidden = false
-        case 1:
-            bannerVideo.isHidden = true
-            
-        default:
-            bannerVideo.isHidden = false
-        }
+        let integrationKind = IntegrationKind.allCases[index]
         
+        updateCasesList(for: integrationKind)
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -90,7 +93,7 @@ class IndexController: UIViewController {
             vc.integrationKind = integrationKind
             
             if buttonText == "Interstitial Video" {
-                vc.bannerFormat = .vast
+                vc.adFormat = .vast
             }
             
         case let vc as NativeViewController:
@@ -109,6 +112,23 @@ class IndexController: UIViewController {
             print("wrong controller")
 
         }
+    }
+    
+    func updateCasesList(for integrationKind: IntegrationKind) {
+        let isMoPub =   integrationKind == .originalMoPub ||
+                        integrationKind == .renderingMoPub
+        
+        let isRendering =   integrationKind == .inApp ||
+                            integrationKind == .renderingMoPub ||
+                            integrationKind == .renderingGAM
+        
+        bannerVideo.isHidden    = isMoPub
+        
+        bannerNative.isHidden   = isRendering
+        inAppNative.isHidden    = isRendering
+        instreamVideo.isHidden  = isRendering
+        
+        
     }
 
 }

--- a/Example/PrebidDemo/PrebidDemoSwift/Info.plist
+++ b/Example/PrebidDemo/PrebidDemoSwift/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -20,13 +25,6 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSAllowsArbitraryLoadsInWebContent</key>
-		<true/>
-	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -56,14 +54,11 @@
 	<string>Need to use location for better ad targeting</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Need to use location for better ad targeting</string>
-
-    <key>GADIsAdManagerApp</key>
-    <true/>
-    <key>gad_preferred_webview</key>
-    <string>wkwebview</string>
-    
-    <key>NSUserTrackingUsageDescription</key>
-    <string>By selecting allow, you give the Prebid Demo Application permission to use your IDFA for testing purposes. This a one time prompt per user. You are still able to change your decision in “Settings > Privacy” to test multiple opt-in scenarios</string>
-    
+	<key>GADIsAdManagerApp</key>
+	<true/>
+	<key>gad_preferred_webview</key>
+	<string>wkwebview</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>By selecting allow, you give the Prebid Demo Application permission to use your IDFA for testing purposes. This a one time prompt per user. You are still able to change your decision in “Settings &gt; Privacy” to test multiple opt-in scenarios</string>
 </dict>
 </plist>

--- a/Example/PrebidDemo/PrebidDemoSwift/InstreamVideoViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/InstreamVideoViewController.swift
@@ -24,7 +24,7 @@ class InstreamVideoViewController: UIViewController, IMAAdsLoaderDelegate, IMAAd
     @IBOutlet var appInstreamView: UIView!
     @IBOutlet weak var playButton: UIButton!
     
-    var adServerName: String = ""
+    var integrationKind: IntegrationKind = .undefined
     let parameters = VideoBaseAdUnit.Parameters()
     var adUnitID: String!
     
@@ -43,7 +43,7 @@ class InstreamVideoViewController: UIViewController, IMAAdsLoaderDelegate, IMAAd
     override func viewDidLoad() {
         super.viewDidLoad()
         playButton.layer.zPosition = CGFloat.greatestFiniteMagnitude
-        adServerLabel.text = adServerName
+        adServerLabel.text = integrationKind.rawValue
         setUpContentPlayer()
     }
     
@@ -55,12 +55,22 @@ class InstreamVideoViewController: UIViewController, IMAAdsLoaderDelegate, IMAAd
     }
     
     @IBAction func onPlayButtonTouch(_ sender: AnyObject) {
-        if (adServerName == "DFP") {
+        
+        switch integrationKind {
+        case .originalGAM:
             setupAndLoadAMInstreamVideo()
-            
-        } else if (adServerName == "MoPub") {
+        case .originalMoPub:
             contentPlayer?.play()
             print("mopub not supported")
+
+        case .inApp:
+            print("TODO: Add Example")
+        case .renderingGAM:
+            print("TODO: Add Example")
+        case .renderingMoPub:
+            print("TODO: Add Example")
+        case .undefined:
+            assertionFailure("The integration kind is: \(integrationKind.rawValue)")
         }
         
         playButton.isHidden = true

--- a/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
@@ -33,7 +33,7 @@ class InterstitialViewController:
     
     // MARK: - Public Properties
 
-    var bannerFormat: BannerFormat = .html
+    var adFormat: AdFormat = .html
     var integrationKind: IntegrationKind = .undefined
 
     // MARK: - Ad Units
@@ -70,7 +70,7 @@ class InterstitialViewController:
     //MARK: - Interstitial
     
     func setupAndLoadGAM() {
-        switch bannerFormat {
+        switch adFormat {
         case .html:
             setupAndLoadAMInterstitial()
         case .vast:
@@ -79,7 +79,7 @@ class InterstitialViewController:
     }
     
     func setupAndLoadMoPub() {
-        switch bannerFormat {
+        switch adFormat {
         case .html:
             setupAndLoadMPInterstitial()
         case .vast:
@@ -103,19 +103,34 @@ class InterstitialViewController:
     func setupAndLoadInAppInterstitial() {
         setupOpenxRendering()
         
-        loadInAppInterstitial()
+        switch adFormat {
+        case .html:
+            loadInAppInterstitial()
+        case .vast:
+            loadInAppVideoInterstitial()
+        }
     }
     
     func setupAndLoadGAMRenderingInterstitial() {
         setupOpenxRendering()
         
-        loadGAMRenderingInterstitial()
+        switch adFormat {
+        case .html:
+            loadGAMRenderingInterstitial()
+        case .vast:
+            loadGAMRenderingVideoInterstitial()
+        }
     }
     
     func setupAndLoadMoPubRenderingInterstitial() {
         setupOpenxRendering()
         
-        loadGAMRenderingInterstitial()
+        switch adFormat {
+        case .html:
+            loadMoPubRenderingInterstitial()
+        case .vast:
+            loadMoPubRenderingVideoInterstitial()
+        }
     }
     
     //Setup PB
@@ -231,6 +246,34 @@ class InterstitialViewController:
         setupPBRubiconInterstitialVAST()
         setupMPRubiconInterstitialVAST()
         loadMPInterstitial()
+    }
+    
+    func loadInAppVideoInterstitial() {
+        renderingInterstitial = InterstitialRenderingAdUnit(configID: "12f58bc2-b664-4672-8d19-638bcc96fd5c")
+        renderingInterstitial.adFormat = .video
+        renderingInterstitial.delegate = self
+        
+        renderingInterstitial.loadAd()
+    }
+    
+    func loadGAMRenderingVideoInterstitial() {
+        let eventHandler = GAMInterstitialEventHandler(adUnitID: "/21808260008/prebid_oxb_interstitial_video")
+        renderingInterstitial = InterstitialRenderingAdUnit(configID: "12f58bc2-b664-4672-8d19-638bcc96fd5c", eventHandler: eventHandler)
+        renderingInterstitial.adFormat = .video
+        renderingInterstitial.delegate = self
+        
+        renderingInterstitial.loadAd()
+    }
+    
+    func loadMoPubRenderingVideoInterstitial() {
+        renderingMoPubInterstitial = MoPubInterstitialAdUnit(configId: "12f58bc2-b664-4672-8d19-638bcc96fd5c")
+        
+        mpInterstitial = MPInterstitialAdController(forAdUnitId: "7e3146fc0c744afebc8547a4567da895")
+        mpInterstitial.delegate = self
+
+        renderingMoPubInterstitial.fetchDemand(with: mpInterstitial) { [weak self] _ in
+            self?.mpInterstitial.loadAd()
+        }
     }
     
     //Setup PB

--- a/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
@@ -162,17 +162,15 @@ class InterstitialViewController:
         self.mpInterstitial = MPInterstitialAdController(forAdUnitId: adUnitId)
         self.mpInterstitial.delegate = self
     }
-    
-    // MARK: - Setup OpenX
-    
+        
     func setupOpenxRendering() {
         PrebidRenderingConfig.shared.accountID = "0689a263-318d-448b-a3d4-b02e8a709d9d"
         try! PrebidRenderingConfig.shared.setCustomPrebidServer(url: "https://prebid.openx.net/openrtb2/auction")
     }
     
-    //Load
+    // MARK: - Load
+    
     func loadAMInterstitial(_ adUnitID: String) {
-        
         adUnit.fetchDemand(adObject: self.amRequest) { [weak self] (resultCode: ResultCode) in
             print("Prebid demand fetch for DFP \(resultCode.name())")
             
@@ -184,7 +182,6 @@ class InterstitialViewController:
                     ad.present(fromRootViewController: self!)
                 }
             }
-
         }
     }
     
@@ -196,11 +193,7 @@ class InterstitialViewController:
             self?.mpInterstitial.loadAd()
         }
     }
-    
-    
-    
-    // MARK: Rendering
-    
+            
     func loadInAppInterstitial() {
         renderingInterstitial = InterstitialRenderingAdUnit(configID: "5a4b8dcf-f984-4b04-9448-6529908d6cb6")
         renderingInterstitial.delegate = self

--- a/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
@@ -25,7 +25,7 @@ class InterstitialViewController: UIViewController, MPInterstitialAdControllerDe
 
     @IBOutlet var adServerLabel: UILabel!
 
-    var adServerName: String = ""
+    var integrationKind: IntegrationKind = .undefined
     var bannerFormat: BannerFormat = .html
     
     private var adUnit: AdUnit!
@@ -38,11 +38,10 @@ class InterstitialViewController: UIViewController, MPInterstitialAdControllerDe
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        adServerLabel.text = adServerName
-
-        if (adServerName == "DFP") {
-            print("entered \(adServerName) loop" )
-            
+        adServerLabel.text = integrationKind.rawValue
+        
+        switch integrationKind {
+        case .originalGAM:
             switch bannerFormat {
             case .html:
                 setupAndLoadAMInterstitial()
@@ -50,15 +49,21 @@ class InterstitialViewController: UIViewController, MPInterstitialAdControllerDe
                 setupAndLoadAMInterstitialVAST()
             }
 
-        } else if (adServerName == "MoPub") {
-            print("entered \(adServerName) loop" )
-            
+        case .originalMoPub:
             switch bannerFormat {
             case .html:
                 setupAndLoadMPInterstitial()
             case .vast:
                 setupAndLoadMPInterstitialVAST()
             }
+        case .inApp:
+            print("TODO: Add Example")
+        case .renderingGAM:
+            print("TODO: Add Example")
+        case .renderingMoPub:
+            print("TODO: Add Example")
+        case .undefined:
+            assertionFailure("The integration kind is: \(integrationKind.rawValue)")
         }
     }
 

--- a/Example/PrebidDemo/PrebidDemoSwift/NativeAd/NativeInAppViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/NativeAd/NativeInAppViewController.swift
@@ -31,7 +31,7 @@ class NativeInAppViewController: UIViewController, GAMBannerAdLoaderDelegate, GA
     var nativeAdView: NativeAdView?
     var nativeUnit: NativeRequest!
     var eventTrackers: NativeEventTracker!
-    var adServerName: String = ""
+    var integrationKind: IntegrationKind = .undefined
 
     
     public var screenWidth: CGFloat {
@@ -44,14 +44,19 @@ class NativeInAppViewController: UIViewController, GAMBannerAdLoaderDelegate, GA
     //MARK: : ViewController LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        if (adServerName == "DFP") {
-            print("entered \(adServerName) loop" )
+        switch integrationKind {
+        case .originalGAM:
             setupAndLoadNativeInAppForDFP()
-            
-        } else if (adServerName == "MoPub") {
-            print("entered \(adServerName) loop" )
+        case .originalMoPub:
             setupAndLoadNativeInAppForMoPub()
+        case .inApp:
+            print("TODO: Add Example")
+        case .renderingGAM:
+            print("TODO: Add Example")
+        case .renderingMoPub:
+            print("TODO: Add Example")
+        case .undefined:
+            assertionFailure("The integration kind is: \(integrationKind.rawValue)")
         }
     }
     
@@ -268,7 +273,7 @@ extension NativeInAppViewController : NativeAdDelegate{
     }
     
     func nativeAdNotFound() {
-        if (adServerName == "MoPub") {
+        if (integrationKind == .originalMoPub) {
             renderMoPubNativeAd( )
         }else {
             print("nativeAdNotFound")

--- a/Example/PrebidDemo/PrebidDemoSwift/NativeViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/NativeViewController.swift
@@ -18,7 +18,7 @@ class NativeViewController: UIViewController, GADBannerViewDelegate, MPAdViewDel
 
     var nativeUnit: NativeRequest!
     
-    var adServerName: String = ""
+    var integrationKind: IntegrationKind = .undefined
     
     @IBOutlet var nativeView: UIView!
     
@@ -34,17 +34,22 @@ class NativeViewController: UIViewController, GADBannerViewDelegate, MPAdViewDel
         Prebid.shared.prebidServerAccountId = "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
         
         loadNativeAssets()
-            
-        if (adServerName == "DFP") {
-            print("entered \(adServerName) loop" )
-            loadDFPNative()
-
-        } else if (adServerName == "MoPub") {
-            print("entered \(adServerName) loop" )
-            loadMoPubNative()
-
-        }
         
+        switch integrationKind {
+        case .originalGAM:
+            loadDFPNative()
+        case .originalMoPub:
+            loadMoPubNative()
+        case .inApp:
+            print("TODO: Add Example")
+        case .renderingGAM:
+            print("TODO: Add Example")
+        case .renderingMoPub:
+            print("TODO: Add Example")
+        case .undefined:
+            assertionFailure("The integration kind is: \(integrationKind.rawValue)")
+        }
+
         // Do any additional setup after loading the view.
         }
         

--- a/Example/PrebidDemo/PrebidDemoSwift/RewardedVideoController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/RewardedVideoController.swift
@@ -26,7 +26,7 @@ class RewardedVideoController: UIViewController, MPRewardedVideoDelegate {
     
     @IBOutlet var adServerLabel: UILabel!
     
-    var adServerName: String = ""
+    var integrationKind: IntegrationKind = .undefined
     
     private var adUnit: AdUnit!
     
@@ -37,12 +37,21 @@ class RewardedVideoController: UIViewController, MPRewardedVideoDelegate {
     
     override func viewDidLoad() {
         
-        adServerLabel.text = adServerName
+        adServerLabel.text = integrationKind.rawValue
         
-        if (adServerName == "DFP") {
+        switch integrationKind {
+        case .originalGAM:
             setupAndLoadAMRewardedVideo()
-        } else if (adServerName == "MoPub") {
+        case .originalMoPub:
             setupAndLoadMPRewardedVideo()
+        case .inApp:
+            print("TODO: Add Example")
+        case .renderingGAM:
+            print("TODO: Add Example")
+        case .renderingMoPub:
+            print("TODO: Add Example")
+        case .undefined:
+            assertionFailure("The integration kind is: \(integrationKind.rawValue)")
         }
     }
     

--- a/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
@@ -245,6 +245,7 @@ struct TestCaseManager {
     // MARK: - Private Methods
     
     // MARK: - --== PREBID ==--
+    
     private static let prebidExamples: [TestCase] = {
         return [
         

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
@@ -26,15 +26,18 @@ public class BaseInterstitialAdUnit :
     
     // MARK: - Public Properties
     
+    @objc
     public var configID: String {
         adUnitConfig.configID
     }
     
+    @objc
     public var adFormat: AdFormat {
         get { adUnitConfig.adFormat }
         set { adUnitConfig.adFormat = newValue }
     }
-        
+     
+    @objc
     public var isReady: Bool {
         objc_sync_enter(blocksLockToken)
         if let block = isReadyBlock {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
@@ -47,6 +47,7 @@ public class BaseInterstitialAdUnit :
         return false
     }
 
+    @objc
     public weak var delegate: AnyObject?
     
     public let adUnitConfig: AdUnitConfig
@@ -126,10 +127,12 @@ public class BaseInterstitialAdUnit :
     
     // MARK: - Public Methods
     
+    @objc
     public func loadAd() {
         adLoadFlowController.refresh()
     }
     
+    @objc
     public func show(from controller: UIViewController) {
         // It is expected from the user to call this method on main thread
         assert(Thread.isMainThread, "Expected to only be called on the main thread");

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialAdUnitDelegate.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialAdUnitDelegate.swift
@@ -20,7 +20,8 @@ import Foundation
  *
  * All messages will be invoked on the main thread.
  */
-@objc public protocol InterstitialAdUnitDelegate where Self: NSObject {
+@objc
+public protocol InterstitialAdUnitDelegate where Self: NSObject {
 
     /// Called when an ad is loaded and ready for display
     @objc optional func interstitialDidReceiveAd(_ interstitial: InterstitialRenderingAdUnit)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
@@ -15,6 +15,7 @@
 
 import UIKit
 
+@objcMembers
 public class InterstitialRenderingAdUnit: BaseInterstitialAdUnit {
 
     @objc public init(configID: String) {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
@@ -15,6 +15,7 @@
 
 import UIKit
 
+@objc
 public class RewardedAdUnit: BaseInterstitialAdUnit,
                              RewardedEventInteractionDelegate {
    

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MoPub/MoPubBannerAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MoPub/MoPubBannerAdUnit.swift
@@ -16,6 +16,7 @@
 import Foundation
 import UIKit
 
+@objcMembers
 public class MoPubBannerAdUnit : NSObject {
     
     var bidRequester: PBMBidRequester?

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MoPub/MoPubBaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MoPub/MoPubBaseInterstitialAdUnit.swift
@@ -14,6 +14,7 @@
  */
 import Foundation
 
+@objcMembers
 public class MoPubBaseInterstitialAdUnit : NSObject {
     
     let adUnitConfig: AdUnitConfig

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MoPub/MoPubInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MoPub/MoPubInterstitialAdUnit.swift
@@ -16,6 +16,7 @@
 import Foundation
 import UIKit
 
+@objcMembers
 public class MoPubInterstitialAdUnit : MoPubBaseInterstitialAdUnit {
     
     // MARK: - Public Properties

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MoPub/MoPubRewardedAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MoPub/MoPubRewardedAdUnit.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 
+@objcMembers
 public class MoPubRewardedAdUnit : MoPubBaseInterstitialAdUnit {
     
     // - MARK: Public Methods


### PR DESCRIPTION
Closes #418

## Description of Change

Add the next cases to the Prebid Demo App (Kotlin and JAVA):

- Display Banner (In-App, GAM, MoPub)
- Display Interstitial (In-App, GAM, MoPub)
- Video Banner (In-App, GAM) (Swift App)
- Video Interstitial (In-App, GAM, MoPub)
- Rewarded Interstitial (In-App, GAM, MoPub)

- Some classes in the  SDK got an @objcMembers notation. 
- Demo Apps now switch the cases based on Enums but not String literals. 