### PR TITLE
fix: automatic pop to root of the interstitial after clickthroughs is prevented

### DIFF
--- a/PrebidMobile/PrebidMobileRendering/AdTypes/PBMHTMLCreative.m
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/PBMHTMLCreative.m
@@ -290,13 +290,6 @@
         [self.creativeViewDelegate creativeClickthroughDidClose:self];
         self.clickthroughVisible = NO;
         
-        //Pop to root after clickthroughs
-        if (self.creativeModel.adConfiguration.presentAsInterstitial) {
-            if (self.dismissInterstitialModalState) {
-                self.dismissInterstitialModalState();
-            }
-        }
-        
         return;
     }
     


### PR DESCRIPTION
The behavior is changed so that when a fullscreen ad opens the browser after clicking on it and after closing the browser, the fullscreen ad does not auto-close