### PR TITLE
Tracking URL

### DIFF
--- a/PrebidMobile/Host.swift
+++ b/PrebidMobile/Host.swift
@@ -109,7 +109,7 @@ public class Host: NSObject {
     }
     
     public func getHostURL() throws -> String {
-        guard let customHostURL = customHostURL else {
+        guard let customHostURL else {
             throw ErrorCode.prebidServerURLInvalid("")
         }
         return customHostURL.absoluteString

--- a/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMAbstractCreative.m
+++ b/PrebidMobile/PrebidMobileRendering/AdTypes/AdView/PBMAbstractCreative.m
@@ -173,7 +173,7 @@
         self.viewabilityTracker = [[PBMCreativeViewabilityTracker alloc] initWithCreative:self];
     }
     
-    PBMORTBBidExtSkadn * skadnInfo = self.transaction.skadnInfo;
+    PBMORTBBidExtSkadn * skadnInfo = self.transaction.bid.skadn;
     
     BOOL showSKOverlay = !self.creativeModel.hasCompanionAd &&
                          self.creativeModel.adConfiguration.isInterstitialAd &&

--- a/PrebidMobileTests/RenderingTests/Tests/PrebidTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PrebidTest.swift
@@ -179,7 +179,6 @@ class PrebidTest: XCTestCase {
         try host.setHostURL(customTrackingHost, nonTrackingURLString: customNonTrackingHost)
         
         //then
-        XCTAssertEqual(PrebidHost.Custom, Prebid.shared.prebidServerHost)
         let getHostURLResult = try host.getHostURL()
         XCTAssertEqual(customTrackingHost, getHostURLResult)
     }


### PR DESCRIPTION
#954 

- Extends `setCustomPrebidServer` method with `nonTrackingURL` parameter.
- Returns the PBS URL based on ATT status.