### PR TITLE
SDK first party data support

### DIFF
--- a/InternalTestApp/PrebidMobileDemoRendering/AppDelegate.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/AppDelegate.swift
@@ -87,7 +87,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         processArgumentsParser.addOption("ADD_ADUNIT_KEYWORD", paramsCount: 1) { params in
             let appConfig = AppConfiguration.shared
-            appConfig.contextKeywords.append(params[0])
+            appConfig.adUnitContextKeywords.append(params[0])
         }
         
         processArgumentsParser.addOption("ADD_USER_EXT_DATA", paramsCount: 2) { params in

--- a/InternalTestApp/PrebidMobileDemoRendering/AppDelegate.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/AppDelegate.swift
@@ -85,6 +85,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             appConfig.adUnitContext = (appConfig.adUnitContext ?? []) + [(key: params[0], value: params[1])]
         }
         
+        processArgumentsParser.addOption("ADD_ADUNIT_KEYWORD", paramsCount: 1) { params in
+            let appConfig = AppConfiguration.shared
+            appConfig.contextKeywords.append(params[0])
+        }
+        
         processArgumentsParser.addOption("ADD_USER_EXT_DATA", paramsCount: 2) { params in
             Targeting.shared.addUserData(key: params[0], value: params[1])
         }
@@ -93,9 +98,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             Targeting.shared.addContextData(key: params[0], value: params[1])
         }
         
+        processArgumentsParser.addOption("ADD_APP_KEYWORD", paramsCount: 1) { params in
+            Targeting.shared.addContextKeyword(params[0])
+        }
+        
         processArgumentsParser.addOption("ADD_USER_DATA_EXT", paramsCount: 2) { params in
             let appConfig = AppConfiguration.shared
             appConfig.userData = (appConfig.userData ?? []) + [(key: params[0], value: params[1])]
+        }
+        
+        processArgumentsParser.addOption("ADD_USER_KEYWORD", paramsCount: 1) { params in
+            Targeting.shared.addUserKeyword(params[0])
         }
         
         processArgumentsParser.addOption("ADD_APP_CONTENT_DATA_EXT", paramsCount: 2) { params in

--- a/InternalTestApp/PrebidMobileDemoRendering/Singletons and Managers/AppConfiguration.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/Singletons and Managers/AppConfiguration.swift
@@ -38,4 +38,7 @@ final class AppConfiguration: NSObject {
     var adUnitContext: [(key: String, value: String)]?
     var userData: [(key: String, value: String)]?
     var appContentData: [(key: String, value: String)]?
+    
+    // imp[].ext.keywords
+    var adUnitContextKeywords = [String]()
 }

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
@@ -135,7 +135,7 @@ class PrebidAdMobBannerViewController:
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
@@ -111,13 +111,22 @@ class PrebidAdMobBannerViewController:
         if let adFormat = adFormat {
             adUnit?.adFormat = adFormat
         }
-        
+                
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adUnit?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -126,6 +135,7 @@ class PrebidAdMobBannerViewController:
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
@@ -128,20 +128,26 @@ class PrebidAdMobBannerViewController:
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         adUnit?.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
@@ -107,12 +107,21 @@ class PrebidAdMobInterstitialViewController: NSObject, AdaptedController, Prebid
             adUnit?.adFormats = adFormats
         }
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adUnit?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -121,8 +130,9 @@ class PrebidAdMobInterstitialViewController: NSObject, AdaptedController, Prebid
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
-            for dataPair in appData {                
+            for dataPair in appData {
                 let appData = PBMORTBContentData()
                 appData.ext = [dataPair.key: dataPair.value]
                 adUnit?.addAppContentData([appData])

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
@@ -130,7 +130,7 @@ class PrebidAdMobInterstitialViewController: NSObject, AdaptedController, Prebid
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
@@ -123,20 +123,26 @@ class PrebidAdMobInterstitialViewController: NSObject, AdaptedController, Prebid
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         adUnit?.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobNativeViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobNativeViewController.swift
@@ -64,6 +64,22 @@ class PrebidAdMobNativeViewController: NSObject, AdaptedController, GADNativeAdL
         setUpBannerArea(rootController: rootController!)
         Prebid.shared.storedAuctionResponse = storedAuctionResponse
         setupMediationNativeAdUnit()
+   
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                nativeAdUnit?.addContextData(dataPair.value, forKey: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                nativeAdUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -72,6 +88,7 @@ class PrebidAdMobNativeViewController: NSObject, AdaptedController, GADNativeAdL
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobNativeViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobNativeViewController.swift
@@ -81,20 +81,26 @@ class PrebidAdMobNativeViewController: NSObject, AdaptedController, GADNativeAdL
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                nativeAdUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                nativeAdUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         nativeAdUnit.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobNativeViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobNativeViewController.swift
@@ -88,7 +88,7 @@ class PrebidAdMobNativeViewController: NSObject, AdaptedController, GADNativeAdL
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobNativeViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobNativeViewController.swift
@@ -88,7 +88,7 @@ class PrebidAdMobNativeViewController: NSObject, AdaptedController, GADNativeAdL
                 ortbUserData.ext?[dataPair.key] = dataPair.value
             }
             
-            adUnit?.addUserData([ortbUserData])
+            nativeAdUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
@@ -100,7 +100,7 @@ class PrebidAdMobNativeViewController: NSObject, AdaptedController, GADNativeAdL
                 ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
             
-            adUnit?.addAppContentData([ortbAppContentData])
+            nativeAdUnit?.addAppContentData([ortbAppContentData])
         }
         
         nativeAdUnit.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
@@ -87,7 +87,7 @@ class PrebidAdMobRewardedViewController: NSObject, AdaptedController, PrebidConf
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
@@ -64,12 +64,21 @@ class PrebidAdMobRewardedViewController: NSObject, AdaptedController, PrebidConf
         Prebid.shared.storedAuctionResponse = storedAuctionResponse
         adUnit = MediationRewardedAdUnit(configId: prebidConfigId, mediationDelegate: mediationDelegate!)
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adUnit?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -78,6 +87,7 @@ class PrebidAdMobRewardedViewController: NSObject, AdaptedController, PrebidConf
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
@@ -80,20 +80,26 @@ class PrebidAdMobRewardedViewController: NSObject, AdaptedController, PrebidConf
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         adUnit?.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMBannerController.swift
@@ -110,7 +110,7 @@ class PrebidGAMBannerController: NSObject, AdaptedController, PrebidConfigurable
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMBannerController.swift
@@ -87,12 +87,21 @@ class PrebidGAMBannerController: NSObject, AdaptedController, PrebidConfigurable
         adBannerView?.delegate = self
         adBannerView?.accessibilityIdentifier = "BannerView"
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adBannerView?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adBannerView?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -101,6 +110,7 @@ class PrebidGAMBannerController: NSObject, AdaptedController, PrebidConfigurable
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMBannerController.swift
@@ -103,20 +103,26 @@ class PrebidGAMBannerController: NSObject, AdaptedController, PrebidConfigurable
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adBannerView?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adBannerView?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adBannerView?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adBannerView?.addAppContentData([ortbAppContentData])
         }
         
         adBannerView?.loadAd()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMInterstitialController.swift
@@ -121,20 +121,26 @@ class PrebidGAMInterstitialController: NSObject, AdaptedController, PrebidConfig
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                interstitialController?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            interstitialController?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                interstitialController?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            interstitialController?.addAppContentData([ortbAppContentData])
         }
         
         interstitialController?.loadAd()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMInterstitialController.swift
@@ -105,12 +105,21 @@ class PrebidGAMInterstitialController: NSObject, AdaptedController, PrebidConfig
             interstitialController?.adFormats = adFormats
         }
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 interstitialController?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                interstitialController?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -119,6 +128,7 @@ class PrebidGAMInterstitialController: NSObject, AdaptedController, PrebidConfig
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMInterstitialController.swift
@@ -128,7 +128,7 @@ class PrebidGAMInterstitialController: NSObject, AdaptedController, PrebidConfig
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMNativeAdController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMNativeAdController.swift
@@ -106,19 +106,35 @@ class PrebidGAMNativeAdController: NSObject, AdaptedController {
         setupNativeAdUnit()
         Prebid.shared.storedAuctionResponse = storedAuctionResponse
         
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
                 appData.ext = [dataPair.key: dataPair.value]
-                self.adUnit?.addUserData([appData])
+                adUnit?.addUserData([appData])
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()
                 appData.ext = [dataPair.key: dataPair.value]
-                self.adUnit?.addAppContentData([appData])
+                adUnit?.addAppContentData([appData])
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMNativeAdController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMNativeAdController.swift
@@ -122,20 +122,26 @@ class PrebidGAMNativeAdController: NSObject, AdaptedController {
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         adUnit?.fetchDemand(completion: { [weak self] result, kvResultDict in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMNativeAdController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMNativeAdController.swift
@@ -129,7 +129,7 @@ class PrebidGAMNativeAdController: NSObject, AdaptedController {
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMRewardedController.swift
@@ -79,20 +79,26 @@ class PrebidGAMRewardedController: NSObject, AdaptedController, PrebidConfigurab
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                rewardedAdController?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            rewardedAdController?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                rewardedAdController?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            rewardedAdController?.addAppContentData([ortbAppContentData])
         }
         
         rewardedAdController?.loadAd()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMRewardedController.swift
@@ -86,7 +86,7 @@ class PrebidGAMRewardedController: NSObject, AdaptedController, PrebidConfigurab
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMRewardedController.swift
@@ -62,12 +62,22 @@ class PrebidGAMRewardedController: NSObject, AdaptedController, PrebidConfigurab
         Prebid.shared.storedAuctionResponse = storedAuctionResponse
         rewardedAdController = RewardedAdUnit(configID: prebidConfigId, eventHandler: eventHandler)
         rewardedAdController?.delegate = self
+   
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 rewardedAdController?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                rewardedAdController?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -76,6 +86,7 @@ class PrebidGAMRewardedController: NSObject, AdaptedController, PrebidConfigurab
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
@@ -118,20 +118,26 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         adUnit?.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
@@ -102,12 +102,21 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
             adUnit?.adFormat = adFormat
         }
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adUnit?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -116,6 +125,7 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
@@ -125,7 +125,7 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
@@ -129,20 +129,26 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         adUnit?.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
@@ -113,12 +113,21 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
             adUnit?.adFormats = adFormats
         }
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adUnit?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -127,6 +136,7 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
@@ -136,7 +136,7 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXNativeController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXNativeController.swift
@@ -72,6 +72,21 @@ class PrebidMAXNativeController: NSObject, AdaptedController {
             nativeAdUnit.addEventTracker(eventTrackers)
         }
         
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                nativeAdUnit?.addContextData(dataPair.value, forKey: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                nativeAdUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -80,6 +95,7 @@ class PrebidMAXNativeController: NSObject, AdaptedController {
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXNativeController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXNativeController.swift
@@ -88,20 +88,26 @@ class PrebidMAXNativeController: NSObject, AdaptedController {
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                nativeAdUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            nativeAdUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                nativeAdUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            nativeAdUnit?.addAppContentData([ortbAppContentData])
         }
         
         nativeAdUnit.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXNativeController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXNativeController.swift
@@ -95,7 +95,7 @@ class PrebidMAXNativeController: NSObject, AdaptedController {
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
@@ -96,7 +96,7 @@ class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurab
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
@@ -89,20 +89,26 @@ class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurab
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         adUnit?.fetchDemand { [weak self] result in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
@@ -73,12 +73,21 @@ class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurab
         mediationDelegate = MAXMediationRewardedUtils(rewardedAd: rewarded!)
         adUnit = MediationRewardedAdUnit(configId: prebidConfigId, mediationDelegate: mediationDelegate!)
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adUnit?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -87,6 +96,7 @@ class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurab
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidBannerController.swift
@@ -109,20 +109,26 @@ class PrebidBannerController: NSObject, AdaptedController, PrebidConfigurableBan
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adBannerView?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adBannerView?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adBannerView?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adBannerView?.addAppContentData([ortbAppContentData])
         }
         
         adBannerView?.loadAd()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidBannerController.swift
@@ -116,7 +116,7 @@ class PrebidBannerController: NSObject, AdaptedController, PrebidConfigurableBan
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidBannerController.swift
@@ -93,12 +93,21 @@ class PrebidBannerController: NSObject, AdaptedController, PrebidConfigurableBan
         adBannerView?.delegate = self
         adBannerView?.accessibilityIdentifier = "PrebidBannerView"
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adBannerView?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adBannerView?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -107,6 +116,7 @@ class PrebidBannerController: NSObject, AdaptedController, PrebidConfigurableBan
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidInterstitialController.swift
@@ -101,12 +101,21 @@ class PrebidInterstitialController: NSObject, AdaptedController, PrebidConfigura
             interstitialController?.adFormats = adFormats
         }
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 interstitialController?.addContextData(dataPair.value, forKey: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                interstitialController?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -115,6 +124,7 @@ class PrebidInterstitialController: NSObject, AdaptedController, PrebidConfigura
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidInterstitialController.swift
@@ -124,7 +124,7 @@ class PrebidInterstitialController: NSObject, AdaptedController, PrebidConfigura
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidInterstitialController.swift
@@ -117,20 +117,26 @@ class PrebidInterstitialController: NSObject, AdaptedController, PrebidConfigura
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                interstitialController?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            interstitialController?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                interstitialController?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            interstitialController?.addAppContentData([ortbAppContentData])
         }
         
         interstitialController?.loadAd()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidNativeAdController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidNativeAdController.swift
@@ -100,12 +100,21 @@ class PrebidNativeAdController: NSObject, AdaptedController {
         setupNativeAdUnit(configId: prebidConfigId)
         Prebid.shared.storedAuctionResponse = storedAuctionResponse
 
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
             }
         }
         
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
         if let userData = AppConfiguration.shared.userData {
             for dataPair in userData {
                 let appData = PBMORTBContentData()
@@ -114,6 +123,7 @@ class PrebidNativeAdController: NSObject, AdaptedController {
             }
         }
         
+        // app.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidNativeAdController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidNativeAdController.swift
@@ -123,7 +123,7 @@ class PrebidNativeAdController: NSObject, AdaptedController {
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidNativeAdController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidNativeAdController.swift
@@ -116,20 +116,26 @@ class PrebidNativeAdController: NSObject, AdaptedController {
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         adUnit?.fetchDemand(completion: { [weak self] result, kvResultDict in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidRewardedController.swift
@@ -75,20 +75,26 @@ class PrebidRewardedController: NSObject, AdaptedController, RewardedAdUnitDeleg
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                rewardedAdController?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            rewardedAdController?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                rewardedAdController?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            rewardedAdController?.addAppContentData([ortbAppContentData])
         }
         
         rewardedAdController?.loadAd()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidRewardedController.swift
@@ -82,7 +82,7 @@ class PrebidRewardedController: NSObject, AdaptedController, RewardedAdUnitDeleg
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidRewardedController.swift
@@ -59,9 +59,35 @@ class PrebidRewardedController: NSObject, AdaptedController, RewardedAdUnitDeleg
         rewardedAdController = RewardedAdUnit(configID: prebidConfigId)
         rewardedAdController?.delegate = self
         
+        // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
                 rewardedAdController?.addContextData(dataPair.value, forKey: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                rewardedAdController?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                rewardedAdController?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                rewardedAdController?.addAppContentData([appData])
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayBannerController.swift
@@ -78,6 +78,38 @@ class PrebidOriginalAPIDisplayBannerController:
         adUnit = BannerAdUnit(configId: prebidConfigId, size: adSize)
         adUnit.setAutoRefreshMillis(time: refreshInterval)
         
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addAppContentData([appData])
+            }
+        }
+        
         gamBanner = GAMBannerView(adSize: gamSizes.first ?? GADAdSizeFromCGSize(adSize))
         gamBanner.validAdSizes = gamSizes.map(NSValueFromGADAdSize)
         gamBanner.adUnitID = adUnitID

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayBannerController.swift
@@ -81,7 +81,7 @@ class PrebidOriginalAPIDisplayBannerController:
         // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
-                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+                adUnit?.addContextData(key: dataPair.key, value: dataPair.value)
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayBannerController.swift
@@ -94,20 +94,26 @@ class PrebidOriginalAPIDisplayBannerController:
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         gamBanner = GAMBannerView(adSize: gamSizes.first ?? GADAdSizeFromCGSize(adSize))

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayBannerController.swift
@@ -101,7 +101,7 @@ class PrebidOriginalAPIDisplayBannerController:
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayInterstitialController.swift
@@ -70,7 +70,7 @@ class PrebidOriginalAPIDisplayInterstitialController:
         // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
-                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+                adUnit?.addContextData(key: dataPair.key, value: dataPair.value)
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayInterstitialController.swift
@@ -66,6 +66,38 @@ class PrebidOriginalAPIDisplayInterstitialController:
         Prebid.shared.storedAuctionResponse = storedAuctionResponse
         
         adUnit = InterstitialAdUnit(configId: prebidConfigId, minWidthPerc: 50, minHeightPerc: 70)
+        
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addAppContentData([appData])
+            }
+        }
        
         let gamRequest = GAMRequest()
         adUnit.fetchDemand(adObject: gamRequest) { [weak self] resultCode in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayInterstitialController.swift
@@ -83,20 +83,26 @@ class PrebidOriginalAPIDisplayInterstitialController:
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
        
         let gamRequest = GAMRequest()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIDisplayInterstitialController.swift
@@ -90,7 +90,7 @@ class PrebidOriginalAPIDisplayInterstitialController:
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeBannerController.swift
@@ -93,7 +93,7 @@ class PrebidOriginalAPINativeBannerController: NSObject, AdaptedController, GADB
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeBannerController.swift
@@ -86,20 +86,26 @@ class PrebidOriginalAPINativeBannerController: NSObject, AdaptedController, GADB
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                nativeUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            nativeUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                nativeUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            nativeUnit?.addAppContentData([ortbAppContentData])
         }
         
         gamBannerView = GAMBannerView(adSize: GADAdSizeFluid)

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeBannerController.swift
@@ -70,6 +70,38 @@ class PrebidOriginalAPINativeBannerController: NSObject, AdaptedController, GADB
         nativeUnit.contextSubType = ContextSubType.Social
         nativeUnit.eventtrackers = eventTrackers
         
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                nativeUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                nativeUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                nativeUnit?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                nativeUnit?.addAppContentData([appData])
+            }
+        }
+        
         gamBannerView = GAMBannerView(adSize: GADAdSizeFluid)
         gamBannerView.adUnitID = adUnitID
         gamBannerView.rootViewController = self.rootController

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeBannerController.swift
@@ -73,7 +73,7 @@ class PrebidOriginalAPINativeBannerController: NSObject, AdaptedController, GADB
         // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
-                nativeUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+                nativeUnit?.addContextData(key: dataPair.key, value: dataPair.value)
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeController.swift
@@ -131,20 +131,26 @@ class PrebidOriginalAPINativeController: NSObject, AdaptedController, GADAdLoade
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                nativeUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            nativeUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                nativeUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            nativeUnit?.addAppContentData([ortbAppContentData])
         }
         
         let gamRequest = GAMRequest()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeController.swift
@@ -138,7 +138,7 @@ class PrebidOriginalAPINativeController: NSObject, AdaptedController, GADAdLoade
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeController.swift
@@ -118,7 +118,7 @@ class PrebidOriginalAPINativeController: NSObject, AdaptedController, GADAdLoade
         // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
-                nativeUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+                nativeUnit?.addContextData(key: dataPair.key, value: dataPair.value)
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPINativeController.swift
@@ -115,6 +115,38 @@ class PrebidOriginalAPINativeController: NSObject, AdaptedController, GADAdLoade
         nativeUnit.contextSubType = ContextSubType.Social
         nativeUnit.eventtrackers = eventTrackers
         
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                nativeUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                nativeUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                nativeUnit?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                nativeUnit?.addAppContentData([appData])
+            }
+        }
+        
         let gamRequest = GAMRequest()
         nativeUnit.fetchDemand(adObject: gamRequest) { [weak self] resultCode in
             guard let self = self else { return }

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoBannerController.swift
@@ -101,7 +101,7 @@ class PrebidOriginalAPIVideoBannerController:
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoBannerController.swift
@@ -77,6 +77,38 @@ class PrebidOriginalAPIVideoBannerController:
         
         adUnit = VideoAdUnit(configId: prebidConfigId, size: adSize)
         adUnit.setAutoRefreshMillis(time: refreshInterval)
+        
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addAppContentData([appData])
+            }
+        }
             
         gamBanner = GAMBannerView(adSize: gamSizes.first ?? GADAdSizeFromCGSize(adSize))
         gamBanner.validAdSizes = gamSizes.map(NSValueFromGADAdSize)

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoBannerController.swift
@@ -94,20 +94,26 @@ class PrebidOriginalAPIVideoBannerController:
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
             
         gamBanner = GAMBannerView(adSize: gamSizes.first ?? GADAdSizeFromCGSize(adSize))

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoBannerController.swift
@@ -81,7 +81,7 @@ class PrebidOriginalAPIVideoBannerController:
         // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
-                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+                adUnit?.addContextData(key: dataPair.key, value: dataPair.value)
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInstreamViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInstreamViewController.swift
@@ -123,20 +123,26 @@ class PrebidOriginalAPIVideoInstreamViewController:
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
         
         let parameters = VideoParameters()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInstreamViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInstreamViewController.swift
@@ -107,6 +107,38 @@ class PrebidOriginalAPIVideoInstreamViewController:
         
         adUnit = VideoAdUnit(configId: prebidConfigId, size: CGSize(width: 1, height: 1))
         
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addAppContentData([appData])
+            }
+        }
+        
         let parameters = VideoParameters()
         parameters.mimes = ["video/mp4"]
         parameters.playbackMethod = [Signals.PlaybackMethod.AutoPlaySoundOn]

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInstreamViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInstreamViewController.swift
@@ -110,7 +110,7 @@ class PrebidOriginalAPIVideoInstreamViewController:
         // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
-                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+                adUnit?.addContextData(key: dataPair.key, value: dataPair.value)
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInstreamViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInstreamViewController.swift
@@ -130,7 +130,7 @@ class PrebidOriginalAPIVideoInstreamViewController:
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInterstitialController.swift
@@ -66,6 +66,38 @@ class PrebidOriginalAPIVideoInterstitialController:
         Prebid.shared.storedAuctionResponse = storedAuctionResponse
         
         adUnit = VideoInterstitialAdUnit(configId: prebidConfigId)
+        
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addAppContentData([appData])
+            }
+        }
          
         let gamRequest = GAMRequest()
         adUnit.fetchDemand(adObject: gamRequest) { [weak self] resultCode in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInterstitialController.swift
@@ -70,7 +70,7 @@ class PrebidOriginalAPIVideoInterstitialController:
         // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
-                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+                adUnit?.addContextData(key: dataPair.key, value: dataPair.value)
             }
         }
         

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInterstitialController.swift
@@ -83,20 +83,26 @@ class PrebidOriginalAPIVideoInterstitialController:
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
          
         let gamRequest = GAMRequest()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoInterstitialController.swift
@@ -90,7 +90,7 @@ class PrebidOriginalAPIVideoInterstitialController:
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoRewardedController.swift
@@ -66,6 +66,38 @@ class PrebidOriginalAPIVideoRewardedController:
         Prebid.shared.storedAuctionResponse = storedAuctionResponse
         
         adUnit = RewardedVideoAdUnit(configId: prebidConfigId)
+        
+        // imp[].ext.data
+        if let adUnitContext = AppConfiguration.shared.adUnitContext {
+            for dataPair in adUnitContext {
+                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+            }
+        }
+        
+        // imp[].ext.keywords
+        if !AppConfiguration.shared.adUnitContextKeywords.isEmpty {
+            for keyword in AppConfiguration.shared.adUnitContextKeywords {
+                adUnit?.addContextKeyword(keyword)
+            }
+        }
+        
+        // user.data
+        if let userData = AppConfiguration.shared.userData {
+            for dataPair in userData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addUserData([appData])
+            }
+        }
+        
+        // app.data
+        if let appData = AppConfiguration.shared.appContentData {
+            for dataPair in appData {
+                let appData = PBMORTBContentData()
+                appData.ext = [dataPair.key: dataPair.value]
+                adUnit?.addAppContentData([appData])
+            }
+        }
          
         let gamRequest = GAMRequest()
         adUnit.fetchDemand(adObject: gamRequest) { [weak self] resultCode in

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoRewardedController.swift
@@ -83,20 +83,26 @@ class PrebidOriginalAPIVideoRewardedController:
         
         // user.data
         if let userData = AppConfiguration.shared.userData {
+            let ortbUserData = PBMORTBContentData()
+            ortbUserData.ext = [:]
+            
             for dataPair in userData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addUserData([appData])
+                ortbUserData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addUserData([ortbUserData])
         }
         
         // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
+            let ortbAppContentData = PBMORTBContentData()
+            ortbAppContentData.ext = [:]
+            
             for dataPair in appData {
-                let appData = PBMORTBContentData()
-                appData.ext = [dataPair.key: dataPair.value]
-                adUnit?.addAppContentData([appData])
+                ortbAppContentData.ext?[dataPair.key] = dataPair.value
             }
+            
+            adUnit?.addAppContentData([ortbAppContentData])
         }
          
         let gamRequest = GAMRequest()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoRewardedController.swift
@@ -90,7 +90,7 @@ class PrebidOriginalAPIVideoRewardedController:
             }
         }
         
-        // app.data
+        // app.content.data
         if let appData = AppConfiguration.shared.appContentData {
             for dataPair in appData {
                 let appData = PBMORTBContentData()

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OriginalAPI/PrebidOriginalAPIVideoRewardedController.swift
@@ -70,7 +70,7 @@ class PrebidOriginalAPIVideoRewardedController:
         // imp[].ext.data
         if let adUnitContext = AppConfiguration.shared.adUnitContext {
             for dataPair in adUnitContext {
-                adUnit?.addContextData(key: dataPair.value, value: dataPair.key)
+                adUnit?.addContextData(key: dataPair.key, value: dataPair.value)
             }
         }
         

--- a/PrebidMobile/AdUnits/AdUnit.swift
+++ b/PrebidMobile/AdUnits/AdUnit.swift
@@ -255,7 +255,7 @@ import ObjectiveC.runtime
         adUnitConfig.getContextKeywords()
     }
     
-    // MARK: - App Content
+    // MARK: - App Content (app.data)
     
     public func setAppContent(_ appContentObject: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContentObject)
@@ -281,7 +281,7 @@ import ObjectiveC.runtime
         adUnitConfig.clearAppContentData()
     }
     
-    // MARK: - User Data
+    // MARK: - User Data (user.data)
         
     public func getUserData() -> [PBMORTBContentData]? {
         return adUnitConfig.getUserData()

--- a/PrebidMobile/AdUnits/AdUnit.swift
+++ b/PrebidMobile/AdUnits/AdUnit.swift
@@ -219,7 +219,7 @@ import ObjectiveC.runtime
         return adUnitConfig.getContextData()
     }
     
-    // MARK: - adunit context keywords (imp[].ext.context.keywords)
+    // MARK: - adunit context keywords (imp[].ext.keywords)
     
     /**
      * This method obtains the context keyword for adunit context targeting

--- a/PrebidMobile/AdUnits/AdUnit.swift
+++ b/PrebidMobile/AdUnits/AdUnit.swift
@@ -183,7 +183,7 @@ import ObjectiveC.runtime
         }
     }
 
-    // MARK: - adunit context data aka inventory data (imp[].ext.context.data)
+    // MARK: - adunit context data aka inventory data (imp[].ext.data)
     
     /**
      * This method obtains the context data keyword & value for adunit context targeting

--- a/PrebidMobile/AdUnits/AdUnit.swift
+++ b/PrebidMobile/AdUnits/AdUnit.swift
@@ -255,7 +255,7 @@ import ObjectiveC.runtime
         adUnitConfig.getContextKeywords()
     }
     
-    // MARK: - App Content (app.data)
+    // MARK: - App Content (app.content.data)
     
     public func setAppContent(_ appContentObject: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContentObject)

--- a/PrebidMobile/ConfigurationAndTargeting/Targeting.swift
+++ b/PrebidMobile/ConfigurationAndTargeting/Targeting.swift
@@ -470,7 +470,6 @@ public class Targeting: NSObject {
     }
     
     public func getContextData() -> [String : [String]] {
-        Log.info("gloabal context data dictionary is \(contextDataDictionary)")
         return contextDataDictionary.mapValues { Array($0) }
     }
     
@@ -497,10 +496,10 @@ public class Targeting: NSObject {
     }
     
     public func getContextKeywords() -> [String] {
-        Log.info("global context keywords set is \(contextKeywordsSet)")
         return Array(contextKeywordsSet)
     }
     
+    @available(*, deprecated, message: "This property is deprecated. Please, use getContextKeywords method instead.")
     public var contextKeywords: [String] {
         Array(contextKeywordsSet)
     }

--- a/PrebidMobile/PrebidMobileRendering/Networking/Parameters/PBMParameterBuilderService.m
+++ b/PrebidMobile/PrebidMobileRendering/Networking/Parameters/PBMParameterBuilderService.m
@@ -125,6 +125,8 @@
     bidRequest.app.domain = targeting.domain;
     bidRequest.app.bundle = targeting.itunesID;
     
+    bidRequest.app.keywords = [[targeting getContextKeywords] componentsJoinedByString:@","];
+    
     if (targeting.publisherName) {
         if (!bidRequest.app.publisher) {
             bidRequest.app.publisher = [[PBMORTBPublisher alloc] init];

--- a/PrebidMobile/PrebidMobileRendering/Networking/Parameters/PBMParameterBuilderService.m
+++ b/PrebidMobile/PrebidMobileRendering/Networking/Parameters/PBMParameterBuilderService.m
@@ -125,7 +125,9 @@
     bidRequest.app.domain = targeting.domain;
     bidRequest.app.bundle = targeting.itunesID;
     
-    bidRequest.app.keywords = [[targeting getContextKeywords] componentsJoinedByString:@","];
+    if ([targeting getContextKeywords].count > 0) {
+        bidRequest.app.keywords = [[targeting getContextKeywords] componentsJoinedByString:@","];
+    }
     
     if (targeting.publisherName) {
         if (!bidRequest.app.publisher) {

--- a/PrebidMobile/PrebidMobileRendering/ORTB/PBMORTBImp.h
+++ b/PrebidMobile/PrebidMobileRendering/ORTB/PBMORTBImp.h
@@ -109,8 +109,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) PBMORTBImpExtPrebid *extPrebid;
 @property (nonatomic, strong) PBMORTBImpExtSkadn  *extSkadn;
-
 @property (nonatomic, strong, nullable) NSMutableDictionary<NSString *, id> *extData;
+@property (nonatomic, strong, nullable) NSString *extKeywords;
 
 - (instancetype)init;
 

--- a/PrebidMobile/PrebidMobileRendering/ORTB/PBMORTBImp.h
+++ b/PrebidMobile/PrebidMobileRendering/ORTB/PBMORTBImp.h
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) PBMORTBImpExtPrebid *extPrebid;
 @property (nonatomic, strong) PBMORTBImpExtSkadn  *extSkadn;
 
-@property (nonatomic, strong, nullable) NSMutableDictionary<NSString *, id> *extContextData;
+@property (nonatomic, strong, nullable) NSMutableDictionary<NSString *, id> *extData;
 
 - (instancetype)init;
 

--- a/PrebidMobile/PrebidMobileRendering/ORTB/PBMORTBImp.m
+++ b/PrebidMobile/PrebidMobileRendering/ORTB/PBMORTBImp.m
@@ -36,7 +36,7 @@
     _secure = @0;
     _extPrebid = [[PBMORTBImpExtPrebid alloc] init];
     _extSkadn = [PBMORTBImpExtSkadn new];
-    _extContextData = [NSMutableDictionary<NSString *, id> new];
+    _extData = [NSMutableDictionary<NSString *, id> new];
     
     return self;
 }
@@ -95,7 +95,7 @@
     _extPrebid = [[PBMORTBImpExtPrebid alloc] initWithJsonDictionary:jsonDictionary[@"ext"][@"prebid"]];
     _extSkadn = [[PBMORTBImpExtSkadn alloc] initWithJsonDictionary:jsonDictionary[@"ext"][@"skadn"]];
     
-    _extContextData = jsonDictionary[@"ext"][@"context"][@"data"];
+    _extData = jsonDictionary[@"ext"][@"data"];
     
     return self;
 }
@@ -116,10 +116,8 @@
         ret[@"skadn"] = extSkadnObj;
     }
     
-    if (self.extContextData && self.extContextData.count > 0) {
-        ret[@"context"] = @{
-            @"data": self.extContextData,
-        };
+    if (self.extData && self.extData.count > 0) {
+        ret[@"data"] = self.extData;
     }
     
     return [ret pbmCopyWithoutEmptyVals];

--- a/PrebidMobile/PrebidMobileRendering/ORTB/PBMORTBImp.m
+++ b/PrebidMobile/PrebidMobileRendering/ORTB/PBMORTBImp.m
@@ -96,6 +96,7 @@
     _extSkadn = [[PBMORTBImpExtSkadn alloc] initWithJsonDictionary:jsonDictionary[@"ext"][@"skadn"]];
     
     _extData = jsonDictionary[@"ext"][@"data"];
+    _extKeywords = jsonDictionary[@"ext"][@"keywords"];
     
     return self;
 }
@@ -118,6 +119,10 @@
     
     if (self.extData && self.extData.count > 0) {
         ret[@"data"] = self.extData;
+    }
+    
+    if (self.extKeywords && self.extKeywords.length > 0) {
+        ret[@"keywords"] = self.extKeywords;
     }
     
     return [ret pbmCopyWithoutEmptyVals];

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -203,7 +203,7 @@ public class BannerView: UIView,
     // MARK: - Context Data (imp[].ext.data)
     
     @objc public func addContextData(_ data: String, forKey key: String) {
-        adUnitConfig.addContextData(key: data, value: key)
+        adUnitConfig.addContextData(key: key, value: data)
     }
     
     @objc public func updateContextData(_ data: Set<String>, forKey key: String) {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -236,7 +236,7 @@ public class BannerView: UIView,
         adUnitConfig.clearContextKeywords()
     }
     
-    // MARK: - App Content (app.data)
+    // MARK: - App Content (app.content.data)
     
     @objc public func setAppContent(_ appContent: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContent)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -200,7 +200,7 @@ public class BannerView: UIView,
         }
     }
     
-    // MARK: - Context Data
+    // MARK: - Context Data (imp[].ext.data)
     
     @objc public func addContextData(_ data: String, forKey key: String) {
         adUnitConfig.addContextData(key: data, value: key)
@@ -218,7 +218,25 @@ public class BannerView: UIView,
         adUnitConfig.clearContextData()
     }
     
-    // MARK: - App Content
+    // MARK: - Context keywords (imp[].ext.keywords)
+    
+    @objc public func addContextKeyword(_ newElement: String) {
+        adUnitConfig.addContextKeyword(newElement)
+    }
+    
+    @objc public func addContextKeywords(_ newElements: Set<String>) {
+        adUnitConfig.addContextKeywords(newElements)
+    }
+    
+    @objc public func removeContextKeyword(_ element: String) {
+        adUnitConfig.removeContextKeyword(element)
+    }
+
+    @objc public func clearContextKeywords() {
+        adUnitConfig.clearContextKeywords()
+    }
+    
+    // MARK: - App Content (app.data)
     
     @objc public func setAppContent(_ appContent: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContent)
@@ -240,7 +258,7 @@ public class BannerView: UIView,
         adUnitConfig.clearAppContentData()
     }
     
-    // MARK: - User Data
+    // MARK: - User Data (user.data)
         
     @objc public func addUserData(_ userDataObjects: [PBMORTBContentData]) {
         adUnitConfig.addUserData(userDataObjects)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
@@ -223,7 +223,7 @@ public class BaseInterstitialAdUnit :
         adUnitConfig.clearContextKeywords()
     }
     
-    // MARK: - App Content (app.data)
+    // MARK: - App Content (app.content.data)
     
     @objc public func setAppContent(_ appContent: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContent)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/GAM/BaseInterstitialAdUnit.swift
@@ -187,7 +187,7 @@ public class BaseInterstitialAdUnit :
 
     }
 
-    // MARK: - Context Data
+    // MARK: - Context Data (imp[].ext.data)
 
     @objc public func addContextData(_ data: String, forKey key: String) {
         adUnitConfig.addContextData(key: key, value: data)
@@ -205,7 +205,25 @@ public class BaseInterstitialAdUnit :
         adUnitConfig.clearContextData()
     }
     
-    // MARK: - App Content
+    // MARK: - Context keywords (imp[].ext.keywords)
+    
+    @objc public func addContextKeyword(_ newElement: String) {
+        adUnitConfig.addContextKeyword(newElement)
+    }
+    
+    @objc public func addContextKeywords(_ newElements: Set<String>) {
+        adUnitConfig.addContextKeywords(newElements)
+    }
+    
+    @objc public func removeContextKeyword(_ element: String) {
+        adUnitConfig.removeContextKeyword(element)
+    }
+
+    @objc public func clearContextKeywords() {
+        adUnitConfig.clearContextKeywords()
+    }
+    
+    // MARK: - App Content (app.data)
     
     @objc public func setAppContent(_ appContent: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContent)
@@ -227,7 +245,7 @@ public class BaseInterstitialAdUnit :
         adUnitConfig.clearAppContentData()
     }
     
-    // MARK: - User Data
+    // MARK: - User Data (user.data)
     
     @objc public func addUserData(_ userDataObjects: [PBMORTBContentData]) {
         adUnitConfig.addUserData(userDataObjects)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBannerAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBannerAdUnit.swift
@@ -106,7 +106,7 @@ public class MediationBannerAdUnit : NSObject {
         adUnitConfig.clearContextKeywords()
     }
     
-    // MARK: - App Content (app.data)
+    // MARK: - App Content (app.content.data)
     
     public func setAppContent(_ appContent: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContent)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBannerAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBannerAdUnit.swift
@@ -70,7 +70,7 @@ public class MediationBannerAdUnit : NSObject {
         set { adUnitConfig.additionalSizes = newValue }
     }
     
-    // MARK: - Context Data
+    // MARK: - Context Data (imp[].ext.data)
     
     public func addContextData(_ data: String, forKey key: String) {
         adUnitConfig.addContextData(key: key, value: data)
@@ -88,7 +88,25 @@ public class MediationBannerAdUnit : NSObject {
         adUnitConfig.clearContextData()
     }
     
-    // MARK: - App Content
+    // MARK: - Сontext keywords (imp[].ext.keywords)
+    
+    @objc public func addContextKeyword(_ newElement: String) {
+        adUnitConfig.addContextKeyword(newElement)
+    }
+    
+    @objc public func addContextKeywords(_ newElements: Set<String>) {
+        adUnitConfig.addContextKeywords(newElements)
+    }
+    
+    @objc public func removeContextKeyword(_ element: String) {
+        adUnitConfig.removeContextKeyword(element)
+    }
+
+    @objc public func clearContextKeywords() {
+        adUnitConfig.clearContextKeywords()
+    }
+    
+    // MARK: - App Content (app.data)
     
     public func setAppContent(_ appContent: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContent)
@@ -110,7 +128,7 @@ public class MediationBannerAdUnit : NSObject {
         adUnitConfig.clearAppContentData()
     }
     
-    // MARK: - User Data
+    // MARK: - User Data (user.data)
     
     public func addUserData(_ userDataObjects: [PBMORTBContentData]) {
         adUnitConfig.addUserData(userDataObjects)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
@@ -76,7 +76,7 @@ public class MediationBaseInterstitialAdUnit : NSObject {
                     completion: completion)
     }
     
-    // MARK: - Context Data
+    // MARK: - Context Data (imp[].ext.data)
     
     public func addContextData(_ data: String, forKey key: String) {
         adUnitConfig.addContextData(key: key, value: data)
@@ -94,7 +94,25 @@ public class MediationBaseInterstitialAdUnit : NSObject {
         adUnitConfig.clearContextData()
     }
     
-    // MARK: - App Content
+    // MARK: - Сontext keywords (imp[].ext.keywords)
+    
+    @objc public func addContextKeyword(_ newElement: String) {
+        adUnitConfig.addContextKeyword(newElement)
+    }
+    
+    @objc public func addContextKeywords(_ newElements: Set<String>) {
+        adUnitConfig.addContextKeywords(newElements)
+    }
+    
+    @objc public func removeContextKeyword(_ element: String) {
+        adUnitConfig.removeContextKeyword(element)
+    }
+
+    @objc public func clearContextKeywords() {
+        adUnitConfig.clearContextKeywords()
+    }
+    
+    // MARK: - App Content (app.data)
     
     public func setAppContent(_ appContent: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContent)
@@ -116,7 +134,7 @@ public class MediationBaseInterstitialAdUnit : NSObject {
         adUnitConfig.clearAppContentData()
     }
     
-    // MARK: - User Data
+    // MARK: - User Data (user.data)
     
     public func addUserData(_ userDataObjects: [PBMORTBContentData]) {
         adUnitConfig.addUserData(userDataObjects)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
@@ -112,7 +112,7 @@ public class MediationBaseInterstitialAdUnit : NSObject {
         adUnitConfig.clearContextKeywords()
     }
     
-    // MARK: - App Content (app.data)
+    // MARK: - App Content (app.content.data)
     
     public func setAppContent(_ appContent: PBMORTBAppContent) {
         adUnitConfig.setAppContent(appContent)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationNativeAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationNativeAdUnit.swift
@@ -79,7 +79,7 @@ public class MediationNativeAdUnit : NSObject {
         nativeAdUnit.ext = ext
     }
     
-    // MARK: - App Content (app.data)
+    // MARK: - App Content (app.content.data)
     
     public func setAppContent(_ appContent: PBMORTBAppContent) {
         nativeAdUnit.setAppContent(appContent)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationNativeAdUnit.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationNativeAdUnit.swift
@@ -28,6 +28,7 @@ public class MediationNativeAdUnit : NSObject {
     var configID: String
     
     // MARK: - Public Methods
+    
     public init(configId: String, mediationDelegate: PrebidMediationDelegate) {
         self.configID = configId
         self.mediationDelegate = mediationDelegate
@@ -78,7 +79,7 @@ public class MediationNativeAdUnit : NSObject {
         nativeAdUnit.ext = ext
     }
     
-    // MARK: - App Content
+    // MARK: - App Content (app.data)
     
     public func setAppContent(_ appContent: PBMORTBAppContent) {
         nativeAdUnit.setAppContent(appContent)
@@ -96,7 +97,7 @@ public class MediationNativeAdUnit : NSObject {
         nativeAdUnit.removeAppContentData(dataObject)
     }
     
-    // MARK: - User Data
+    // MARK: - User Data (user.data)
     
     public func addUserData(_ userDataObjects: [PBMORTBContentData]) {
         nativeAdUnit.addUserData(userDataObjects)
@@ -108,6 +109,42 @@ public class MediationNativeAdUnit : NSObject {
     
     public func clearUserData() {
         nativeAdUnit.clearUserData()
+    }
+    
+    // MARK: - Context Data (imp[].ext.data)
+    
+    public func addContextData(_ data: String, forKey key: String) {
+        nativeAdUnit.addContextData(key: key, value: data)
+    }
+    
+    public func updateContextData(_ data: Set<String>, forKey key: String) {
+        nativeAdUnit.updateContextData(key: key, value: data)
+    }
+    
+    public func removeContextDate(forKey key: String) {
+        nativeAdUnit.removeContextData(forKey: key)
+    }
+    
+    public func clearContextData() {
+        nativeAdUnit.clearContextData()
+    }
+    
+    // MARK: - Сontext keywords (imp[].ext.keywords)
+    
+    @objc public func addContextKeyword(_ newElement: String) {
+        nativeAdUnit.addContextKeyword(newElement)
+    }
+    
+    @objc public func addContextKeywords(_ newElements: Set<String>) {
+        nativeAdUnit.addContextKeywords(newElements)
+    }
+    
+    @objc public func removeContextKeyword(_ element: String) {
+        nativeAdUnit.removeContextKeyword(element)
+    }
+
+    @objc public func clearContextKeywords() {
+        nativeAdUnit.clearContextKeywords()
     }
     
     public func fetchDemand(completion: ((ResultCode)->Void)?) {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
@@ -142,7 +142,7 @@ public class AdUnitConfig: NSObject, NSCopying {
         contextKeywords
     }
 
-    // MARK: - App Content (app.data)
+    // MARK: - App Content (app.content.data)
 
     public func setAppContent(_ appContent: PBMORTBAppContent) {
         self.appContent = appContent

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
@@ -120,7 +120,7 @@ public class AdUnitConfig: NSObject, NSCopying {
         contextDataDictionary
     }
 
-    // MARK: - Context keywords (imp[].ext.context.keywords)
+    // MARK: - Context keywords (imp[].ext.keywords)
 
     public func addContextKeyword(_ newElement: String) {
         contextKeywords.insert(newElement)

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
@@ -243,6 +243,7 @@ public class AdUnitConfig: NSObject, NSCopying {
         clone.minSizePerc = self.minSizePerc
         clone.extensionData = self.extensionData.merging(clone.extensionData) { $1 }
         clone.adPosition = self.adPosition
+        clone.pbAdSlot = self.pbAdSlot
         
         return clone
     }

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
@@ -242,6 +242,9 @@ public class AdUnitConfig: NSObject, NSCopying {
         clone.refreshInterval = self.refreshInterval
         clone.minSizePerc = self.minSizePerc
         clone.extensionData = self.extensionData.merging(clone.extensionData) { $1 }
+        clone.appContent = self.appContent
+        clone.contextKeywords = self.contextKeywords
+        clone.userData = self.userData
         clone.adPosition = self.adPosition
         clone.pbAdSlot = self.pbAdSlot
         

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
@@ -94,7 +94,7 @@ public class AdUnitConfig: NSObject, NSCopying {
         adConfiguration.size = adSize
     }
     
-    // MARK: - Context Data (imp[].ext.context.data)
+    // MARK: - Context Data (imp[].ext.data)
 
     public func addContextData(key: String, value: String) {
         if extensionData[key] == nil {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/PBMPrebidParameterBuilder.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/PBMPrebidParameterBuilder.m
@@ -163,10 +163,10 @@
         nextImp.extPrebid.isRewardedInventory = self.adConfiguration.adConfiguration.isOptIn;
         
         if (self.adConfiguration.contextDataDictionary.count > 0) {
-            nextImp.extContextData = self.adConfiguration.contextDataDictionary.mutableCopy;
+            nextImp.extData = self.adConfiguration.contextDataDictionary.mutableCopy;
         }
         
-        nextImp.extContextData[@"adslot"] = [self.adConfiguration getPbAdSlot];
+        nextImp.extData[@"adslot"] = [self.adConfiguration getPbAdSlot];
        
         for (AdFormat* adFormat in adFormats) {
             if (adFormat == AdFormat.display) {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/PBMPrebidParameterBuilder.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/PBMPrebidParameterBuilder.m
@@ -166,6 +166,11 @@
             nextImp.extData = self.adConfiguration.contextDataDictionary.mutableCopy;
         }
         
+        if ([self.adConfiguration getContextKeywords].count > 0) {
+            NSMutableArray * contextKeywords = [NSMutableArray arrayWithArray:[[self.adConfiguration getContextKeywords] allObjects]];
+            nextImp.extKeywords = [contextKeywords componentsJoinedByString:@","];
+        }
+        
         nextImp.extData[@"adslot"] = [self.adConfiguration getPbAdSlot];
        
         for (AdFormat* adFormat in adFormats) {

--- a/PrebidMobileTests/RenderingTests/Tests/PBMORTBAbstractTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMORTBAbstractTest.swift
@@ -238,9 +238,9 @@ class PBMORTBAbstractTest : XCTestCase {
         pbmORTBImp.instl = 1
         pbmORTBImp.tagid = "tagid"
         pbmORTBImp.secure = 1
-        pbmORTBImp.extContextData = ["lookup_words": ["dragon", "flame"]]
+        pbmORTBImp.extData = ["lookup_words": ["dragon", "flame"]]
         
-        codeAndDecode(abstract: pbmORTBImp, expectedString: "{\"clickbrowser\":0,\"displaymanager\":\"MOCK_SDK_NAME\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"context\":{\"data\":{\"lookup_words\":[\"dragon\",\"flame\"]}},\"dlp\":1},\"id\":\"\(uuid)\",\"instl\":1,\"native\":{\"ver\":\"1.2\"},\"secure\":1,\"tagid\":\"tagid\"}")
+        codeAndDecode(abstract: pbmORTBImp, expectedString: "{\"clickbrowser\":0,\"displaymanager\":\"MOCK_SDK_NAME\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"data\":{\"lookup_words\":[\"dragon\",\"flame\"]},\"dlp\":1},\"id\":\"\(uuid)\",\"instl\":1,\"native\":{\"ver\":\"1.2\"},\"secure\":1,\"tagid\":\"tagid\"}")
     }
     
     

--- a/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/ParameterBuilderServiceTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/ParameterBuilderServiceTest.swift
@@ -49,6 +49,7 @@ class ParameterBuilderServiceTest : XCTestCase {
         targeting.userCustomData = "customDataString"
         targeting.publisherName = publisherName
         targeting.addUserKeyword("keyword1,keyword2")
+        targeting.addContextKeyword("appKeyword1,appKeyword2")
         
         let sdkConfiguration = Prebid.mock
         
@@ -139,7 +140,7 @@ class ParameterBuilderServiceTest : XCTestCase {
         }
         
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\",\"publisher\":{\"name\":\"Publisher\"},\"storeurl\":\"https:\\/\\/openx.com\"},\"device\":{\"carrier\":\"MOCK_CARRIER_NAME\",\"connectiontype\":2,\(deviceExt)\"geo\":{\"lat\":34.149335,\"lon\":-118.1328249,\"type\":1},\"h\":200,\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"mccmnc\":\"123-456\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":0,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":1,\"ext\":{\"gdpr\":0}},\"user\":{\"buyeruid\":\"buyerUID\",\"customdata\":\"customDataString\",\"ext\":{\"consent\":\"consentstring\"},\"gender\":\"M\",\"keywords\":\"keyword1,keyword2\"}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"keywords\":\"appKeyword1,appKeyword2\",\"name\":\"MockBundleDisplayName\",\"publisher\":{\"name\":\"Publisher\"},\"storeurl\":\"https:\\/\\/openx.com\"},\"device\":{\"carrier\":\"MOCK_CARRIER_NAME\",\"connectiontype\":2,\(deviceExt)\"geo\":{\"lat\":34.149335,\"lon\":-118.1328249,\"type\":1},\"h\":200,\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"mccmnc\":\"123-456\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":0,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":1,\"ext\":{\"gdpr\":0}},\"user\":{\"buyeruid\":\"buyerUID\",\"customdata\":\"customDataString\",\"ext\":{\"consent\":\"consentstring\"},\"gender\":\"M\",\"keywords\":\"keyword1,keyword2\"}}
         """
         PBMAssertEq(strORTB, expectedOrtb)
     }

--- a/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/PrebidParameterBuilderTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/PrebidParameterBuilderTest.swift
@@ -196,6 +196,21 @@ class PrebidParameterBuilderTest: XCTestCase {
         
         XCTAssertEqual(imp.extData, ["buy": ["mushrooms"]])
     }
+    
+    func testAdUnitSpecificKeywords() {
+        let adUnit = AdUnit(configId: "config_id", size: nil)
+        
+        let expectedKeywords = Set<String>(["keyword1", "keyword2", "keyword3"])
+        
+        adUnit.addContextKeywords(expectedKeywords)
+        
+        let bidRequest = buildBidRequest(with: adUnit.adUnitConfig)
+        
+        bidRequest.imp.forEach { imp in
+            let resultKeywords = Set<String>((imp.extKeywords?.components(separatedBy: ",")) ?? [])
+            XCTAssertEqual(resultKeywords, expectedKeywords)
+        }
+    }
 
     func testPbAdSlotWithContextDataDictionary() {
         let testAdSlot = "test ad slot"

--- a/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/PrebidParameterBuilderTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/PrebidParameterBuilderTest.swift
@@ -194,7 +194,7 @@ class PrebidParameterBuilderTest: XCTestCase {
             return
         }
         
-        XCTAssertEqual(imp.extContextData, ["buy": ["mushrooms"]])
+        XCTAssertEqual(imp.extData, ["buy": ["mushrooms"]])
     }
 
     func testPbAdSlotWithContextDataDictionary() {
@@ -210,13 +210,13 @@ class PrebidParameterBuilderTest: XCTestCase {
         let bidRequest = buildBidRequest(with: adUnitConfig)
 
         bidRequest.imp.forEach { imp in
-            guard let extContextData = imp.extContextData as? [String: Any], let result = extContextData["key"] as? [String] else {
+            guard let extData = imp.extData as? [String: Any], let result = extData["key"] as? [String] else {
                 XCTFail()
                 return
             }
 
             XCTAssertEqual(Set(result), Set(["value1", "value2"]))
-            XCTAssertEqual(extContextData["adslot"] as? String, testAdSlot)
+            XCTAssertEqual(extData["adslot"] as? String, testAdSlot)
         }
     }
 


### PR DESCRIPTION
Closes #785 

- move `imp[].ext.context.data` to `imp[].ext.data`;
- move `imp[].ext.context.keywords` to `imp[].ext.keywords`;
- add command line args setup in `InternalTestApp` for testing;
- update setup adunit-specific properties in each test case in `InternalTestApp`(`imp[].ext.data`, `imp[].ext.keywords`, `user.data`, `app.content.data`);
- remove redundunt logs from `Targeting` getters;
- add `app.keywords` to bid request;
- add `imp[].ext.data` and `imp[].ext.keywords` to bid request;
- add missing `imp[].ext.keywords` setters/getters into `BannerView` (Rendering API);
- add missing `imp[].ext.keywords` setters/getters into `BaseInterstitialAdUnit` (Rendering API);
- add missing `imp[].ext.keywords` setters/getters into `MediationBannerAdUnit` (Rendering API);
- add missing `imp[].ext.keywords` setters/getters into `MediationBaseInterstitialAdUnit` (Rendering API);
- add missing `imp[].ext.keywords` setters/getters into `MediationNativeAdUnit` (Rendering API);
- rename`app.data` to `app.content.data` in comments;
- add/update unit tests