### PR TITLE
Exposure of the bid request to publishers 

### DIFF
--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/PBMAdLoadFlowController+PrivateState.h
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/PBMAdLoadFlowController+PrivateState.h
@@ -38,9 +38,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) PBMBidRequester *bidRequester;
 @property (nonatomic, strong, nullable) NSError *bidRequestError;
 
-// State: DemandReceived
-@property (nonatomic, strong, nullable) BidResponseForRendering *bidResponse;
-
 // State: PrimaryAdRequest
 // _(no relevant properties)_
 

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/PBMAdLoadFlowController.h
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/PBMAdLoadFlowController.h
@@ -39,6 +39,9 @@ typedef BOOL(^PBMAdUnitConfigValidationBlock)(AdUnitConfig *adUnitConfig, BOOL r
 /// Should only be access
 @property (nonatomic, assign, readonly) BOOL hasFailedLoading;
 
+// State: DemandReceived
+@property (nonatomic, strong, nullable) BidResponseForRendering *bidResponse;
+
 - (instancetype)initWithBidRequesterFactory:(id<PBMBidRequesterProtocol> (^)(AdUnitConfig *))bidRequesterFactory
                                    adLoader:(id<PBMAdLoaderProtocol>)adLoader
                                    delegate:(id<AdLoadFlowControllerDelegate>)delegate

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -28,6 +28,10 @@ public class BannerView: UIView,
     
     // MARK: - Public Properties
     
+    public var lastBidResponse: BidResponseForRendering? {
+        adLoadFlowController?.bidResponse
+    }
+    
     @objc public var configID: String {
         adUnitConfig.configID
     }

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
@@ -26,6 +26,10 @@ public class BaseInterstitialAdUnit :
     
     // MARK: - Public Properties
     
+    public var lastBidResponse: BidResponseForRendering? {
+        return adLoadFlowController?.bidResponse
+    }
+    
     @objc
     public var configID: String {
         adUnitConfig.configID

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/PBMStandaloneSDK/DemandResponseInfo.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/PBMStandaloneSDK/DemandResponseInfo.swift
@@ -23,12 +23,16 @@ public class DemandResponseInfo: NSObject {
     @objc public private(set) var bid: Bid?
     
     var winNotifierBlock: PBMWinNotifierBlock
+    
+    private(set) var bidResponse: BidResponseForRendering?
 
     @objc public required init(fetchDemandResult: FetchDemandResult,
-                  bid: Bid?,
-                  configId: String?,
-                  winNotifierBlock: @escaping PBMWinNotifierBlock
+                               bid: Bid?,
+                               configId: String?,
+                               winNotifierBlock: @escaping PBMWinNotifierBlock,
+                               bidResponse: BidResponseForRendering?
     ) {
+        self.bidResponse = bidResponse
         self.fetchDemandResult = fetchDemandResult
         self.bid = bid
         self.configId = configId

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/PBMStandaloneSDK/NativeAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/PBMStandaloneSDK/NativeAdUnit.swift
@@ -39,9 +39,10 @@ class NativeAdUnit: PBMBaseAdUnit {
         objc_sync_enter(self.stateLockToken)
         if hasStartedFetching {
             completion(DemandResponseInfo(fetchDemandResult: .sdkMisuseNativeAdUnitFetchedAgain,
-                                             bid: nil,
-                                             configId: nil,
-                                             winNotifierBlock: winNotifierBlock))
+                                          bid: nil,
+                                          configId: nil,
+                                          winNotifierBlock: winNotifierBlock,
+                                          bidResponse: nil))
             objc_sync_exit(self.stateLockToken)
             return
         }

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/PBMStandaloneSDK/PBMBaseAdUnit.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/PBMStandaloneSDK/PBMBaseAdUnit.m
@@ -103,7 +103,8 @@
         completion([[DemandResponseInfo alloc] initWithFetchDemandResult:previousFetchNotCompletedYet
                                                                         bid:nil
                                                                    configId:self.configId
-                                                           winNotifierBlock:self.winNotifierBlock]);
+                                                           winNotifierBlock:self.winNotifierBlock
+                                                                bidResponse:nil]);
         return;
     }
     self.completion = [completion copy];
@@ -158,17 +159,20 @@
             result = [[DemandResponseInfo alloc] initWithFetchDemandResult:[PBMError demandResultFrom:error]
                                                                           bid:nil
                                                                      configId:self.configId
-                                                             winNotifierBlock:self.winNotifierBlock];
+                                                             winNotifierBlock:self.winNotifierBlock
+                                                                  bidResponse:bidResponse];
         } else if (!bidResponse.winningBid) {
             result = [[DemandResponseInfo alloc] initWithFetchDemandResult:FetchDemandResultDemandNoBids
                                                                           bid:nil
                                                                      configId:self.configId
-                                                             winNotifierBlock:self.winNotifierBlock];
+                                                             winNotifierBlock:self.winNotifierBlock
+                                                                  bidResponse:bidResponse];
         } else {
             result = [[DemandResponseInfo alloc] initWithFetchDemandResult:FetchDemandResultOk
                                                                           bid:bidResponse.winningBid
                                                                      configId:self.configId
-                                                             winNotifierBlock:self.winNotifierBlock];
+                                                             winNotifierBlock:self.winNotifierBlock
+                                                                  bidResponse:bidResponse];
         }
         
         self.lastDemandResponseInfoUnsafe = result;

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/DemandResponseInfoTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/DemandResponseInfoTest.swift
@@ -42,7 +42,8 @@ class DemandResponseInfoTest: XCTestCase, RawWinningBidFabricator {
             let responseInfo = DemandResponseInfo(fetchDemandResult: initArgs.fetchDemandResult,
                                                   bid: initArgs.bid,
                                                   configId: initArgs.configId,
-                                                  winNotifierBlock: notifier)
+                                                  winNotifierBlock: notifier,
+                                                  bidResponse: nil)
             
             XCTAssertEqual(responseInfo.fetchDemandResult, initArgs.fetchDemandResult)
             XCTAssertEqual(responseInfo.bid, initArgs.bid)
@@ -66,11 +67,11 @@ class DemandResponseInfoTest: XCTestCase, RawWinningBidFabricator {
         let expectationToCall = NSMutableArray(object: noCallExpectation)
         let adMarkupString = "<div>Some Ad markup</div>"
         
-        let responseInfo = DemandResponseInfo(fetchDemandResult: .ok, bid: winningBid, configId: configID) {
+        let responseInfo = DemandResponseInfo(fetchDemandResult: .ok, bid: winningBid, configId: configID, winNotifierBlock: {
             (expectationToCall[0] as! XCTestExpectation).fulfill()
             XCTAssertEqual($0, winningBid)
             $1(adMarkupString)
-        }
+        }, bidResponse: nil)
         
         waitForExpectations(timeout: 1)
         
@@ -89,9 +90,9 @@ class DemandResponseInfoTest: XCTestCase, RawWinningBidFabricator {
     }
     
     func testGetAdMarkupString_NoBid() {
-        let responseInfo = DemandResponseInfo(fetchDemandResult: .ok, bid: nil, configId: nil) { _, _ in
+        let responseInfo = DemandResponseInfo(fetchDemandResult: .ok, bid: nil, configId: nil, winNotifierBlock: { _, _ in
             XCTFail()
-        }
+        }, bidResponse: nil)
         
         let noWinNotifierCall = expectation(description: "win notifier not called")
         noWinNotifierCall.isInverted = true
@@ -133,11 +134,11 @@ class DemandResponseInfoTest: XCTestCase, RawWinningBidFabricator {
             let expectationToCall = NSMutableArray(object: noCallExpectation)
             let adMarkupString = nextMarkup.adMarkup
             
-            let responseInfo = DemandResponseInfo(fetchDemandResult: .ok, bid: winningBid, configId: configID) {
+            let responseInfo = DemandResponseInfo(fetchDemandResult: .ok, bid: winningBid, configId: configID, winNotifierBlock: {
                 (expectationToCall[0] as! XCTestExpectation).fulfill()
                 XCTAssertEqual($0, winningBid)
                 $1(adMarkupString)
-            }
+            }, bidResponse: nil)
             
             waitForExpectations(timeout: 1)
             

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/PBMBannerViewTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/PBMBannerViewTest.swift
@@ -17,6 +17,12 @@ import XCTest
 
 @testable import PrebidMobile
 
+class MockBannerView: BannerView, WinningBidResponseFabricator {
+    override var lastBidResponse: BidResponseForRendering? {
+        return makeWinningBidResponse(bidPrice: 0.85)
+    }
+}
+
 class PBMBannerViewTest: XCTestCase {
     override func tearDown() {
         PrebidRenderingConfig.reset()
@@ -29,7 +35,7 @@ class PBMBannerViewTest: XCTestCase {
         
         let primarySize = CGSize(width: 320, height: 50)
         
-        let bannerView = BannerView(frame: CGRect(origin: .zero, size: primarySize), configID: testID, adSize: primarySize)
+        let bannerView = MockBannerView(frame: CGRect(origin: .zero, size: primarySize), configID: testID, adSize: primarySize, eventHandler: BannerEventHandlerStandalone())
         let adUnitConfig = bannerView.adUnitConfig
         
         XCTAssertEqual(adUnitConfig.configID, testID)
@@ -59,7 +65,7 @@ class PBMBannerViewTest: XCTestCase {
         PrebidRenderingConfig.shared.accountID = ""
         let primarySize = CGSize(width: 320, height: 50)
         
-        let bannerView = BannerView(frame: CGRect(origin: .zero, size: primarySize), configID: testID, adSize: primarySize)
+        let bannerView = MockBannerView(frame: CGRect(origin: .zero, size: primarySize), configID: testID, adSize: primarySize, eventHandler: BannerEventHandlerStandalone())
         let exp = expectation(description: "loading callback called")
         let delegate = TestBannerDelegate(exp: exp)
         bannerView.delegate = delegate
@@ -82,6 +88,7 @@ class PBMBannerViewTest: XCTestCase {
         
         func bannerView(_ bannerView: BannerView, didFailToReceiveAdWith error: Error) {
             XCTAssertEqual(error as NSError?, PBMError.invalidAccountId as NSError?)
+            XCTAssertNotNil(bannerView.lastBidResponse)
             exp.fulfill()
         }
         


### PR DESCRIPTION
## Description of changes
- `bidResponse` property in PBMAdLoadFlowController is public now;
- `lastBidResponse` could be read in the delegate methods `bannerView:didReceiveAdWithAdSize`, `interstitialDidReceiveAd`, `rewardedAdDidReceiveAd` ;
- some mock classes were added and some unit tests were modified  in order to test `lastBidResponse`;
- update DemandResponseInfo.