### PR TITLE
Fix zsh redirection

### DIFF
--- a/scripts/buildPrebidMobile.sh
+++ b/scripts/buildPrebidMobile.sh
@@ -123,11 +123,12 @@ do
 	# find all .bcsymbolmap and concatinate -debug-symbols
 	debugSymbolsBcsymbolmap=""
 
+	bcsymbolmapsFileName=$([ -d "$XCODE_ARCHIVE_DIR_ABSOLUTE/${schemes[$n]}.xcarchive/BCSymbolMaps" ] &&  find "$XCODE_ARCHIVE_DIR_ABSOLUTE/${schemes[$n]}.xcarchive/BCSymbolMaps" -name "*.bcsymbolmap")
 	while read bcsymbolmapsFileName
 	do
 	    # echo "BCSymbolMap: '$bcsymbolmapsFileName'"
 	    debugSymbolsBcsymbolmap="$debugSymbolsBcsymbolmap -debug-symbols \"$bcsymbolmapsFileName\""
-	done < <(find "$XCODE_ARCHIVE_DIR_ABSOLUTE/${schemes[$n]}.xcarchive/BCSymbolMaps" -name "*.bcsymbolmap")
+	done
 
 	# echo "debugSymbolsBcsymbolmap: '$debugSymbolsBcsymbolmap'"
 


### PR DESCRIPTION
For some reason the output redirection doesn't work in zsh / mac osx

I've tried to maintain the same feature while support both zsh + bash

Before this change running buildPrebidMobile.sh continuously fails in zsh with the following error message

```
BUILD PREBID MOBILE


./scripts/buildPrebidMobile.sh: line 130: syntax error near unexpected token `<'
```
https://github.com/prebid/prebid-mobile-ios/blob/master/scripts/buildPrebidMobile.sh#L130