### PR TITLE
Remove data from request as its already contained on the uploadTask

### DIFF
--- a/PrebidMobile/PrebidMobileRendering/Networking/PrebidServerConnection.swift
+++ b/PrebidMobile/PrebidMobileRendering/Networking/PrebidServerConnection.swift
@@ -101,7 +101,6 @@ public class PrebidServerConnection: NSObject, PrebidServerConnectionProtocol, U
         }
         
         request.httpMethod = HTTPMethodPOST
-        request.httpBody = data
         request.timeoutInterval = timeout
         request.setValue(contentType, forHTTPHeaderField: PrebidServerConnection.contentTypeKey)
         


### PR DESCRIPTION
This PR is to address issue #920 where an error is shown on`session.uploadTask` when the request contains a body.

As the title states, the data should not be required in the request as its already passed to the `uploadTask` method.