### PR TITLE
Restore parameters classes in original API & corrections

### DIFF
--- a/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/BannerController.swift
@@ -31,7 +31,8 @@ fileprivate let storedImpVideoBanner                = "imp-prebid-video-outstrea
 // Stored Responses
 fileprivate let storedResponseDisplayBanner         = "response-prebid-banner-320-50"
 
-fileprivate let storedResponseVideoBanner           = "response-prebid-video-outstream"
+fileprivate let storedResponseOriginalVideoBanner   = "response-prebid-video-outstream-original-api"
+fileprivate let storedResponseRenderingVideoBanner  = "response-prebid-video-outstream"
 
 // GAM
 fileprivate let gamAdUnitDisplayBannerOriginal      = "/21808260008/prebid_demo_app_original_api_banner"
@@ -204,8 +205,7 @@ class BannerController:
     }
 
     func setupGAMBannerVAST(width: Int, height: Int) {
-        // TODO: actualize stored response for this case
-        setupPrebidServer(storedResponse: storedResponseVideoBanner)
+        setupPrebidServer(storedResponse: storedResponseOriginalVideoBanner)
 
         let adUnit = VideoAdUnit(configId: storedImpVideoBanner, size: CGSize(width: width, height: height))
 
@@ -303,7 +303,7 @@ class BannerController:
     }
 
     func loadInAppVideoBanner() {
-        setupPrebidServer(storedResponse: storedResponseVideoBanner)
+        setupPrebidServer(storedResponse: storedResponseRenderingVideoBanner)
 
         let size = CGSize(width: 300, height: 250)
         prebidBannerView = BannerView(frame: CGRect(origin: .zero, size: size),
@@ -349,7 +349,7 @@ class BannerController:
     func loadGAMRenderingVideoBanner() {
         let size = CGSize(width: 300, height: 250)
 
-        setupPrebidServer(storedResponse: storedResponseVideoBanner)
+        setupPrebidServer(storedResponse: storedResponseRenderingVideoBanner)
 
         let eventHandler = GAMBannerEventHandler(adUnitID: gamAdUnitVideoBannerRendering, validGADAdSizes: [kGADAdSizeBanner].map(NSValueFromGADAdSize))
         prebidBannerView = BannerView(frame: CGRect(origin: .zero, size: size),
@@ -387,7 +387,7 @@ class BannerController:
     }
     
     func loadAdMobRenderingBannerVideo() {
-        setupPrebidServer(storedResponse: storedResponseVideoBanner)
+        setupPrebidServer(storedResponse: storedResponseRenderingVideoBanner)
         setupAdMobBanner(adUnitId: adMobAdUnitDisplayBannerRendering, width: 300, height: 250)
 
         let size = CGSize(width: 300, height: 250)
@@ -420,7 +420,7 @@ class BannerController:
     }
 
     func loadMAXRenderingBannerVideo() {
-        setupPrebidServer(storedResponse: storedResponseVideoBanner)
+        setupPrebidServer(storedResponse: storedResponseRenderingVideoBanner)
         setupMAXBanner(adUnitId: maxAdUnitMRECRendering, width: 300, height: 250)
 
         let size = CGSize(width: 300, height: 250)

--- a/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/InterstitialViewController.swift
@@ -30,7 +30,8 @@ fileprivate let storedImpVideoInterstitial              = "imp-prebid-video-inte
 
 // Stored Responses
 fileprivate let storedResponseDisplayInterstitial       = "response-prebid-display-interstitial-320-480"
-fileprivate let storedResponseVideoInterstitial         = "response-prebid-video-interstitial-320-480"
+fileprivate let storedResponseOriginalVideoInterstitial = "response-prebid-video-interstitial-320-480-original-api"
+fileprivate let storedResponseRenderingVideoInterstitial = "response-prebid-video-interstitial-320-480"
 
 // GAM
 fileprivate let gamAdUnitDisplayInterstitialOriginal    = "/21808260008/prebid-demo-app-original-api-display-interstitial"
@@ -72,7 +73,7 @@ class InterstitialViewController:
     // In-App
     private var renderingInterstitial: InterstitialRenderingAdUnit!
     
-    // AdMob 
+    // AdMob
     private var gadRequest = GADRequest()
     private var interstitial: GADInterstitialAd?
     private var admobAdUnit: MediationInterstitialAdUnit?
@@ -225,7 +226,7 @@ class InterstitialViewController:
     }
     
     func loadAdMobRenderingVideoInterstitial() {
-        setupPrebidServer(storedResponse: storedResponseVideoInterstitial)
+        setupPrebidServer(storedResponse: storedResponseRenderingVideoInterstitial)
 
         mediationDelegate = AdMobMediationInterstitialUtils(gadRequest: self.gadRequest)
         admobAdUnit = MediationInterstitialAdUnit(configId: storedImpVideoInterstitial, mediationDelegate: mediationDelegate!)
@@ -263,7 +264,7 @@ class InterstitialViewController:
     }
     
     func loadMAXRenderingVideoInterstitial() {
-        setupPrebidServer(storedResponse: storedResponseVideoInterstitial)
+        setupPrebidServer(storedResponse: storedResponseRenderingVideoInterstitial)
         maxInterstitial = MAInterstitialAd(adUnitIdentifier: maxAdUnitDisplayInterstitial)
         maxMediationDelegate = MAXMediationInterstitialUtils(interstitialAd: maxInterstitial)
         maxAdUnit = MediationInterstitialAdUnit(configId: storedImpVideoInterstitial, mediationDelegate: maxMediationDelegate)
@@ -277,7 +278,7 @@ class InterstitialViewController:
     //MARK: - Interstitial VAST
     
     func setupAndLoadAMInterstitialVAST() {
-        setupPrebidServer(storedResponse: storedResponseVideoInterstitial)
+        setupPrebidServer(storedResponse: storedResponseOriginalVideoInterstitial)
 
         let adUnit = VideoInterstitialAdUnit(configId: storedImpVideoInterstitial)
         let parameters = VideoParameters()
@@ -297,7 +298,7 @@ class InterstitialViewController:
     }
     
     func loadInAppVideoInterstitial() {
-        setupPrebidServer(storedResponse: storedResponseVideoInterstitial)
+        setupPrebidServer(storedResponse: storedResponseRenderingVideoInterstitial)
         
         renderingInterstitial = InterstitialRenderingAdUnit(configID: storedImpVideoInterstitial)
         renderingInterstitial.adFormats = [.video]
@@ -307,7 +308,7 @@ class InterstitialViewController:
     }
     
     func loadGAMRenderingVideoInterstitial() {
-        setupPrebidServer(storedResponse: storedResponseVideoInterstitial)
+        setupPrebidServer(storedResponse: storedResponseRenderingVideoInterstitial)
 
         let eventHandler = GAMInterstitialEventHandler(adUnitID: gamAdUnitVideoInterstitialRendering)
         renderingInterstitial = InterstitialRenderingAdUnit(configID: storedImpVideoInterstitial, eventHandler: eventHandler)

--- a/PrebidMobile/AdUnits/BannerBaseAdUnit.swift
+++ b/PrebidMobile/AdUnits/BannerBaseAdUnit.swift
@@ -18,4 +18,13 @@ public class BannerBaseAdUnit: AdUnit {
         get { adUnitConfig.adConfiguration.bannerParameters }
         set { adUnitConfig.adConfiguration.bannerParameters = newValue }
     }
+    
+    @available(*, deprecated, message: "This class is deprecated. Please, use BannerParameters instead.")
+    @objc(PBBannerAdUnitParameters)
+    public class Parameters: NSObject {
+        
+        /// List of supported API frameworks for this impression. If an API is not explicitly listed, it is assumed not to be supported.
+        @objc
+        public var api: [Signals.Api]?
+    }
 }

--- a/PrebidMobile/AdUnits/VideoBaseAdUnit.swift
+++ b/PrebidMobile/AdUnits/VideoBaseAdUnit.swift
@@ -26,4 +26,57 @@ public class VideoBaseAdUnit: AdUnit {
         super.init(configId: configId, size: size)
         adUnitConfig.adFormats = [.video]
     }
+    
+    @available(*, deprecated, message: "This class is deprecated. Please, use VideoParameters instead.")
+    /// Describes an [OpenRTB](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf) video object
+    @objc(PBVideoAdUnitParameters)
+    public class Parameters: NSObject {
+        
+        /// List of supported API frameworks for this impression. If an API is not explicitly listed, it is assumed not to be supported.
+        @objc
+        public var api: [Signals.Api]?
+
+        /// Maximum bit rate in Kbps.
+        @objc
+        public var maxBitrate: SingleContainerInt?
+        
+        /// Maximum bit rate in Kbps.
+        @objc
+        public var minBitrate: SingleContainerInt?
+        
+        /// Maximum video ad duration in seconds.
+        @objc
+        public var maxDuration: SingleContainerInt?
+        
+
+        /// Minimum video ad duration in seconds.
+        @objc
+        public var minDuration: SingleContainerInt?
+        
+        /**
+        Content MIME types supported
+        
+        # Example #
+        * "video/mp4"
+        * "video/x-ms-wmv"
+        */
+        @objc
+        public var mimes: [String]?
+        
+        /// Allowed playback methods. If none specified, assume all are allowed.
+        @objc
+        public var playbackMethod: [Signals.PlaybackMethod]?
+        
+        /// Array of supported video bid response protocols.
+        @objc
+        public var protocols: [Signals.Protocols]?
+        
+        /// Indicates the start delay in seconds for pre-roll, mid-roll, or post-roll ad placements.
+        @objc
+        public var startDelay: Signals.StartDelay?
+        
+        /// Placement type for the impression.
+        @objc
+        public var placement: Signals.Placement?
+    }
 }


### PR DESCRIPTION
- restore Parameters classes in BannerBaseAdUnit and VideoBaseAdUnit and mark it deprecated;
- add storedResponse for original GAM video interstitial integration;
- add storedResponse for original GAM banner video integration.