### PR TITLE
Update playbackend default value from 2 → 1 for interstitial video ads

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/Prebid/PBMCore/PBMPrebidParameterBuilder.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/Prebid/PBMCore/PBMPrebidParameterBuilder.m
@@ -197,7 +197,7 @@
                 PBMORTBVideo * const nextVideo = nextImp.video;
                 
                 if (!self.adConfiguration.adConfiguration.isOriginalAPI) {
-                    nextVideo.playbackend = @(2);
+                    nextVideo.playbackend = @(1);
                     nextVideo.pos = @(7);
                     nextVideo.protocols = @[@(2),@(5)];
                     nextVideo.mimes = PrebidConstants.SUPPORTED_VIDEO_MIME_TYPES;

--- a/PrebidMobileTests/RenderingTests/Tests/PBMORTBAbstractTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMORTBAbstractTest.swift
@@ -337,9 +337,9 @@ class PBMORTBAbstractTest : XCTestCase {
         pbmORTBVideo.protocols = [2, 5]
         pbmORTBVideo.pos = 7
         pbmORTBVideo.delivery = [3]
-        pbmORTBVideo.playbackend = 2
+        pbmORTBVideo.playbackend = 1
         
-        codeAndDecode(abstract: pbmORTBVideo, expectedString: "{\"delivery\":[3],\"h\":200,\"linearity\":1,\"maxbitrate\":40,\"maxduration\":100,\"mimes\":[\"video\\/mp4\",\"video\\/quicktime\",\"video\\/x-m4v\",\"video\\/3gpp\",\"video\\/3gpp2\"],\"minbitrate\":20,\"minduration\":10,\"playbackend\":2,\"pos\":7,\"protocols\":[2,5],\"startdelay\":5,\"w\":100}")
+        codeAndDecode(abstract: pbmORTBVideo, expectedString: "{\"delivery\":[3],\"h\":200,\"linearity\":1,\"maxbitrate\":40,\"maxduration\":100,\"mimes\":[\"video\\/mp4\",\"video\\/quicktime\",\"video\\/x-m4v\",\"video\\/3gpp\",\"video\\/3gpp2\"],\"minbitrate\":20,\"minduration\":10,\"playbackend\":1,\"pos\":7,\"protocols\":[2,5],\"startdelay\":5,\"w\":100}")
     }
     
     func testFormatToJsonString() {

--- a/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/PrebidParameterBuilderTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/PrebidParameterBuilderTest.swift
@@ -166,7 +166,7 @@ class PrebidParameterBuilderTest: XCTestCase {
         PBMAssertEq(video.protocols, [2, 5])
         PBMAssertEq(video.startdelay, -1)
         PBMAssertEq(video.mimes, PrebidConstants.SUPPORTED_VIDEO_MIME_TYPES)
-        PBMAssertEq(video.playbackend, 2)
+        PBMAssertEq(video.playbackend, 1)
         PBMAssertEq(video.delivery, [3])
         PBMAssertEq(video.battr, [15, 16])
         PBMAssertEq(video.skip, 0)
@@ -610,7 +610,7 @@ class PrebidParameterBuilderTest: XCTestCase {
         PBMAssertEq(video.protocols, [2,5])
         PBMAssertEq(video.delivery!, [3])
         PBMAssertEq(video.pos, 7)
-        PBMAssertEq(video.playbackend, 2)
+        PBMAssertEq(video.playbackend, 1)
     }
 
     func testParameterBuilderInterstitialVAST() {


### PR DESCRIPTION
## Summary
Change the default value of the `playbackend` from 2 → 1 for interstitial video ads.

## Current Behavior
- The `playBackend` property is set to `2` by default.
- All videos are interstitials, so "On Leaving Viewport" never occurs.
- Video end always happens as "On Video Completion or when Terminated by User".
- Sending `playBackend = 2` may cause DSPs / advertisers to undervalue the ad request, leading to lower bids than the actual inventory performance would justify.

## Change
- Update default value of `playBackend` to `1` to reflect actual behavior.

## Impact
- This change is backward-compatible and only adjusts the default setting to better reflect real playback behavior, without impacting other features.

## Related Issue
- Closes #1199 