### PR TITLE
Add custom headers to bid requests

### DIFF
--- a/PrebidMobile/Prebid.swift
+++ b/PrebidMobile/Prebid.swift
@@ -34,6 +34,8 @@ import Foundation
     public var storedAuctionResponse: String = ""
     
     public var pbsDebug: Bool = false
+
+    var customHeaders: [String: String] = [:]
     
     var storedBidResponses: [String: String] = [:]
 
@@ -113,5 +115,13 @@ import Foundation
     
     public func clearStoredBidResponses() {
         storedBidResponses.removeAll()
+    }
+
+    public func addCustomHeader(name: String, value: String) {
+        customHeaders[name] = value
+    }
+
+    public func clearCustomHeaders() {
+        customHeaders.removeAll()
     }
 }

--- a/PrebidMobile/RequestBuilder.swift
+++ b/PrebidMobile/RequestBuilder.swift
@@ -75,10 +75,8 @@ class RequestBuilder: NSObject {
     }
     
     func setCustomHeaders(request: inout URLRequest) {
-        if !Prebid.shared.customHeaders.isEmpty {
-            for(headerName, headerValue) in Prebid.shared.customHeaders {
-                request.addValue(headerValue, forHTTPHeaderField: headerName)
-            }
+        for(headerName, headerValue) in Prebid.shared.customHeaders {
+            request.addValue(headerValue, forHTTPHeaderField: headerName)
         }
     }
 

--- a/PrebidMobile/RequestBuilder.swift
+++ b/PrebidMobile/RequestBuilder.swift
@@ -58,6 +58,7 @@ class RequestBuilder: NSObject {
         //HTTP HeadersExpression implicitly coerced from '[AnyHashable : Any]?' to Any
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
+        self.setCustomHeaders(request: &request)
         request.httpShouldHandleCookies = isAllowedAccessDeviceData()
         
         let gdprApplies = Targeting.shared.subjectToGDPR
@@ -71,6 +72,14 @@ class RequestBuilder: NSObject {
         Log.info("Prebid Request post body \(stringObject ?? "nil")")
         
         return request
+    }
+    
+    func setCustomHeaders(request: inout URLRequest) {
+        if !Prebid.shared.customHeaders.isEmpty {
+            for(headerName, headerValue) in Prebid.shared.customHeaders {
+                request.addValue(headerValue, forHTTPHeaderField: headerName)
+            }
+        }
     }
 
     func openRTBRequestBody(adUnit: AdUnit?) -> [AnyHashable: Any]? {

--- a/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
+++ b/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
@@ -214,6 +214,21 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         //then
         XCTAssertEqual("appdomain.com", domain)
     }
+    
+    func testPostDataWithCustomHeaders() throws {
+        let headerField = "X-JamboJambo"
+        let headerValue = "value-of-the-header-field"
+        
+        //given
+        Prebid.shared.clearCustomHeaders()
+        Prebid.shared.addCustomHeader(name: headerField, value: headerValue)
+
+        //when
+        let urlRequest = try getPostDataHelper(adUnit: adUnit).urlRequest
+
+        //then
+        XCTAssertEqual(headerValue, urlRequest.value(forHTTPHeaderField: headerField))
+    }
 
     func testPostDataWithRubiconHost() throws {
 

--- a/PrebidMobileTests/PrebidTests.swift
+++ b/PrebidMobileTests/PrebidTests.swift
@@ -120,6 +120,40 @@ class PrebidTests: XCTestCase {
         XCTAssertNotEqual(0, case1)
         XCTAssertEqual(0, case2)
     }
+
+    func testAddCustomHeader() {
+
+        //given
+        let sdkVersionHeader = "X-SDK-Version"
+        let bundleHeader = "X-Bundle"
+
+        let sdkVersion = "1.1.666"
+        let bundleName = "com.app.nextAd"
+
+        //when
+        Prebid.shared.addCustomHeader(name: sdkVersionHeader, value: sdkVersion)
+        Prebid.shared.addCustomHeader(name: bundleHeader, value: bundleName)
+
+        //then
+        let dict = Prebid.shared.customHeaders
+        XCTAssertEqual(2, dict.count)
+        XCTAssert(dict[sdkVersionHeader] == sdkVersion && dict[bundleHeader] == bundleName )
+    }
+
+    func testClearCustomHeaders() {
+
+        //given
+        Prebid.shared.addCustomHeader(name: "header", value: "value")
+        let case1 = Prebid.shared.customHeaders.count
+
+        //when
+        Prebid.shared.clearCustomHeaders()
+        let case2 = Prebid.shared.customHeaders.count
+
+        //then
+        XCTAssertNotEqual(0, case1)
+        XCTAssertEqual(0, case2)
+    }
     
     func testShareGeoLocation() {
         //given


### PR DESCRIPTION
This change makes it possible to add custom headers to requests made to Prebid server. Motivation for this change is to enable team in charge of prebid server to:

- Roll out PBS updates only on selected apps (by having two instances of PBS behind a load-balancer)
- Monitor/report on SDK version and bundle id
- Run A/B tests on selected app and SDK versions

Our colleagues also implemented this feature for Android: https://github.com/prebid/prebid-mobile-android/pull/338