### PR TITLE
Support different versions of xcode

### DIFF
--- a/scripts/runSwift.sh
+++ b/scripts/runSwift.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Build and run PrebidDemoSwift application on emulator $1
+# Example: ./script/runSwift.sh "iPhone 14 Pro Max"
+
+if [ -d "scripts" ]; then
+cd scripts/
+fi
+
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+echo -e "\n\n${GREEN}RUN PREBID SWIFT DEMO${NC}\n\n"
+
+cd ..
+echo $PWD
+
+
+if [ -z "$1" ]
+  then
+    echo "Please supply an emulator (xcrun simctl list)"
+    exit
+fi
+
+emulator_name=$1
+xcodebuild -workspace PrebidMobile.xcworkspace -scheme "PrebidDemoSwift" -destination "platform=iOS Simulator,name=${emulator_name},OS=latest" -derivedDataPath build
+
+open -a "simulator"
+
+uuid=$(xcrun simctl list | grep -E -i "${emulator_name}" | grep -Eo -i '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}')
+xcrun simctl install ${uuid} ./build/Build/Products/Debug-iphonesimulator/PrebidDemoSwift.app
+xcrun simctl launch ${uuid} org.prebid.PrebidDemoSwift


### PR DESCRIPTION
Hi!

OS X Ventura and Xcode>=14 have made some changes that requires some updates in the build scripts.

For example, Xcode 14 only supports iOS >11 and BITCODE is deprecated, thus, `find` will fail and the build script will error out.

These changes will allow users to build against xcode14 and xcode13. This can of course be expanded to support versions even further back but this seems to be a good start.

I added `runSwift.sh` for building and launching the PrebidSwiftDemo application in a simulator of choice.

To build prebid-mobile-ios and launch the swift application, first build the project:

`./script/buildPrebidMobile.sh`

then build and launch the PrebidSwiftDemo

`./script/runSwift.sh "iPhone 14 Pro Max"`

**Note:**
I have limited experience with iOS and Xcode, let me know if something does not make sense.

Some of the projects are not listed in he Podfile and thus cannot be modified to in the `post-install` step. These project needs to be added to the Podfile or users need to update them manually. Warnings that would eventually lead to errors are:

```
prebid-mobile-ios/EventHandlers/EventHandlers.xcodeproj: warning: The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 10.0, but the range of supported deployment target versions is 11.0 to 16.1.99. (in target 'PrebidMobileGAMEventHandlers' from project 'EventHandlers')
```

For Xcode 14, `IPHONEOS_DEPLOYMENT_TARGET` should be set to `12`.

My knowledge with Podfiles are limited, so I am not sure what would be the best way to include these project files in the post-install step.

Update these files:

```
EventHandlers/EventHandlers.xcodeproj/project.pbxproj
PrebidMobile.xcodeproj/project.pbxproj

```

with

```
-                               IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+                               IPHONEOS_DEPLOYMENT_TARGET = 12;
```

To fix all warnings, also change these:

```
-                               CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+                               CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = '$(inherited)';
```
 

![image](https://user-images.githubusercontent.com/867096/203858682-737d9557-555f-4838-9e90-57356525e96b.png)
