### PR TITLE
Fix CacheManager concurrency issue

### DIFF
--- a/PrebidMobileTests/CacheManagerTests.swift
+++ b/PrebidMobileTests/CacheManagerTests.swift
@@ -74,4 +74,22 @@ class CacheManagerTests: XCTestCase {
         
         waitForExpectations(timeout: 5.0)
     }
+
+    func testConcurrency() {
+        let manager = CacheManager.shared
+        for _ in 1 ... 1000 {
+            let expectation = XCTestExpectation(description: "All tasks are done")
+            expectation.expectedFulfillmentCount = 2
+            let concurrentQueue = DispatchQueue(label: "test", attributes: .concurrent)
+            concurrentQueue.async {
+                _ = manager.save(content: UUID().uuidString)
+                expectation.fulfill()
+            }
+            concurrentQueue.async {
+                _ = manager.get(cacheId: "1")
+                expectation.fulfill()
+            }
+            wait(for: [expectation])
+        }
+    }
 }


### PR DESCRIPTION
Fix #921 by using `NSLock` when accessing shared resources: `savedValuesDict` and `delegates`.