### PR TITLE
Server-side video ad configurations & bug fixes

### DIFF
--- a/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
@@ -889,6 +889,22 @@ struct TestCaseManager {
                         
                 setupCustomParams(for: interstitialController.prebidConfigId)
             }),
+            
+            TestCase(title: "Video Interstitial With Ad Configuration 320x480 (In-App)",
+                     tags: [.video, .inapp, .server],
+                     exampleVCStoryboardID: "AdapterViewController",
+                     configurationClosure: { vc in
+                guard let adapterVC = vc as? AdapterViewController else {
+                    return
+                }
+                let interstitialController = PrebidInterstitialController(rootController: adapterVC)
+                interstitialController.prebidConfigId = "imp-prebid-video-interstitial-320-480"
+                interstitialController.storedAuctionResponse = "response-prebid-video-interstitial-320-480-with-ad-configuration"
+                interstitialController.adFormats = [.video]
+                adapterVC.setup(adapter: interstitialController)
+                        
+                setupCustomParams(for: interstitialController.prebidConfigId)
+            }),
 
             TestCase(title: "Video Interstitial 320x480 (In-App) [noBids]",
                      tags: [.video, .inapp, .server],
@@ -1450,6 +1466,23 @@ struct TestCaseManager {
                 let rewardedAdController = PrebidRewardedController(rootController: adapterVC)
                 rewardedAdController.prebidConfigId = "imp-prebid-video-rewarded-320-480"
                 rewardedAdController.storedAuctionResponse = "response-prebid-video-rewarded-320-480"
+                adapterVC.setup(adapter: rewardedAdController)
+                        
+                setupCustomParams(for: rewardedAdController.prebidConfigId)
+            }),
+            
+            TestCase(title: "Video Rewarded With Ad Configuration 320x480 (In-App)",
+                     tags: [.video, .inapp, .server],
+                     exampleVCStoryboardID: "AdapterViewController",
+                     configurationClosure: { vc in
+                guard let adapterVC = vc as? AdapterViewController else {
+                    return
+                }
+                let rewardedAdController = PrebidRewardedController(rootController: adapterVC)
+                
+                rewardedAdController.prebidConfigId = "imp-prebid-video-rewarded-320-480"
+                
+                rewardedAdController.storedAuctionResponse = "response-prebid-video-rewarded-320-480-with-ad-configuration"
                 adapterVC.setup(adapter: rewardedAdController)
                         
                 setupCustomParams(for: rewardedAdController.prebidConfigId)

--- a/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
@@ -2217,10 +2217,17 @@ struct TestCaseManager {
                 }
                 let nativeAdController = PrebidNativeAdController(rootController: adapterVC)
                 nativeAdController.setupNativeAdView(NativeAdViewBoxLinks())
-
                 nativeAdController.prebidConfigId = "imp-prebid-native-links"
                 nativeAdController.storedAuctionResponse = "response-prebid-native-links"
-                nativeAdController.nativeAssets = .defaultNativeRequestAssets
+                         
+                Prebid.shared.shouldAssignNativeAssetID = true
+                         
+                let sponsored = NativeAssetData(type: .sponsored, required: true)
+                let rating = NativeAssetData(type: .rating, required: true)
+                let desc = NativeAssetData(type: .description, required: true)
+                let cta = NativeAssetData(type: .ctatext, required: true)
+                         
+                nativeAdController.nativeAssets = [sponsored, desc, rating, cta]
                 nativeAdController.eventTrackers = .defaultNativeEventTrackers
 
                 adapterVC.setup(adapter: nativeAdController)

--- a/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
@@ -905,6 +905,22 @@ struct TestCaseManager {
                         
                 setupCustomParams(for: interstitialController.prebidConfigId)
             }),
+            
+            TestCase(title: "Video Interstitial With Ad Configuration With End Card 320x480 (In-App)",
+                     tags: [.video, .inapp, .server],
+                     exampleVCStoryboardID: "AdapterViewController",
+                     configurationClosure: { vc in
+                guard let adapterVC = vc as? AdapterViewController else {
+                    return
+                }
+                let interstitialController = PrebidInterstitialController(rootController: adapterVC)
+                interstitialController.prebidConfigId = "imp-prebid-video-interstitial-320-480-with-end-card"
+                interstitialController.storedAuctionResponse = "response-prebid-video-interstitial-320-480-with-end-card-with-ad-configuration"
+                interstitialController.adFormats = [.video]
+                adapterVC.setup(adapter: interstitialController)
+                        
+                setupCustomParams(for: interstitialController.prebidConfigId)
+            }),
 
             TestCase(title: "Video Interstitial 320x480 (In-App) [noBids]",
                      tags: [.video, .inapp, .server],

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMNativeAdController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMNativeAdController.swift
@@ -228,6 +228,7 @@ extension PrebidGAMNativeAdController: GADNativeAdLoaderDelegate {
                     let adView = nibObjects.first as? UnifiedNativeAdView
                 else {
                     assert(false, "Could not load nib file for adView")
+                    return
                 }
                 
                 self.setAdView(adView)

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/NativeAdViewBoxLinks.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/NativeAdViewBoxLinks.swift
@@ -71,8 +71,8 @@ extension NativeAdViewBoxLinks {
     func renderNativeAd(_ nativeAd: NativeAd) {
         linkRootButton.setTitle(nativeAd.callToAction, for: .normal)
         deepLinkOkButton.setTitle(nativeAd.text, for: .normal)
-    
         sponsoredButton.setTitle(nativeAd.sponsoredBy ?? "", for: .normal)
+        ratingButton.setTitle(nativeAd.dataObjects(of: .rating).first?.value, for: .normal)
     }
     
     func registerViews(_ nativeAd: NativeAd) {

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidBannerController.swift
@@ -26,7 +26,7 @@ class PrebidBannerController: NSObject, AdaptedController, PrebidConfigurableBan
     var adSizes = [CGSize]()
     var adFormat: AdFormat?
     
-    var adBannerView : BannerView?
+    var adBannerView: BannerView?
     
     weak var rootController: AdapterViewController?
     

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidNativeAdController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidNativeAdController.swift
@@ -45,9 +45,12 @@ class PrebidNativeAdController: NSObject, AdaptedController {
         self.rootController = rootController
         rootController.showButton.isHidden = true
     }
+    
     deinit {
         Prebid.shared.storedAuctionResponse = nil
+        Prebid.shared.shouldAssignNativeAssetID = false
     }
+    
     func setupNativeAdView(_ nativeAdViewBox: NativeAdViewBoxProtocol) {
         
         self.nativeAdViewBox = nativeAdViewBox

--- a/InternalTestApp/PrebidMobileDemoRenderingUITests/UITests/PrebidServerUITests.swift
+++ b/InternalTestApp/PrebidMobileDemoRenderingUITests/UITests/PrebidServerUITests.swift
@@ -32,7 +32,7 @@ class PrebidServerUITests: AdsLoaderUITestCase {
     func testBannerWithGDPR() {
         enableGDPRIfNeeded()
         checkBannerLoadResult(exampleName: "Banner 320x50 (In-App)",
-                              expectFailure: true)
+                              expectFailure: false)
     }
     
     func testInAppBanner_noBids() {

--- a/PrebidMobile.xcodeproj/project.pbxproj
+++ b/PrebidMobile.xcodeproj/project.pbxproj
@@ -632,6 +632,7 @@
 		9236A650272FEC5A00ABBEF4 /* ImpressionTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236A64F272FEC5A00ABBEF4 /* ImpressionTask.swift */; };
 		923B55002744F19600E00C88 /* PrebidMediationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923B54FF2744F19600E00C88 /* PrebidMediationDelegate.swift */; };
 		923B5521274536B400E00C88 /* MockMediationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923B5520274536B400E00C88 /* MockMediationUtils.swift */; };
+		9247FEFE2808175E00ACD84A /* VideoControlsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9247FEFD2808175E00ACD84A /* VideoControlsConfiguration.swift */; };
 		924F661827FDB79C00C8DAF7 /* PBMORTBExtPrebidPassthrough.h in Headers */ = {isa = PBXBuildFile; fileRef = 924F661727FDB79C00C8DAF7 /* PBMORTBExtPrebidPassthrough.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		924F661A27FDB82600C8DAF7 /* PBMORTBAdConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 924F661927FDB82600C8DAF7 /* PBMORTBAdConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		924F661C27FDBA5200C8DAF7 /* PBMORTBAdConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 924F661B27FDBA5200C8DAF7 /* PBMORTBAdConfiguration.m */; };
@@ -1493,6 +1494,7 @@
 		9236A64F272FEC5A00ABBEF4 /* ImpressionTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionTask.swift; sourceTree = "<group>"; };
 		923B54FF2744F19600E00C88 /* PrebidMediationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrebidMediationDelegate.swift; sourceTree = "<group>"; };
 		923B5520274536B400E00C88 /* MockMediationUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediationUtils.swift; sourceTree = "<group>"; };
+		9247FEFD2808175E00ACD84A /* VideoControlsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoControlsConfiguration.swift; sourceTree = "<group>"; };
 		924F661727FDB79C00C8DAF7 /* PBMORTBExtPrebidPassthrough.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBMORTBExtPrebidPassthrough.h; sourceTree = "<group>"; };
 		924F661927FDB82600C8DAF7 /* PBMORTBAdConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBMORTBAdConfiguration.h; sourceTree = "<group>"; };
 		924F661B27FDBA5200C8DAF7 /* PBMORTBAdConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBMORTBAdConfiguration.m; sourceTree = "<group>"; };
@@ -2248,6 +2250,7 @@
 				5388F32527F46A7F00319FE4 /* AdViewButtonDecorator.swift */,
 				92C3A83727F98B9700DC05E9 /* AdConfiguration.swift */,
 				92EE5A0C27F9D292003D7691 /* Position.swift */,
+				9247FEFD2808175E00ACD84A /* VideoControlsConfiguration.swift */,
 			);
 			path = AdView;
 			sourceTree = "<group>";
@@ -4204,6 +4207,7 @@
 				5BC37954271F1D0000444D5E /* PBMCreativeViewabilityTracker.m in Sources */,
 				5BC37A89271F1D0000444D5E /* RewardedEventInteractionDelegate.swift in Sources */,
 				9290549227A417F00091D10D /* ImageHelper.swift in Sources */,
+				9247FEFE2808175E00ACD84A /* VideoControlsConfiguration.swift in Sources */,
 				5BC37913271F1CFF00444D5E /* PBMDownloadDataHelper.m in Sources */,
 				5BC378BE271F1CFF00444D5E /* NSMutableDictionary+PBMExtensions.m in Sources */,
 				FAEE4D17262DC2B200AD9966 /* NativeRequest.swift in Sources */,

--- a/PrebidMobile.xcodeproj/project.pbxproj
+++ b/PrebidMobile.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 		60C0381F2204AF5D0082B32C /* DispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979177962201AF5F00E624CE /* DispatcherTests.swift */; };
 		60C038242204AF5D0082B32C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97826AA621FB4F1B001E2C05 /* Constants.swift */; };
 		92028EA627F0D89E00783470 /* NativeAdConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92028EA527F0D89E00783470 /* NativeAdConfiguration.swift */; };
+		920E8D6D28084BF200E6313B /* VideoControlsConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920E8D6C28084BF200E6313B /* VideoControlsConfigTests.swift */; };
 		922AFC61273491F000732C53 /* PBMLocationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BC376BC271F1CFE00444D5E /* PBMLocationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		922AFC8827352B0100732C53 /* MockUserAgentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922AFC8727352B0100732C53 /* MockUserAgentService.swift */; };
 		922AFC8B27352BB100732C53 /* MockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922AFC8A27352BB100732C53 /* MockUserDefaults.swift */; };
@@ -1392,6 +1393,7 @@
 		60D792FB217E229B0080F428 /* PrebidMobileTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrebidMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		60D79302217E229B0080F428 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		92028EA527F0D89E00783470 /* NativeAdConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAdConfiguration.swift; sourceTree = "<group>"; };
+		920E8D6C28084BF200E6313B /* VideoControlsConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoControlsConfigTests.swift; sourceTree = "<group>"; };
 		922AFC8727352B0100732C53 /* MockUserAgentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserAgentService.swift; sourceTree = "<group>"; };
 		922AFC8927352B4C00732C53 /* PBMUserAgentService+pbmTestExtension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PBMUserAgentService+pbmTestExtension.h"; sourceTree = "<group>"; };
 		922AFC8A27352BB100732C53 /* MockUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserDefaults.swift; sourceTree = "<group>"; };
@@ -2842,6 +2844,7 @@
 				925D5D7D2737B9BE00A8A2B5 /* SkadnParametersManagerTest.swift */,
 				53EF49E827D61CAC00648F0E /* PBMAgeUtilsTest.swift */,
 				53019E6027E9E40700D509C1 /* LogTest.swift */,
+				920E8D6C28084BF200E6313B /* VideoControlsConfigTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -3810,6 +3813,7 @@
 				922AFD47273729B700732C53 /* PBMHTMLCreativeTest_MRAIDResize.swift in Sources */,
 				922AFCFD27370D8100732C53 /* PBMMRAIDControllerObjCTest.m in Sources */,
 				925D5E142737E74D00A8A2B5 /* PBMBidResponseTransformerTest.swift in Sources */,
+				920E8D6D28084BF200E6313B /* VideoControlsConfigTests.swift in Sources */,
 				FA9D7F2722E8A83D006FCBEF /* AdViewUtilsTests.swift in Sources */,
 				925D5DB32737C56000A8A2B5 /* MockBidRequester.swift in Sources */,
 				925D5DA12737C38B00A8A2B5 /* SupportedProtocolsParameterBuilderTest.swift in Sources */,

--- a/PrebidMobile.xcodeproj/project.pbxproj
+++ b/PrebidMobile.xcodeproj/project.pbxproj
@@ -632,6 +632,10 @@
 		9236A650272FEC5A00ABBEF4 /* ImpressionTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9236A64F272FEC5A00ABBEF4 /* ImpressionTask.swift */; };
 		923B55002744F19600E00C88 /* PrebidMediationDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923B54FF2744F19600E00C88 /* PrebidMediationDelegate.swift */; };
 		923B5521274536B400E00C88 /* MockMediationUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923B5520274536B400E00C88 /* MockMediationUtils.swift */; };
+		924F661827FDB79C00C8DAF7 /* PBMORTBExtPrebidPassthrough.h in Headers */ = {isa = PBXBuildFile; fileRef = 924F661727FDB79C00C8DAF7 /* PBMORTBExtPrebidPassthrough.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		924F661A27FDB82600C8DAF7 /* PBMORTBAdConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 924F661927FDB82600C8DAF7 /* PBMORTBAdConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		924F661C27FDBA5200C8DAF7 /* PBMORTBAdConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 924F661B27FDBA5200C8DAF7 /* PBMORTBAdConfiguration.m */; };
+		924F661E27FDBC3100C8DAF7 /* PBMORTBExtPrebidPassthrough.m in Sources */ = {isa = PBXBuildFile; fileRef = 924F661D27FDBC3100C8DAF7 /* PBMORTBExtPrebidPassthrough.m */; };
 		925A641627317A39009E72F9 /* HiddenWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925A641527317A39009E72F9 /* HiddenWebViewManager.swift */; };
 		925D5D6A2737B5BC00A8A2B5 /* PBMServerConnectionWithMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D5D692737B5BC00A8A2B5 /* PBMServerConnectionWithMockServer.swift */; };
 		925D5D6E2737B6B500A8A2B5 /* PBMTouchDownRecognizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D5D6D2737B6B500A8A2B5 /* PBMTouchDownRecognizerTests.swift */; };
@@ -1489,6 +1493,10 @@
 		9236A64F272FEC5A00ABBEF4 /* ImpressionTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpressionTask.swift; sourceTree = "<group>"; };
 		923B54FF2744F19600E00C88 /* PrebidMediationDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrebidMediationDelegate.swift; sourceTree = "<group>"; };
 		923B5520274536B400E00C88 /* MockMediationUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMediationUtils.swift; sourceTree = "<group>"; };
+		924F661727FDB79C00C8DAF7 /* PBMORTBExtPrebidPassthrough.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBMORTBExtPrebidPassthrough.h; sourceTree = "<group>"; };
+		924F661927FDB82600C8DAF7 /* PBMORTBAdConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PBMORTBAdConfiguration.h; sourceTree = "<group>"; };
+		924F661B27FDBA5200C8DAF7 /* PBMORTBAdConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBMORTBAdConfiguration.m; sourceTree = "<group>"; };
+		924F661D27FDBC3100C8DAF7 /* PBMORTBExtPrebidPassthrough.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PBMORTBExtPrebidPassthrough.m; sourceTree = "<group>"; };
 		925A641527317A39009E72F9 /* HiddenWebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenWebViewManager.swift; sourceTree = "<group>"; };
 		925D5D692737B5BC00A8A2B5 /* PBMServerConnectionWithMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBMServerConnectionWithMockServer.swift; sourceTree = "<group>"; };
 		925D5D6D2737B6B500A8A2B5 /* PBMTouchDownRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBMTouchDownRecognizerTests.swift; sourceTree = "<group>"; };
@@ -2426,6 +2434,10 @@
 				5BC3781D271F1CFF00444D5E /* PBMORTBBidResponseExt.h */,
 				5BC37817271F1CFF00444D5E /* PBMORTBBidResponseExt.m */,
 				5BC3781C271F1CFF00444D5E /* PBMORTBPrebid.h */,
+				924F661727FDB79C00C8DAF7 /* PBMORTBExtPrebidPassthrough.h */,
+				924F661927FDB82600C8DAF7 /* PBMORTBAdConfiguration.h */,
+				924F661B27FDBA5200C8DAF7 /* PBMORTBAdConfiguration.m */,
+				924F661D27FDBC3100C8DAF7 /* PBMORTBExtPrebidPassthrough.m */,
 			);
 			path = Prebid;
 			sourceTree = "<group>";
@@ -3501,6 +3513,7 @@
 				5BC37968271F1D0000444D5E /* PBMVastInlineAd.h in Headers */,
 				5BC3799C271F1D0000444D5E /* PBMModalViewController+Private.h in Headers */,
 				5BC378DC271F1CFF00444D5E /* PBMORTBPublisher.h in Headers */,
+				924F661A27FDB82600C8DAF7 /* PBMORTBAdConfiguration.h in Headers */,
 				5BC37960271F1D0000444D5E /* PBMVastTrackingEvents.h in Headers */,
 				5BC37906271F1CFF00444D5E /* PBMWebView+Internal.h in Headers */,
 				5BC37AC4271F1D0100444D5E /* PBMAppInfoParameterBuilder.h in Headers */,
@@ -3524,6 +3537,7 @@
 				5BC3798A271F1D0000444D5E /* PBMInterstitialDisplayProperties.h in Headers */,
 				5BC37A9D271F1D0000444D5E /* PBMAdLoadFlowController.h in Headers */,
 				5BC37921271F1CFF00444D5E /* PBMUIApplicationProtocol.h in Headers */,
+				924F661827FDB79C00C8DAF7 /* PBMORTBExtPrebidPassthrough.h in Headers */,
 				5BC378C5271F1CFF00444D5E /* NSMutableDictionary+PBMExtensions.h in Headers */,
 				5BC378C1271F1CFF00444D5E /* NSException+PBMExtensions.h in Headers */,
 				5BC37951271F1D0000444D5E /* PBMCreativeFactoryJob.h in Headers */,
@@ -4122,6 +4136,7 @@
 				5BC379C0271F1D0000444D5E /* PBMInterstitialDisplayProperties.m in Sources */,
 				5BC378AF271F1CFF00444D5E /* PBMNetworkType.m in Sources */,
 				5BC3793D271F1D0000444D5E /* PBMUserAgentService.m in Sources */,
+				924F661E27FDBC3100C8DAF7 /* PBMORTBExtPrebidPassthrough.m in Sources */,
 				5BC37A51271F1D0000444D5E /* PBMPrebidParameterBuilder.m in Sources */,
 				92C85D6427A979F20080BAC5 /* NativeLink.swift in Sources */,
 				5BC3792B271F1D0000444D5E /* PBMConstants.m in Sources */,
@@ -4129,6 +4144,7 @@
 				5BC37A61271F1D0000444D5E /* PBMORTBBidExt.m in Sources */,
 				FAEE4D13262DC2B200AD9966 /* AdUnit.swift in Sources */,
 				5BC379CF271F1D0000444D5E /* PBMAdLoadManagerBase.m in Sources */,
+				924F661C27FDBA5200C8DAF7 /* PBMORTBAdConfiguration.m in Sources */,
 				5BC379FB271F1D0000444D5E /* PBMExternalURLOpenCallbacks.m in Sources */,
 				5BC37A78271F1D0000444D5E /* PBMTransactionFactory.m in Sources */,
 				5BC37972271F1D0000444D5E /* PBMVastTrackingEvents.m in Sources */,

--- a/PrebidMobile/BuildFiles/PrebidMobile.modulemap
+++ b/PrebidMobile/BuildFiles/PrebidMobile.modulemap
@@ -150,6 +150,8 @@ framework module PrebidMobile {
     header "PBMORTBBidExt.h"
     header "PBMORTBSeatBid.h"
     header "PBMORTBBidExtPrebid.h"
+    header "PBMORTBExtPrebidPassthrough.h"
+    header "PBMORTBAdConfiguration.h"
     header "PBMORTBBidExtSkadn.h"
     header "PBMORTBSkadnFidelity.h"
     header "PBMORTBMacrosHelper.h"

--- a/PrebidMobile/BuildFiles/PrebidMobileSwiftHeaders.h
+++ b/PrebidMobile/BuildFiles/PrebidMobileSwiftHeaders.h
@@ -28,6 +28,7 @@
 // Bid
 #import "PBMORTBBid.h"
 #import "PBMORTBBidExt.h"
+#import "PBMORTBAdConfiguration.h"
 #import "PBMRawBidResponse.h"
 #import "PBMLocationManager.h"
 #import "Log+Extensions.h"

--- a/PrebidMobile/Dispatcher.swift
+++ b/PrebidMobile/Dispatcher.swift
@@ -31,7 +31,7 @@ class Dispatcher: NSObject {
 
     var timer: Timer?
 
-    var delegate: DispatcherDelegate!
+    weak var delegate: DispatcherDelegate!
 
     var repeatInSeconds: Double = 0
     

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/AdConfiguration.swift
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/AdConfiguration.swift
@@ -88,78 +88,9 @@ public class AdConfiguration: AutoRefreshCountConfig {
     public var winningBidAdFormat: AdFormat?
     
     /**
-     This property indicates whether the ad should run playback with sound or not.
+     This property represents video controls custom configuration.
      */
-    public var isMuted = true
-    
-    /**
-     This property indicates whether mute controls is visible on the screen.
-     */
-    public var isSoundButtonVisible = false
-    
-    /**
-     This property indicates the area which the close button should occupy on the screen.
-     */
-    public var closeButtonArea: Double {
-        set {
-            if newValue <= 1 && newValue >= 0 {
-                _closeButtonArea = newValue
-            } else {
-                Log.warn("The possible values for close button area value are [0...1]")
-            }
-        }
-        get { _closeButtonArea }
-    }
-    
-    /**
-     This property indicates the position of the close button on the screen.
-     */
-    public var closeButtonPosition: Position {
-        set {
-            if ![Position.topRight, Position.topLeft].contains(newValue) {
-                Log.warn("There are two options available for close button posiiton for now: topLeft anf topRight.")
-                return
-            }
-            _closeButtonPosition = newValue
-        }
-        
-        get { _closeButtonPosition }
-    }
-    
-    /**
-     This property indicates the area which the skip button should occupy on the screen.
-     */
-    public var skipButtonArea: Double {
-        set {
-            if newValue <= 1 && newValue >= 0 {
-                _skipButtonArea = newValue
-            } else {
-                Log.warn("The possible values for skip button area value are [0...1]")
-            }
-        }
-        
-        get { _skipButtonArea }
-    }
-    
-    /**
-     This property indicates the position of the skip button on the screen.
-     */
-    public var skipButtonPosition: Position {
-        set {
-            if ![Position.topRight, Position.topLeft].contains(newValue) {
-                Log.warn("There are two options available for skip button posiiton for now: topLeft anf topRight.")
-                return
-            }
-            _skipButtonPosition = newValue
-        }
-        
-        get { _skipButtonPosition }
-    }
-    
-    /**
-     This property indicates the number of seconds which should be passed from the start of playback until the skip or close button should be shown.
-     */
-    public var skipDelay = PBMConstants.SKIP_DELAY_DEFAULT.doubleValue
+    public lazy var videoControlsConfig = VideoControlsConfiguration()
     
     // MARK: - Impression Tracking
     
@@ -192,10 +123,4 @@ public class AdConfiguration: AutoRefreshCountConfig {
     // MARK: Private properties
     
     private var _autoRefreshDelay: TimeInterval? = PBMAutoRefresh.AUTO_REFRESH_DELAY_DEFAULT
-    
-    private var _closeButtonArea = PBMConstants.BUTTON_AREA_DEFAULT.doubleValue
-    private var _closeButtonPosition = Position.topRight
-    
-    private var _skipButtonArea = PBMConstants.BUTTON_AREA_DEFAULT.doubleValue
-    private var _skipButtonPosition = Position.topRight
 }

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/AdViewButtonDecorator.swift
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/AdViewButtonDecorator.swift
@@ -142,7 +142,7 @@ public class AdViewButtonDecorator: NSObject {
     }
     
     // MARK: - Private properties
-    private var displayView: UIView?
+    private weak var displayView: UIView?
     private var buttonImage: UIImage?
     private var activeConstraints: [NSLayoutConstraint]?
 }

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/Modals/PBMModalViewController.m
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/Modals/PBMModalViewController.m
@@ -243,8 +243,8 @@
         PBMWebView *webView = (PBMWebView *)self.modalState.view;
         self.closeButtonDecorator.isMRAID = webView.isMRAID;        
     }    
-    self.closeButtonDecorator.buttonArea = self.modalState.adConfiguration.closeButtonArea;
-    self.closeButtonDecorator.buttonPosition = self.modalState.adConfiguration.closeButtonPosition;
+    self.closeButtonDecorator.buttonArea = self.modalState.adConfiguration.videoControlsConfig.closeButtonArea;
+    self.closeButtonDecorator.buttonPosition = self.modalState.adConfiguration.videoControlsConfig.closeButtonPosition;
     [self.closeButtonDecorator setImage:[self.displayProperties getCloseButtonImage]];
     [self.closeButtonDecorator addButtonTo:self.view displayView:self.displayView];
     [self setupCloseButtonVisibility];

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMCreativeModelCollectionMakerVAST.m
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMCreativeModelCollectionMakerVAST.m
@@ -135,9 +135,13 @@
         [PBMError createError:error description:errorMessage statusCode:PBMErrorCodeGeneral];
         return nil;
     }
-
-    if (self.adConfiguration.videoParameters.maxDuration.value && creative.duration > self.adConfiguration.videoParameters.maxDuration.value) {
-        NSString *errorMessage = @"Creative duration is bigger than maximum available playback time.";
+    
+    if (self.adConfiguration.videoControlsConfig.maxVideoDuration && creative.duration > self.adConfiguration.videoControlsConfig.maxVideoDuration.doubleValue) {
+        NSString *errorMessage = @"Creative duration is bigger than maximum available playback time obtained from server response.";
+        [PBMError createError:error description:errorMessage statusCode:PBMErrorCodeGeneral];
+        return nil;
+    } else if (self.adConfiguration.videoParameters.maxDuration.value && creative.duration > self.adConfiguration.videoParameters.maxDuration.value) {
+        NSString *errorMessage = @"Creative duration is bigger than maximum available playback time set by the user.";
         [PBMError createError:error description:errorMessage statusCode:PBMErrorCodeGeneral];
         return nil;
     }

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMVideoCreative.m
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMVideoCreative.m
@@ -96,7 +96,7 @@
     @weakify(self);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         @strongify(self);
-        if (self.creativeModel.adConfiguration.isMuted) {
+        if (self.creativeModel.adConfiguration.videoControlsConfig.isMuted) {
             [self.videoView mute];
         } else {
             [self.videoView unmute];
@@ -279,8 +279,8 @@
 - (NSTimeInterval)calculateCloseDelayForPubCloseDelay:(NSTimeInterval)pubCloseDelay {
     if (self.creativeModel.adConfiguration.isOptIn || self.creativeModel.hasCompanionAd) {
         return [self.creativeModel.displayDurationInSeconds doubleValue];
-    } else if (self.creativeModel.adConfiguration.skipDelay && self.creativeModel.adConfiguration.skipDelay <= self.creativeModel.displayDurationInSeconds.doubleValue) {
-        return self.creativeModel.adConfiguration.skipDelay;
+    } else if (self.creativeModel.adConfiguration.videoControlsConfig.skipDelay && self.creativeModel.adConfiguration.videoControlsConfig.skipDelay <= self.creativeModel.displayDurationInSeconds.doubleValue) {
+        return self.creativeModel.adConfiguration.videoControlsConfig.skipDelay;
     } else if (self.creativeModel.skipOffset && self.creativeModel.skipOffset.doubleValue <= self.creativeModel.displayDurationInSeconds.doubleValue) {
         return [self.creativeModel.skipOffset doubleValue];
     } else {

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMVideoCreative.m
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMVideoCreative.m
@@ -140,7 +140,7 @@
 }
 
 - (BOOL)isPlaybackFinished {
-    return self.videoView.vastDurationHasEnded;
+    return self.videoView.isPlaybackFinished;
 }
 
 - (void)createOpenMeasurementSession {

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.h
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.h
@@ -37,7 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Indicates that video reached the VAST Duration
 // We must use this flag instead of player’s state to prevent double-stopping of the video due to async work of observers.
-@property (nonatomic, assign, readonly) BOOL vastDurationHasEnded;
+@property (nonatomic, assign, readonly) BOOL isPlaybackFinished;
 
 @property (nonatomic, assign) BOOL isSoundButtonVisible;
 

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m
@@ -159,7 +159,7 @@ static CGSize const MUTE_BUTTON_SIZE = { 24, 24 };
     
     [self setupSkipButton];
     
-    self.isSoundButtonVisible = self.creative.creativeModel.adConfiguration.isSoundButtonVisible;
+    self.isSoundButtonVisible = self.creative.creativeModel.adConfiguration.videoControlsConfig.isSoundButtonVisible;
 }
 
 #pragma mark - Public
@@ -454,8 +454,8 @@ static CGSize const MUTE_BUTTON_SIZE = { 24, 24 };
 - (void)setupSkipButton {
     self.skipButtonDecorator = [AdViewButtonDecorator new];
     self.skipButtonDecorator.button.hidden = YES;
-    self.skipButtonDecorator.buttonArea = self.creative.creativeModel.adConfiguration.skipButtonArea;
-    self.skipButtonDecorator.buttonPosition = self.creative.creativeModel.adConfiguration.skipButtonPosition;
+    self.skipButtonDecorator.buttonArea = self.creative.creativeModel.adConfiguration.videoControlsConfig.skipButtonArea;
+    self.skipButtonDecorator.buttonPosition = self.creative.creativeModel.adConfiguration.videoControlsConfig.skipButtonPosition;
     
     UIImage *skipButtonImage = [UIImage imageNamed:@"PBM_skipButton" inBundle:[PBMFunctions bundleForSDK] compatibleWithTraitCollection:nil];
     
@@ -482,7 +482,7 @@ static CGSize const MUTE_BUTTON_SIZE = { 24, 24 };
         return;
     }
     
-    dispatch_time_t dispatchTime = [PBMFunctions dispatchTimeAfterTimeInterval:self.creative.creativeModel.adConfiguration.skipDelay];
+    dispatch_time_t dispatchTime = [PBMFunctions dispatchTimeAfterTimeInterval:self.creative.creativeModel.adConfiguration.videoControlsConfig.skipDelay];
     @weakify(self);
     dispatch_after(dispatchTime, dispatch_get_main_queue(), ^{
         @strongify(self);
@@ -610,7 +610,7 @@ static CGSize const MUTE_BUTTON_SIZE = { 24, 24 };
 
     [self.avPlayer play];
     
-    [self handleSkipDelay:self.creative.creativeModel.adConfiguration.skipDelay videoDuration:self.creative.creativeModel.displayDurationInSeconds.doubleValue];
+    [self handleSkipDelay:self.creative.creativeModel.adConfiguration.videoControlsConfig.skipDelay videoDuration:self.creative.creativeModel.displayDurationInSeconds.doubleValue];
 
     if (!self.isPlaybackStarted) {
         self.isPlaybackStarted = YES;

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/Position.swift
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/Position.swift
@@ -25,4 +25,15 @@ import Foundation
     case bottomCenter
     case bottomRight
     case custom
+    
+    public static func getPositionByStringLiteral(_ stringValue: String) -> Position? {
+        switch stringValue {
+        case "topleft":
+            return .topLeft
+        case "topright":
+            return .topRight
+        default:
+            return nil
+        }
+    }
 }

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/VideoControlsConfiguration.swift
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/VideoControlsConfiguration.swift
@@ -1,0 +1,154 @@
+/*   Copyright 2018-2021 Prebid.org, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+@objcMembers
+public class VideoControlsConfiguration: NSObject {
+    
+    /**
+     This property indicates maximum video duration.
+     Obtained from the field ext,prebid.passthrough[].adConfiguration.maxvideoduration.
+     */
+    private(set) public var maxVideoDuration: NSNumber?
+    
+    /**
+     This property indicates whether the ad should run playback with sound or not.
+     Obtained from the field ext,prebid.passthrough[].adConfiguration.ismuted or set by user.
+     */
+    public var isMuted: Bool = true
+    
+    /**
+     This property indicates the area which the close button should occupy on the screen.
+     Obtained from the field ext,prebid.passthrough[].adConfiguration.closebuttonarea or set by user.
+     */
+    public var closeButtonArea: Double {
+        set {
+            if newValue <= 1 && newValue >= 0 {
+                _closeButtonArea = newValue
+            } else {
+                Log.warn("The possible values for close button area value are [0...1]")
+            }
+        }
+        get { _closeButtonArea }
+    }
+    
+    /**
+     This property indicates the position of the close button on the screen.
+     Obtained from the field ext,prebid.passthrough[].adConfiguration.closebuttonposition or set by user.
+     */
+    public var closeButtonPosition: Position {
+        set {
+            if ![Position.topRight, Position.topLeft].contains(newValue) {
+                Log.warn("There are two options available for close button posiiton for now: topLeft anf topRight.")
+                return
+            }
+            _closeButtonPosition = newValue
+        }
+        
+        get { _closeButtonPosition }
+    }
+    
+    /**
+     This property indicates the area which the skip button should occupy on the screen.
+     Obtained from the field ext,prebid.passthrough[].adConfiguration.skipbuttonarea or set by user.
+     */
+    public var skipButtonArea: Double {
+        set {
+            if newValue <= 1 && newValue >= 0 {
+                _skipButtonArea = newValue
+            } else {
+                Log.warn("The possible values for skip button area value are [0...1]")
+            }
+        }
+        
+        get { _skipButtonArea }
+    }
+    
+    /**
+     This property indicates the position of the skip button on the screen.
+     Obtained from the field ext,prebid.passthrough[].adConfiguration.skipbuttonposition or set by user.
+     */
+    public var skipButtonPosition: Position {
+        set {
+            if ![Position.topRight, Position.topLeft].contains(newValue) {
+                Log.warn("There are two options available for skip button posiiton for now: topLeft anf topRight.")
+                return
+            }
+            _skipButtonPosition = newValue
+        }
+        
+        get { _skipButtonPosition }
+    }
+    
+    /**
+     This property indicates the number of seconds which should be passed from the start of playback until the skip or close button should be shown.
+     Obtained from the field ext,prebid.passthrough[].adConfiguration.skipdelay or set by user.
+     */
+    public var skipDelay = PBMConstants.SKIP_DELAY_DEFAULT.doubleValue
+    
+    /**
+     This property indicates whether mute controls is visible on the screen.
+     */
+    public var isSoundButtonVisible = false
+    
+    /**
+     Use to initialize video controls with server values.
+     */
+    public func initialize(with ortbAdConfiguration: PBMORTBAdConfiguration?) {
+        
+        guard let ortbAdConfiguration = ortbAdConfiguration else {
+            return
+        }
+        
+        maxVideoDuration = ortbAdConfiguration.maxVideoDuration
+        
+        if let ortbIsMuted = ortbAdConfiguration.isMuted {
+            isMuted = ortbIsMuted.boolValue
+        }
+    
+        if let ortbCloseButtonArea = ortbAdConfiguration.closeButtonArea {
+            closeButtonArea = ortbCloseButtonArea.doubleValue
+        }
+        
+        if let ortbCloseButtonPosition = ortbAdConfiguration.closeButtonPosition {
+            if let closeButtonPosition = Position.getPositionByStringLiteral(ortbCloseButtonPosition) {
+                self.closeButtonPosition = closeButtonPosition
+            }
+        }
+        
+        if let ortbSkipButtonArea = ortbAdConfiguration.skipButtonArea {
+            skipButtonArea = ortbSkipButtonArea.doubleValue
+        }
+        
+        if let ortbSkipButtonPosition = ortbAdConfiguration.skipButtonPosition {
+            if let skipButtonPosition = Position.getPositionByStringLiteral(ortbSkipButtonPosition) {
+                self.skipButtonPosition = skipButtonPosition
+            }
+        }
+        
+        if let ortbSkipDelay = ortbAdConfiguration.skipDelay {
+            skipDelay = ortbSkipDelay.doubleValue
+        }
+    }
+    
+    // MARK: - Private properties
+    
+    private var _closeButtonArea = PBMConstants.BUTTON_AREA_DEFAULT.doubleValue
+    private var _closeButtonPosition = Position.topRight
+    
+    private var _skipButtonArea = PBMConstants.BUTTON_AREA_DEFAULT.doubleValue
+    private var _skipButtonPosition = Position.topRight
+}

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
@@ -60,23 +60,23 @@ public class BaseInterstitialAdUnit :
     }
 
     @objc public var isMuted: Bool {
-        get { adUnitConfig.adConfiguration.isMuted }
-        set { adUnitConfig.adConfiguration.isMuted = newValue }
+        get { adUnitConfig.adConfiguration.videoControlsConfig.isMuted }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.isMuted = newValue }
     }
 
     @objc public var isSoundButtonVisible: Bool {
-        get { adUnitConfig.adConfiguration.isSoundButtonVisible }
-        set { adUnitConfig.adConfiguration.isSoundButtonVisible = newValue }
+        get { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
 
     @objc public var closeButtonArea: Double {
-        get { adUnitConfig.adConfiguration.closeButtonArea }
-        set { adUnitConfig.adConfiguration.closeButtonArea = newValue }
+        get { adUnitConfig.adConfiguration.videoControlsConfig.closeButtonArea }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.closeButtonArea = newValue }
     }
 
     @objc public var closeButtonPosition: Position {
-        get { adUnitConfig.adConfiguration.closeButtonPosition }
-        set { adUnitConfig.adConfiguration.closeButtonPosition = newValue }
+        get { adUnitConfig.adConfiguration.videoControlsConfig.closeButtonPosition }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.closeButtonPosition = newValue }
     }
 
     @objc public weak var delegate: AnyObject?
@@ -98,8 +98,8 @@ public class BaseInterstitialAdUnit :
     // MARK: - Public Methods
     
     required public init(configID: String,
-                minSizePerc: NSValue?,
-                eventHandler: AnyObject?) {
+                         minSizePerc: NSValue?,
+                         eventHandler: AnyObject?) {
         
         adUnitConfig = AdUnitConfig(configId: configID)
         adUnitConfig.adConfiguration.isInterstitialAd = true

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
@@ -19,18 +19,18 @@ import UIKit
 public class InterstitialRenderingAdUnit: BaseInterstitialAdUnit {
     
     @objc public var skipButtonArea: Double {
-        get { adUnitConfig.adConfiguration.skipButtonArea }
-        set { adUnitConfig.adConfiguration.skipButtonArea = newValue }
+        get { adUnitConfig.adConfiguration.videoControlsConfig.skipButtonArea }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.skipButtonArea = newValue }
     }
     
     @objc public var skipButtonPosition: Position {
-        get { adUnitConfig.adConfiguration.skipButtonPosition }
-        set { adUnitConfig.adConfiguration.skipButtonPosition = newValue }
+        get { adUnitConfig.adConfiguration.videoControlsConfig.skipButtonPosition }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.skipButtonPosition = newValue }
     }
     
     @objc public var skipDelay: Double {
-        get { adUnitConfig.adConfiguration.skipDelay }
-        set { adUnitConfig.adConfiguration.skipDelay = newValue }
+        get { adUnitConfig.adConfiguration.videoControlsConfig.skipDelay }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.skipDelay = newValue }
     }
 
     @objc public init(configID: String) {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCacheRenderers/InterstitialController.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCacheRenderers/InterstitialController.swift
@@ -61,6 +61,12 @@ public class InterstitialController: NSObject, PBMAdViewManagerDelegate {
         adConfiguration.adConfiguration.winningBidAdFormat = bid.adFormat
         adConfiguration.adConfiguration.videoControlsConfig.initialize(with: bid.videoAdConfiguration)
         
+        // This part is dedicating to test server-side ad configurations.
+        // Need to be removed when ext.prebid.passthrough will be available.
+        #if DEBUG
+        adConfiguration.adConfiguration.videoControlsConfig.initialize(with: bid.testVideoAdConfiguration)
+        #endif
+        
         transactionFactory = PBMTransactionFactory(bid: bid,
                                                    adConfiguration: adConfiguration,
                                                    connection: PBMServerConnection.shared,

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCacheRenderers/InterstitialController.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCacheRenderers/InterstitialController.swift
@@ -57,7 +57,10 @@ public class InterstitialController: NSObject, PBMAdViewManagerDelegate {
         guard transactionFactory == nil else {
             return
         }
+        
         adConfiguration.adConfiguration.winningBidAdFormat = bid.adFormat
+        adConfiguration.adConfiguration.videoControlsConfig.initialize(with: bid.videoAdConfiguration)
+        
         transactionFactory = PBMTransactionFactory(bid: bid,
                                                    adConfiguration: adConfiguration,
                                                    connection: PBMServerConnection.shared,

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
@@ -237,13 +237,7 @@ public class AdUnitConfig: NSObject, NSCopying {
         clone.nativeAdConfiguration = self.nativeAdConfiguration
         clone.adConfiguration.bannerParameters = self.adConfiguration.bannerParameters
         clone.adConfiguration.videoParameters = self.adConfiguration.videoParameters
-        clone.adConfiguration.isMuted = self.adConfiguration.isMuted
-        clone.adConfiguration.isSoundButtonVisible = self.adConfiguration.isSoundButtonVisible
-        clone.adConfiguration.closeButtonPosition = self.adConfiguration.closeButtonPosition
-        clone.adConfiguration.closeButtonArea = self.adConfiguration.closeButtonArea
-        clone.adConfiguration.skipButtonArea = self.adConfiguration.skipButtonArea
-        clone.adConfiguration.skipButtonPosition = self.adConfiguration.skipButtonPosition
-        clone.adConfiguration.skipDelay = self.adConfiguration.skipDelay
+        clone.adConfiguration.videoControlsConfig = self.adConfiguration.videoControlsConfig
         clone.sizes = sizes
         clone.refreshInterval = self.refreshInterval
         clone.minSizePerc = self.minSizePerc

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/Bid.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/Bid.swift
@@ -64,6 +64,14 @@ public class Bid: NSObject {
         bid.ext.prebid?.passthrough?.filter { $0.type == "prebidmobilesdk" }.first?.adConfiguration
     }
     
+    // This part is dedicating to test server-side ad configurations.
+    // Need to be removed when ext.prebid.passthrough will be available.
+    #if DEBUG
+    @objc public var testVideoAdConfiguration: PBMORTBAdConfiguration? {
+        bid.ext.passthrough?.filter { $0.type == "prebidmobilesdk" }.first?.adConfiguration
+    }
+    #endif
+    
     /// Returns YES if this bid is intented for display.
     @objc public var isWinning: Bool {
         guard let targetingInfo = self.targetingInfo else {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/Bid.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/Bid.swift
@@ -59,6 +59,11 @@ public class Bid: NSObject {
         AdFormat.allCases.filter { $0.stringEquivalent == bid.ext.prebid?.type }.first
     }
     
+    /// Prebid video ad configuration
+    @objc public var videoAdConfiguration: PBMORTBAdConfiguration? {
+        bid.ext.prebid?.passthrough?.filter { $0.type == "prebidmobilesdk" }.first?.adConfiguration
+    }
+    
     /// Returns YES if this bid is intented for display.
     @objc public var isWinning: Bool {
         guard let targetingInfo = self.targetingInfo else {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBAdConfiguration.h
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBAdConfiguration.h
@@ -15,18 +15,25 @@
 
 #import "PBMORTBAbstract.h"
 
-@class PBMORTBBidExtPrebidCache;
-@class PBMORTBExtPrebidPassthrough;
-
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PBMORTBBidExtPrebid : PBMORTBAbstract
+@interface PBMORTBAdConfiguration: PBMORTBAbstract
 
-@property (nonatomic, strong, nullable) PBMORTBBidExtPrebidCache *cache;
-@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *targeting;
-@property (nonatomic, copy, nullable) NSString *type;
-@property (nonatomic, copy, nullable) NSArray<PBMORTBExtPrebidPassthrough *> *passthrough;
+@property (nonatomic, copy, nullable) NSNumber *maxVideoDuration;
+
+@property (nonatomic, copy, nullable) NSNumber *isMuted;
+
+@property (nonatomic, copy, nullable) NSNumber *closeButtonArea;
+
+@property (nonatomic, copy, nullable) NSString *closeButtonPosition;
+
+@property (nonatomic, copy, nullable) NSNumber *skipButtonArea;
+
+@property (nonatomic, copy, nullable) NSString *skipButtonPosition;
+
+@property (nonatomic, copy, nullable) NSNumber *skipDelay;
 
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBAdConfiguration.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBAdConfiguration.m
@@ -1,0 +1,53 @@
+/*   Copyright 2018-2021 Prebid.org, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "PBMORTBAbstract+Protected.h"
+#import "PBMORTBAdConfiguration.h"
+
+@implementation PBMORTBAdConfiguration
+
+- (instancetype)initWithJsonDictionary:(PBMJsonDictionary *)jsonDictionary {
+    if (!(self = [super init])) {
+        return nil;
+    }
+    
+    _maxVideoDuration = jsonDictionary[@"maxvideoduration"];
+    _isMuted = jsonDictionary[@"ismuted"];
+    _closeButtonArea = jsonDictionary[@"closebuttonarea"];
+    _closeButtonPosition = jsonDictionary[@"closebuttonposition"];
+    _skipButtonArea = jsonDictionary[@"skipbuttonarea"];
+    _skipButtonPosition = jsonDictionary[@"skipButtonPossition"];
+    _skipDelay = jsonDictionary[@"skipdelay"];
+    
+    return self;
+}
+
+- (PBMJsonDictionary *)toJsonDictionary {
+    PBMMutableJsonDictionary * const ret = [[PBMMutableJsonDictionary alloc] init];
+    
+    ret[@"maxvideoduration"] = self.maxVideoDuration;
+    ret[@"ismuted"] = self.isMuted;
+    ret[@"closebuttonarea"] = self.closeButtonArea;
+    ret[@"closebuttonposition"] = self.closeButtonPosition;
+    ret[@"skipbuttonarea"] = self.skipButtonArea;
+    ret[@"skipButtonPossition"] = self.skipButtonPosition;
+    ret[@"skipdelay"] = self.maxVideoDuration;
+    
+    [ret pbmRemoveEmptyVals];
+    
+    return ret;
+}
+
+@end

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBAdConfiguration.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBAdConfiguration.m
@@ -28,7 +28,7 @@
     _closeButtonArea = jsonDictionary[@"closebuttonarea"];
     _closeButtonPosition = jsonDictionary[@"closebuttonposition"];
     _skipButtonArea = jsonDictionary[@"skipbuttonarea"];
-    _skipButtonPosition = jsonDictionary[@"skipButtonPossition"];
+    _skipButtonPosition = jsonDictionary[@"skipbuttonposition"];
     _skipDelay = jsonDictionary[@"skipdelay"];
     
     return self;

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBBidExt.h
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBBidExt.h
@@ -18,6 +18,10 @@
 @class PBMORTBBidExtPrebid;
 @class PBMORTBBidExtSkadn;
 
+#if DEBUG
+@class PBMORTBExtPrebidPassthrough;
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface PBMORTBBidExt : PBMORTBAbstract
@@ -26,6 +30,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) NSDictionary *bidder;
 
 @property (nonatomic, strong, nullable) PBMORTBBidExtSkadn *skadn;
+
+// This part is dedicating to test server-side ad configurations.
+// Need to be removed when ext.prebid.passthrough will be available.
+#if DEBUG
+@property (nonatomic, copy, nullable) NSArray<PBMORTBExtPrebidPassthrough *> *passthrough;
+#endif
 
 @end
 

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBBidExt.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBBidExt.m
@@ -19,6 +19,10 @@
 #import "PBMORTBBidExtPrebid.h"
 #import "PBMORTBBidExtSkadn.h"
 
+#if DEBUG
+#import "PBMORTBExtPrebidPassthrough.h"
+#endif
+
 @implementation PBMORTBBidExt
 
 - (instancetype)initWithJsonDictionary:(PBMJsonDictionary *)jsonDictionary {
@@ -38,6 +42,23 @@
         _skadn = [[PBMORTBBidExtSkadn alloc] initWithJsonDictionary:skadnDict];
     }
     
+    #if DEBUG
+    NSArray * const passthroughDics = jsonDictionary[@"passthrough"];
+    _passthrough = nil;
+    if (passthroughDics) {
+        NSMutableArray * const newPassthrough = [[NSMutableArray alloc] initWithCapacity:passthroughDics.count];
+        for(PBMJsonDictionary *nextDic in passthroughDics) {
+            PBMORTBExtPrebidPassthrough * const nextPassthrough = [[PBMORTBExtPrebidPassthrough alloc] initWithJsonDictionary:nextDic];
+            if (nextPassthrough) {
+                [newPassthrough addObject:nextPassthrough];
+            }
+        }
+        if (newPassthrough.count > 0) {
+            _passthrough = newPassthrough;
+        }
+    }
+    #endif
+    
     return self;
 }
 
@@ -47,6 +68,17 @@
     ret[@"bidder"] = self.bidder;
     ret[@"prebid"] = [self.prebid toJsonDictionary];
     ret[@"skadn"] = [self.skadn toJsonDictionary];
+    
+    #if DEBUG
+    NSMutableArray * const passthroughDicArr = [[NSMutableArray alloc] initWithCapacity:self.passthrough.count];
+    for(PBMORTBExtPrebidPassthrough *nextPassthrough in self.passthrough) {
+        [passthroughDicArr addObject:[nextPassthrough toJsonDictionary]];
+    }
+    
+    if (passthroughDicArr.count > 0) {
+        ret[@"passthrough"] = passthroughDicArr;
+    }
+    #endif
     
     [ret pbmRemoveEmptyVals];
     

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBBidExtPrebid.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBBidExtPrebid.m
@@ -17,6 +17,7 @@
 #import "PBMORTBAbstract+Protected.h"
 
 #import "PBMORTBBidExtPrebidCache.h"
+#import "PBMORTBExtPrebidPassthrough.h"
 
 @implementation PBMORTBBidExtPrebid
 
@@ -33,6 +34,19 @@
     _targeting = jsonDictionary[@"targeting"];
     _type = jsonDictionary[@"type"];
     
+    NSArray * const passthroughDics = jsonDictionary[@"passthrough"];
+    _passthrough = nil;
+    if (passthroughDics) {
+        NSMutableArray * const newPassthrough = [[NSMutableArray alloc] initWithCapacity:passthroughDics.count];
+        for(PBMJsonDictionary *nextDic in passthroughDics) {
+            PBMORTBExtPrebidPassthrough * const nextPassthrough = [[PBMORTBExtPrebidPassthrough alloc] initWithJsonDictionary:nextDic];
+            if (nextPassthrough) {
+                [newPassthrough addObject:nextPassthrough];
+            }
+        }
+        _passthrough = newPassthrough;
+    }
+    
     return self;
 }
 
@@ -42,6 +56,12 @@
     ret[@"cache"] = [self.cache toJsonDictionary];
     ret[@"targeting"] = self.targeting;
     ret[@"type"] = self.type;
+    
+    NSMutableArray * const passthroughDicArr = [[NSMutableArray alloc] initWithCapacity:self.passthrough.count];
+    for(PBMORTBExtPrebidPassthrough *nextPassthrough in self.passthrough) {
+        [passthroughDicArr addObject:[nextPassthrough toJsonDictionary]];
+    }
+    ret[@"passthrough"] = passthroughDicArr;
     
     [ret pbmRemoveEmptyVals];
     

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBBidExtPrebid.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBBidExtPrebid.m
@@ -44,7 +44,9 @@
                 [newPassthrough addObject:nextPassthrough];
             }
         }
-        _passthrough = newPassthrough;
+        if (newPassthrough.count > 0) {
+            _passthrough = newPassthrough;
+        }
     }
     
     return self;
@@ -61,7 +63,10 @@
     for(PBMORTBExtPrebidPassthrough *nextPassthrough in self.passthrough) {
         [passthroughDicArr addObject:[nextPassthrough toJsonDictionary]];
     }
-    ret[@"passthrough"] = passthroughDicArr;
+    
+    if (passthroughDicArr.count > 0) {
+        ret[@"passthrough"] = passthroughDicArr;
+    }
     
     [ret pbmRemoveEmptyVals];
     

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBExtPrebidPassthrough.h
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBExtPrebidPassthrough.h
@@ -15,18 +15,17 @@
 
 #import "PBMORTBAbstract.h"
 
-@class PBMORTBBidExtPrebidCache;
-@class PBMORTBExtPrebidPassthrough;
+@class PBMORTBAdConfiguration;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface PBMORTBBidExtPrebid : PBMORTBAbstract
+@interface PBMORTBExtPrebidPassthrough: PBMORTBAbstract
 
-@property (nonatomic, strong, nullable) PBMORTBBidExtPrebidCache *cache;
-@property (nonatomic, copy, nullable) NSDictionary<NSString *, NSString *> *targeting;
 @property (nonatomic, copy, nullable) NSString *type;
-@property (nonatomic, copy, nullable) NSArray<PBMORTBExtPrebidPassthrough *> *passthrough;
+
+@property (nonatomic, strong, nullable) PBMORTBAdConfiguration *adConfiguration;
 
 @end
 
 NS_ASSUME_NONNULL_END
+

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBExtPrebidPassthrough.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBExtPrebidPassthrough.m
@@ -1,0 +1,50 @@
+/*   Copyright 2018-2021 Prebid.org, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "PBMORTBAbstract+Protected.h"
+#import "PBMORTBExtPrebidPassthrough.h"
+#import "PBMORTBAdConfiguration.h"
+
+@implementation PBMORTBExtPrebidPassthrough
+
+- (instancetype)initWithJsonDictionary:(PBMJsonDictionary *)jsonDictionary {
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    _type = jsonDictionary[@"type"];
+    
+    PBMJsonDictionary * const adConfigDic = jsonDictionary[@"adConfiguration"];
+    
+    if (adConfigDic) {
+        _adConfiguration = [[PBMORTBAdConfiguration alloc] initWithJsonDictionary:adConfigDic];
+    }
+    
+    return self;
+}
+
+- (PBMJsonDictionary *)toJsonDictionary {
+    PBMMutableJsonDictionary * const ret = [[PBMMutableJsonDictionary alloc] init];
+    
+    ret[@"type"] = self.type;
+    
+    ret[@"adConfiguration"] = [self.adConfiguration toJsonDictionary];
+    
+    [ret pbmRemoveEmptyVals];
+    
+    return ret;
+}
+
+@end

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBExtPrebidPassthrough.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBExtPrebidPassthrough.m
@@ -26,7 +26,7 @@
 
     _type = jsonDictionary[@"type"];
     
-    PBMJsonDictionary * const adConfigDic = jsonDictionary[@"adConfiguration"];
+    PBMJsonDictionary * const adConfigDic = jsonDictionary[@"adconfiguration"];
     
     if (adConfigDic) {
         _adConfiguration = [[PBMORTBAdConfiguration alloc] initWithJsonDictionary:adConfigDic];

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBPrebid.h
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/PBMORTBPrebid.h
@@ -25,6 +25,7 @@
 // MARK: response.seatbid[?].bid[?].ext
 #import "PBMORTBBidExt.h"
 #import "PBMORTBBidExtPrebid.h"
+#import "PBMORTBExtPrebidPassthrough.h"
 #import "PBMORTBBidExtPrebidCache.h"
 #import "PBMORTBBidExtPrebidCacheBids.h"
 #import "PBMORTBBidExtSkadn.h"

--- a/PrebidMobileTests/RenderingTests/Tests/AdConfigurationTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/AdConfigurationTest.swift
@@ -38,39 +38,4 @@ class AdConfigurationTest: XCTestCase {
         adConfiguration.forceInterstitialPresentation = nil
         XCTAssertNotNil(adConfiguration.autoRefreshDelay)
     }
-
-    func testDefaultIsMuted() {
-        let adConfiguration = AdConfiguration()
-        XCTAssertTrue(adConfiguration.isMuted == true)
-    }
-
-    func testDefaultIsMuteControlsDisabled() {
-        let adConfiguration = AdConfiguration()
-        XCTAssertTrue(adConfiguration.isSoundButtonVisible == false)
-    }
-
-    func testCloseButtonArea() {
-        let adConfiguration = AdConfiguration()
-        XCTAssertEqual(adConfiguration.closeButtonArea, PBMConstants.BUTTON_AREA_DEFAULT.doubleValue)
-    }
-    
-    func testDefaultCloseButtonPosition() {
-        let adConfiguration = AdConfiguration()
-        XCTAssertTrue(adConfiguration.closeButtonPosition == .topRight)
-    }
-    
-    func testDefaultSkipButtonArea() {
-        let adConfiguration = AdConfiguration()
-        XCTAssertEqual(adConfiguration.skipButtonArea, PBMConstants.BUTTON_AREA_DEFAULT.doubleValue)
-    }
-    
-    func testDefaultSkipButtonPosition() {
-        let adConfiguration = AdConfiguration()
-        XCTAssertEqual(adConfiguration.skipButtonPosition, .topRight)
-    }
-    
-    func testDefaultSkipButtonDelay() {
-        let adConfiguration = AdConfiguration()
-        XCTAssertEqual(adConfiguration.skipDelay, PBMConstants.SKIP_DELAY_DEFAULT.doubleValue)
-    }
 }

--- a/PrebidMobileTests/RenderingTests/Tests/PBMVideoCreativeTestCloseDelay.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMVideoCreativeTestCloseDelay.swift
@@ -39,13 +39,13 @@ class PBMVideoCreativeTestCloseDelay : XCTestCase {
         model.hasCompanionAd = false
         
         //for video without end cart use skip delay
-        model.adConfiguration?.skipDelay = 5
+        model.adConfiguration?.videoControlsConfig.skipDelay = 5
         expected = 5
         actual = calculateCloseDelay(with:model, pubCloseDelay:5)
         PBMAssertEq(actual, expected)
         
         //reset
-        model.adConfiguration?.skipDelay = 1000000
+        model.adConfiguration?.videoControlsConfig.skipDelay = 1000000
         
         //if skipOffset is not nil and is less than video duration - use it
         model.skipOffset = 4

--- a/PrebidMobileTests/RenderingTests/Tests/PBMVideoViewTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMVideoViewTest.swift
@@ -258,9 +258,9 @@ class PBMVideoViewTest: XCTestCase, PBMCreativeResolutionDelegate, PBMCreativeVi
     
     func testIsMuted() {
         let adConfig = AdConfiguration()
-        XCTAssertTrue(adConfig.isMuted == true)
+        XCTAssertTrue(adConfig.videoControlsConfig.isMuted == true)
         
-        adConfig.isMuted = false
+        adConfig.videoControlsConfig.isMuted = false
         // Expected duration of video small.mp4 is 6 sec
         let expectedVideoDuration = 6.0
 
@@ -303,7 +303,7 @@ class PBMVideoViewTest: XCTestCase, PBMCreativeResolutionDelegate, PBMCreativeVi
         
         self.videoCreative.creativeModel = PBMCreativeModel()
         self.videoCreative.creativeModel?.adConfiguration = AdConfiguration()
-        self.videoCreative.creativeModel?.adConfiguration?.skipDelay = 1
+        self.videoCreative.creativeModel?.adConfiguration?.videoControlsConfig.skipDelay = 1
         self.videoCreative.creativeModel?.displayDurationInSeconds = 10
         self.videoCreative.creativeModel?.hasCompanionAd = true
         

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/BaseInterstitialAdUnitTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/BaseInterstitialAdUnitTest.swift
@@ -38,6 +38,6 @@ class BaseInterstitialAdUnitTest: XCTestCase {
         XCTAssertEqual(adUnit.closeButtonPosition, .topRight)
         
         adUnit.closeButtonPosition = .topLeft
-        XCTAssertEqual(adUnit.adUnitConfig.adConfiguration.closeButtonPosition, .topLeft)
+        XCTAssertEqual(adUnit.adUnitConfig.adConfiguration.videoControlsConfig.closeButtonPosition, .topLeft)
     }
 }

--- a/PrebidMobileTests/RenderingTests/Tests/VASTTests/PBMVideoCreativeTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/VASTTests/PBMVideoCreativeTest.swift
@@ -232,7 +232,7 @@ class VideoCreativeDelegateTest: XCTestCase, PBMCreativeResolutionDelegate, PBMC
         self.videoCreative.modalManager = mockModalManager
         self.videoCreative.creativeModel?.hasCompanionAd = false
         self.videoCreative.creativeModel?.adConfiguration?.isOptIn = false
-        self.videoCreative.creativeModel?.adConfiguration?.skipDelay = 1000
+        self.videoCreative.creativeModel?.adConfiguration?.videoControlsConfig.skipDelay = 1000
         mockModalManager.mock_pushModalClosure = { (modalState, _, _, _, completionHandler) in
             expectation.fulfill()
             PBMAssertEq(model.skipOffset, modalState.displayProperties?.closeDelay as NSNumber?)

--- a/PrebidMobileTests/RenderingTests/Tests/VideoControlsConfigTests.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/VideoControlsConfigTests.swift
@@ -1,0 +1,76 @@
+/*   Copyright 2018-2021 Prebid.org, Inc.
+ 
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
+import XCTest
+@testable import PrebidMobile
+
+class VideoControlsConfigTests: XCTestCase {
+    func testDefaultIsMuted() {
+        let adConfiguration = VideoControlsConfiguration()
+        XCTAssertTrue(adConfiguration.isMuted == true)
+    }
+
+    func testDefaultIsMuteControlsDisabled() {
+        let adConfiguration = VideoControlsConfiguration()
+        XCTAssertTrue(adConfiguration.isSoundButtonVisible == false)
+    }
+
+    func testCloseButtonArea() {
+        let adConfiguration = VideoControlsConfiguration()
+        XCTAssertEqual(adConfiguration.closeButtonArea, PBMConstants.BUTTON_AREA_DEFAULT.doubleValue)
+    }
+    
+    func testDefaultCloseButtonPosition() {
+        let adConfiguration = VideoControlsConfiguration()
+        XCTAssertTrue(adConfiguration.closeButtonPosition == .topRight)
+    }
+    
+    func testDefaultSkipButtonArea() {
+        let adConfiguration = VideoControlsConfiguration()
+        XCTAssertEqual(adConfiguration.skipButtonArea, PBMConstants.BUTTON_AREA_DEFAULT.doubleValue)
+    }
+    
+    func testDefaultSkipButtonPosition() {
+        let adConfiguration = VideoControlsConfiguration()
+        XCTAssertEqual(adConfiguration.skipButtonPosition, .topRight)
+    }
+    
+    func testDefaultSkipButtonDelay() {
+        let adConfiguration = VideoControlsConfiguration()
+        XCTAssertEqual(adConfiguration.skipDelay, PBMConstants.SKIP_DELAY_DEFAULT.doubleValue)
+    }
+    
+    func testInitWithORTBAdConfiguration() {
+        let adConfiguration = VideoControlsConfiguration()
+        
+        let ortbAdConfig = PBMORTBAdConfiguration()
+        ortbAdConfig.isMuted = false
+        ortbAdConfig.maxVideoDuration = 40
+        ortbAdConfig.skipButtonArea = 0.3
+        ortbAdConfig.skipButtonPosition = "topleft"
+        ortbAdConfig.closeButtonArea = 0.3
+        ortbAdConfig.closeButtonPosition = "topleft"
+        
+        adConfiguration.initialize(with: ortbAdConfig)
+        
+        XCTAssertEqual(adConfiguration.isMuted, false)
+        XCTAssertEqual(adConfiguration.maxVideoDuration?.doubleValue, 40)
+        XCTAssertEqual(adConfiguration.skipButtonArea, 0.3)
+        XCTAssertEqual(adConfiguration.skipButtonPosition, .topLeft)
+        XCTAssertEqual(adConfiguration.closeButtonArea, 0.3)
+        XCTAssertEqual(adConfiguration.closeButtonPosition, .topLeft)
+        
+    }
+}


### PR DESCRIPTION
Closes #608,  #598,  #615 

- support server-side video ad configuration;
- add non-production video ad configuration(ext.passthrough) in order to test sdk;
- fix banner view leak;
- fix rewarded end card problem;
- fix native links test example;
- add & update tests.