### PR TITLE
Fix double encoding and replace bid price on Native Ad

### DIFF
--- a/PrebidMobile/AdUnits/Native/NativeAd.swift
+++ b/PrebidMobile/AdUnits/Native/NativeAd.swift
@@ -107,7 +107,11 @@ import UIKit
         }) else {
             return nil
         }
-        
+
+        let macrosHelper = PBMORTBMacrosHelper(bid: rawBid)
+        rawBid.adm = macrosHelper.replaceMacros(in: rawBid.adm)
+        rawBid.nurl = macrosHelper.replaceMacros(in: rawBid.nurl)
+
         let ad = NativeAd()
         
         let internalEventTracker = PrebidServerEventTracker()

--- a/PrebidMobile/AdUnits/Native/NativeAd.swift
+++ b/PrebidMobile/AdUnits/Native/NativeAd.swift
@@ -294,8 +294,7 @@ import UIKit
     @objc private func handleClick() {
         self.delegate?.adWasClicked?(ad: self)
         if let clickUrl = nativeAdMarkup?.link?.url,
-           let clickUrlString = clickUrl.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-           let url = URL(string: clickUrlString) {
+           let url = URL(string: clickUrl) {
             if openURLWithExternalBrowser(url: url) {
                 if let clickTrackers = nativeAdMarkup?.link?.clicktrackers {
                     fireClickTrackers(clickTrackersUrls: clickTrackers)


### PR DESCRIPTION
This PR fixes a bug where the {AUCTION_PRICE} template in a url was not replaced with the bid price. 
And fixes a double encoding of the click url from the native ad.