### PR TITLE
Support openRTB app.name field in the Bid Request

### DIFF
--- a/PrebidMobile/RequestBuilder.swift
+++ b/PrebidMobile/RequestBuilder.swift
@@ -276,6 +276,11 @@ class RequestBuilder: NSObject {
 
         let itunesID: String? = Targeting.shared.itunesID
         let bundle = Bundle.main.bundleIdentifier
+        let bundleAppName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
+        
+        if let bundleAppName = bundleAppName {
+            app["name"] = bundleAppName
+        }
         if itunesID != nil {
             app["bundle"] = itunesID
         } else if bundle != nil {

--- a/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
+++ b/PrebidMobileTests/FetchingLogictests/RequestBuilderTests.swift
@@ -161,6 +161,17 @@ class RequestBuilderTests: XCTestCase, CLLocationManagerDelegate {
         XCTAssertEqual("12345", itunesID)
     }
     
+    func testAppName() throws {
+        let jsonRequestBody = try getPostDataHelper(adUnit: adUnit).jsonRequestBody
+        guard let app = jsonRequestBody["app"] as? [String: Any],
+              let appName = app["name"] as? String else {
+                  
+                  XCTFail("parsing error")
+                  return
+              }
+        XCTAssertFalse(appName.isEmpty)
+    }
+    
     func testPostDataVersion() throws {
 
         //when


### PR DESCRIPTION
Closes #489 
 
`app.name` ORTB parameter has been supported in original API request builder.