### PR TITLE
Fix crash in SFSafariViewController

### DIFF
--- a/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/PBMSafariVCOpener.m
+++ b/PrebidMobile/PrebidMobileRendering/Prebid/PBMCore/PBMSafariVCOpener.m
@@ -112,6 +112,11 @@
         return NO;
     }
      
+    if (!([strURLscheme isEqualToString:@"http"] || [strURLscheme isEqualToString:@"https"])) {
+        PBMLogError(@"Attempting to open url [%@] in SFSafariViewController. SFSafariViewController only supports initial URLs with http:// or https:// schemes.", url);
+        return NO;
+    }
+    
     //Show clickthrough browser
     
     return [self openClickthroughWithURL:url


### PR DESCRIPTION
During click handling an attempt to open SFSafariViewController could result in a crash.
`The specified URL has an unsupported scheme. Only HTTP and HTTPS URLs are supported.`

The check is added to the section of PBMSafariVCOpener where some other similar checks are carried out.

Fixes to https://github.com/prebid/prebid-mobile-ios/issues/966