### PR TITLE
Change default omidpv value to Prebid SDK version in rendering API

### DIFF
--- a/PrebidMobile/PrebidMobileRendering/3dPartyWrappers/OpenMeasurement/PBMOpenMeasurementWrapper.m
+++ b/PrebidMobile/PrebidMobileRendering/3dPartyWrappers/OpenMeasurement/PBMOpenMeasurementWrapper.m
@@ -272,7 +272,7 @@ static NSString * const PBMOpenMeasurementCustomRefId   = @"";
     }
     
     self.partner = [[OMIDPrebidorgPartner alloc] initWithName:self.partnerName
-                                                versionString:[PBMFunctions omidVersion]];
+                                                versionString:[PBMFunctions sdkVersion]];
 }
 
 -(nullable NSString*)fetchOMSDKScript {

--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/PBMPrebidParameterBuilder.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/PBMPrebidParameterBuilder.m
@@ -107,7 +107,7 @@
     
     if (!self.adConfiguration.adConfiguration.isOriginalAPI) {
         extSource.omidpn = @"Prebid";
-        extSource.omidpv = [PBMFunctions omidVersion];
+        extSource.omidpv = [PBMFunctions sdkVersion];
     }
     
     if (Targeting.shared.omidPartnerName) {

--- a/PrebidMobile/PrebidMobileRendering/Utilities/PBMFunctions.h
+++ b/PrebidMobile/PrebidMobileRendering/Utilities/PBMFunctions.h
@@ -20,7 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PBMFunctions : NSObject
 
 + (NSString *)sdkVersion;
-+ (NSString *)omidVersion;
 + (nonnull NSArray<NSString *> *)supportedSKAdNetworkVersions;
 + (NSDictionary<NSString *, NSString *> *)extractVideoAdParamsFromTheURLString:(NSString *)urlString forKeys:(NSArray *)keys;
 + (BOOL)canLoadVideoAdWithDomain:(NSString *)domain adUnitID:(nullable NSString *)adUnitID adUnitGroupID:(nullable NSString *)adUnitGroupID;

--- a/PrebidMobile/PrebidMobileRendering/Utilities/PBMFunctions.m
+++ b/PrebidMobile/PrebidMobileRendering/Utilities/PBMFunctions.m
@@ -42,11 +42,6 @@ static NSString * const PBMPlistExt = @"plist";
     return version ? version : @"";
 }
 
-+ (NSString *)omidVersion {
-    // FIXME: review the version on the next certification with IAB
-    return @"5.0";
-}
-
 // MARK: - SKAdNetwork
 
 + (nonnull NSArray<NSString *> *)supportedSKAdNetworkVersions {

--- a/PrebidMobileTests/RenderingTests/Tests/PBMORTBAbstractTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMORTBAbstractTest.swift
@@ -26,7 +26,7 @@ class PBMORTBAbstractTest : XCTestCase {
     }
     
     private var omidVersion: String {
-        return PBMFunctions.omidVersion();
+        return PBMFunctions.sdkVersion();
     }
     
     private let userAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 OpenXSDK/\(Prebid.shared.version)"

--- a/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/PrebidParameterBuilderTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/PrebidParameterBuilderTest.swift
@@ -239,11 +239,11 @@ class PrebidParameterBuilderTest: XCTestCase {
         let configId = "b6260e2b-bc4c-4d10-bdb5-f7bdd62f5ed4"
         let adUnitConfig = AdUnitConfig(configId: configId, size: CGSize(width: 320, height: 50))
         Targeting.shared.omidPartnerName = "Prebid"
-        Targeting.shared.omidPartnerVersion = PBMFunctions.omidVersion()
+        Targeting.shared.omidPartnerVersion = PBMFunctions.sdkVersion()
         var bidRequest = buildBidRequest(with: adUnitConfig)
 
         XCTAssertEqual(bidRequest.source.extOMID.omidpn, "Prebid")
-        XCTAssertEqual(bidRequest.source.extOMID.omidpv, PBMFunctions.omidVersion())
+        XCTAssertEqual(bidRequest.source.extOMID.omidpv, PBMFunctions.sdkVersion())
 
         targeting.omidPartnerVersion = "test omid version"
         targeting.omidPartnerName = "test omid name"


### PR DESCRIPTION
Changed to use Prebid SDK Version (like it does on Android).  Removed the omidversion function as it was a hardcoded value and no longer needed as the Prebid SDK version is always used.  Also updated the tests to use the SDK version and ran all tests and they passed.

Addresses this issue: https://github.com/prebid/prebid-mobile-ios/pull/884 