### PR TITLE
Device screen size in pixels in a request

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/Networking/Parameters/PBMDeviceInfoParameterBuilder.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/Networking/Parameters/PBMDeviceInfoParameterBuilder.m
@@ -74,7 +74,7 @@
         return;
     }
     
-    CGSize screenSize = self.deviceAccessManager.screenSize;
+    CGSize screenSize = self.deviceAccessManager.screenSizeInPixels;
     
     bidRequest.device.w = @(screenSize.width);
     bidRequest.device.h = @(screenSize.height);

--- a/PrebidMobile/Objc/PrebidMobileRendering/ORTB/PBMORTBBidRequestExtPrebid.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/ORTB/PBMORTBBidRequestExtPrebid.m
@@ -44,10 +44,12 @@
     ret[@"storedrequest"] = storedRequest;
     storedRequest[@"id"] = self.storedRequestID;
     
+    PBMMutableJsonDictionary *sdk = [PBMMutableJsonDictionary new];
+    sdk[@"usepxratio"] = @YES;
     if (self.sdkRenderers != nil && self.sdkRenderers.count > 0) {
-        NSDictionary * sdk = @{ @"renderers" : self.sdkRenderers };
-        ret[@"sdk"] = sdk;
+        sdk[@"renderers"] = self.sdkRenderers;
     }
+    ret[@"sdk"] = sdk;
     
     ret[@"targeting"] = self.targeting;
     

--- a/PrebidMobile/Swift/PrebidMobileRendering/Utilities/DeviceAccessManager.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Utilities/DeviceAccessManager.swift
@@ -101,4 +101,12 @@ public class DeviceAccessManager: NSObject {
     @objc public func screenSize() -> CGSize {
         UIDevice.current.screenSize
     }
+    
+    @objc public func screenSizeInPixels() -> CGSize {
+        let toPixels = {
+            Int(($0 * UIScreen.main.scale).rounded())
+        }
+        let size = screenSize()
+        return CGSize(width: toPixels(size.width), height: toPixels(size.height))
+    }
 }

--- a/PrebidMobileTests/RenderingTests/Mocks/MockDeviceAccessManager.swift
+++ b/PrebidMobileTests/RenderingTests/Mocks/MockDeviceAccessManager.swift
@@ -83,6 +83,14 @@ class MockDeviceAccessManager: DeviceAccessManager {
         return CGSize(width: 100, height: 200)
     }
     
+    override func screenSizeInPixels() -> CGSize {
+        let toPixels = {
+            Int(($0 * UIScreen.main.scale).rounded())
+        }
+        let size = screenSize()
+        return CGSize(width: toPixels(size.width), height: toPixels(size.height))
+    }
+    
     class func reset() {
         self.mockAdvertisingTrackingEnabled = advertisingTrackingEnabledDefault
         self.mockUserLanguageCode = defaultUserLanguageCode

--- a/PrebidMobileTests/RenderingTests/Tests/PBMDeviceAccessManagerTests.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMDeviceAccessManagerTests.swift
@@ -53,10 +53,15 @@ class PBMDeviceAccessManagerTests : XCTestCase {
     
     func testScreenSize() {
         let size = deviceAccessManager.screenSize()
+        let sizeInPixels = deviceAccessManager.screenSizeInPixels()
         
         // nothing to test other than running it and it doesn't crash.
         XCTAssert(size.width > 0)
         XCTAssert(size.height > 0)
+        
+        XCTAssert(sizeInPixels.width > 0)
+        XCTAssert(sizeInPixels.height > 0)
+
     }
     
     func testUserLanguage() {

--- a/PrebidMobileTests/RenderingTests/Tests/PBMORTBAbstractTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMORTBAbstractTest.swift
@@ -183,12 +183,12 @@ class PBMORTBAbstractTest : XCTestCase {
         extPrebid.storedAuctionResponse = "stored-auction-response-test"
         extPrebid.sdkRenderers = [["name": "MockRenderer1", "version": "0.0.1"], ["name": "MockRenderer2", "version": "0.0.2"]]
         
-        codeAndDecode(abstract: extPrebid, expectedString: "{\"data\":{\"bidders\":[\"openx\",\"prebid\",\"thanatos\"]},\"sdk\":{\"renderers\":[{\"name\":\"MockRenderer1\",\"version\":\"0.0.1\"},{\"name\":\"MockRenderer2\",\"version\":\"0.0.2\"}]},\"storedauctionresponse\":{\"id\":\"stored-auction-response-test\"},\"storedrequest\":{\"id\":\"b4eb1475-4e3d-4186-97b7-25b6a6cf8618\"},\"targeting\":{}}")
+        codeAndDecode(abstract: extPrebid, expectedString: "{\"data\":{\"bidders\":[\"openx\",\"prebid\",\"thanatos\"]},\"sdk\":{\"renderers\":[{\"name\":\"MockRenderer1\",\"version\":\"0.0.1\"},{\"name\":\"MockRenderer2\",\"version\":\"0.0.2\"}],\"usepxratio\":true},\"storedauctionresponse\":{\"id\":\"stored-auction-response-test\"},\"storedrequest\":{\"id\":\"b4eb1475-4e3d-4186-97b7-25b6a6cf8618\"},\"targeting\":{}}")
         
         let pbmORTBBidRequest = PBMORTBBidRequest()
         pbmORTBBidRequest.extPrebid = extPrebid
         
-        codeAndDecode(abstract: pbmORTBBidRequest, expectedString: "{\"ext\":{\"prebid\":{\"data\":{\"bidders\":[\"openx\",\"prebid\",\"thanatos\"]},\"sdk\":{\"renderers\":[{\"name\":\"MockRenderer1\",\"version\":\"0.0.1\"},{\"name\":\"MockRenderer2\",\"version\":\"0.0.2\"}]},\"storedauctionresponse\":{\"id\":\"stored-auction-response-test\"},\"storedrequest\":{\"id\":\"b4eb1475-4e3d-4186-97b7-25b6a6cf8618\"},\"targeting\":{}}},\"imp\":[{\"clickbrowser\":1,\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":0}]}")
+        codeAndDecode(abstract: pbmORTBBidRequest, expectedString: "{\"ext\":{\"prebid\":{\"data\":{\"bidders\":[\"openx\",\"prebid\",\"thanatos\"]},\"sdk\":{\"renderers\":[{\"name\":\"MockRenderer1\",\"version\":\"0.0.1\"},{\"name\":\"MockRenderer2\",\"version\":\"0.0.2\"}],\"usepxratio\":true},\"storedauctionresponse\":{\"id\":\"stored-auction-response-test\"},\"storedrequest\":{\"id\":\"b4eb1475-4e3d-4186-97b7-25b6a6cf8618\"},\"targeting\":{}}},\"imp\":[{\"clickbrowser\":1,\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":0}]}")
     }
     
     func testSourceToJsonString() {

--- a/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/DeviceInfoParameterBuilderTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/DeviceInfoParameterBuilderTest.swift
@@ -22,12 +22,14 @@ class DeviceInfoParameterBuilderTest: XCTestCase {
 
     let initialDict = [String:String]()
     var userDefaults: UserDefaults!
+    var mockDeviceAccessManager: MockDeviceAccessManager!
     var deviceInfoParameterBuilder: DeviceInfoParameterBuilder!
     var bidRequest: PBMORTBBidRequest!
 
     override func setUp() {
         self.userDefaults = UserDefaults()
-        self.deviceInfoParameterBuilder = DeviceInfoParameterBuilder(deviceAccessManager: MockDeviceAccessManager(rootViewController: nil))
+        self.mockDeviceAccessManager = MockDeviceAccessManager(rootViewController: nil)
+        self.deviceInfoParameterBuilder = DeviceInfoParameterBuilder(deviceAccessManager: self.mockDeviceAccessManager)
         self.bidRequest = PBMORTBBidRequest()
     }
 
@@ -38,9 +40,10 @@ class DeviceInfoParameterBuilderTest: XCTestCase {
 
     func testDeviceSize() {
         self.deviceInfoParameterBuilder.build(self.bidRequest)
+        let expectedScreenSize = self.mockDeviceAccessManager.screenSizeInPixels()
         
-        PBMAssertEq(self.bidRequest.device.w, 100)
-        PBMAssertEq(self.bidRequest.device.h, 200)
+        PBMAssertEq(self.bidRequest.device.w, NSNumber(value: Int(expectedScreenSize.width)))
+        PBMAssertEq(self.bidRequest.device.h, NSNumber(value: Int(expectedScreenSize.height)))
     }
 
     func testAdTrackingEnabled() {

--- a/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/ParameterBuilderServiceTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/ParameterBuilderServiceTest.swift
@@ -33,6 +33,11 @@ class ParameterBuilderServiceTest : XCTestCase {
     }
     
     var sdkVersion: String { return Bundle(for: BannerView.self).infoDictionary!["CFBundleShortVersionString"] as! String }
+
+    private func expectedDeviceSizeInPixels(_ deviceAccessManager: MockDeviceAccessManager) -> (width: Int, height: Int) {
+        let size = deviceAccessManager.screenSizeInPixels()
+        return (Int(size.width), Int(size.height))
+    }
     
     func testBuildParamsDict() {
         let url = "https://openx.com"
@@ -108,8 +113,8 @@ class ParameterBuilderServiceTest : XCTestCase {
         PBMAssertEq(bidRequest.app.publisher?.name, publisherName)
         
         //Verify DeviceInfoParameterBuilder
-        PBMAssertEq(bidRequest.device.w!.intValue, Int(mockDeviceAccessManager.screenSize().width))
-        PBMAssertEq(bidRequest.device.h!.intValue, Int(mockDeviceAccessManager.screenSize().height))
+        PBMAssertEq(bidRequest.device.w!.intValue, Int(mockDeviceAccessManager.screenSizeInPixels().width))
+        PBMAssertEq(bidRequest.device.h!.intValue, Int(mockDeviceAccessManager.screenSizeInPixels().height))
         PBMAssertEq(bidRequest.device.ifa, MockDeviceAccessManager.mockAdvertisingIdentifier)
         PBMAssertEq(bidRequest.device.lmt, 0)
         PBMAssertEq(bidRequest.device.hwv, mockDeviceAccessManager.platformString)
@@ -152,8 +157,9 @@ class ParameterBuilderServiceTest : XCTestCase {
             mccmnc = "\"mccmnc\":\"123-456\","
         }
         
+        let deviceSize = expectedDeviceSizeInPixels(mockDeviceAccessManager)
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"keywords\":\"appKeyword1,appKeyword2\",\"name\":\"MockBundleDisplayName\",\"publisher\":{\"name\":\"Publisher\"},\"storeurl\":\"https:\\/\\/openx.com\"},\"device\":{\(carrier)\"connectiontype\":2,\(deviceExt)\"geo\":{\"lat\":34.149335,\"lon\":-118.1328249,\"type\":1},\"h\":200,\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\(mccmnc)\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":1,\"ext\":{\"gdpr\":0}},\"user\":{\"ext\":{\"consent\":\"consentstring\"},\"keywords\":\"keyword1,keyword2\"}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"keywords\":\"appKeyword1,appKeyword2\",\"name\":\"MockBundleDisplayName\",\"publisher\":{\"name\":\"Publisher\"},\"storeurl\":\"https:\\/\\/openx.com\"},\"device\":{\(carrier)\"connectiontype\":2,\(deviceExt)\"geo\":{\"lat\":34.149335,\"lon\":-118.1328249,\"type\":1},\"h\":\(deviceSize.height),\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\(mccmnc)\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":\(deviceSize.width)},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":1,\"ext\":{\"gdpr\":0}},\"user\":{\"ext\":{\"consent\":\"consentstring\"},\"keywords\":\"keyword1,keyword2\"}}
         """
         PBMAssertEq(strORTB, expectedOrtb)
     }
@@ -227,8 +233,9 @@ class ParameterBuilderServiceTest : XCTestCase {
             deviceExt = "\"ext\":{\"atts\":3},"
         }
 
+        let deviceSize = expectedDeviceSizeInPixels(mockDeviceAccessManager)
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"geo\":{\"lat\":34.15,\"lon\":-118.13,\"type\":1},\"h\":200,\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"geo\":{\"lat\":34.15,\"lon\":-118.13,\"type\":1},\"h\":\(deviceSize.height),\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":\(deviceSize.width)},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0}}
         """
         
         PBMAssertEq(strORTB, expectedOrtb)
@@ -304,8 +311,9 @@ class ParameterBuilderServiceTest : XCTestCase {
             deviceExt = "\"ext\":{\"atts\":3},"
         }
 
+        let deviceSize = expectedDeviceSizeInPixels(mockDeviceAccessManager)
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":200,\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0},\"user\":{\"geo\":{\"lat\":34.15,\"lon\":-118.13}}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":\(deviceSize.height),\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":\(deviceSize.width)},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0},\"user\":{\"geo\":{\"lat\":34.15,\"lon\":-118.13}}}
         """
         
         PBMAssertEq(strORTB, expectedOrtb)
@@ -381,8 +389,9 @@ class ParameterBuilderServiceTest : XCTestCase {
             deviceExt = "\"ext\":{\"atts\":3},"
         }
 
+        let deviceSize = expectedDeviceSizeInPixels(mockDeviceAccessManager)
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":200,\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0},\"user\":{\"geo\":{\"lat\":34.149335,\"lon\":-118.1328249}}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":\(deviceSize.height),\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":\(deviceSize.width)},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0},\"user\":{\"geo\":{\"lat\":34.149335,\"lon\":-118.1328249}}}
         """
         
         PBMAssertEq(strORTB, expectedOrtb)
@@ -458,8 +467,9 @@ class ParameterBuilderServiceTest : XCTestCase {
             deviceExt = "\"ext\":{\"atts\":3},"
         }
 
+        let deviceSize = expectedDeviceSizeInPixels(mockDeviceAccessManager)
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":200,\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0},\"user\":{\"geo\":{\"lat\":34.149335,\"lon\":-118.1328249}}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":\(deviceSize.height),\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":\(deviceSize.width)},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0},\"user\":{\"geo\":{\"lat\":34.149335,\"lon\":-118.1328249}}}
         """
         
         PBMAssertEq(strORTB, expectedOrtb)
@@ -535,8 +545,9 @@ class ParameterBuilderServiceTest : XCTestCase {
             deviceExt = "\"ext\":{\"atts\":3},"
         }
 
+        let deviceSize = expectedDeviceSizeInPixels(mockDeviceAccessManager)
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":200,\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0},\"user\":{\"geo\":{\"lat\":34,\"lon\":-118}}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":\(deviceSize.height),\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":\(deviceSize.width)},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0},\"user\":{\"geo\":{\"lat\":34,\"lon\":-118}}}
         """
         
         PBMAssertEq(strORTB, expectedOrtb)
@@ -611,8 +622,9 @@ class ParameterBuilderServiceTest : XCTestCase {
             deviceExt = "\"ext\":{\"atts\":3},"
         }
 
+        let deviceSize = expectedDeviceSizeInPixels(mockDeviceAccessManager)
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":200,\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":\(deviceSize.height),\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":\(deviceSize.width)},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0}}
         """
         
         PBMAssertEq(strORTB, expectedOrtb)
@@ -687,8 +699,9 @@ class ParameterBuilderServiceTest : XCTestCase {
             deviceExt = "\"ext\":{\"atts\":3},"
         }
 
+        let deviceSize = expectedDeviceSizeInPixels(mockDeviceAccessManager)
         let expectedOrtb = """
-        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":200,\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":100},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0}}
+        {\"app\":{\"bundle\":\"Mock.Bundle.Identifier\",\"name\":\"MockBundleDisplayName\"},\"device\":{\"connectiontype\":2,\(deviceExt)\"h\":\(deviceSize.height),\"hwv\":\"iPhone1,1\",\"ifa\":\"abc123\",\"language\":\"ml\",\"lmt\":0,\"make\":\"MockMake\",\"model\":\"MockModel\",\"os\":\"MockOS\",\"osv\":\"1.2.3\",\"w\":\(deviceSize.width)},\"imp\":[{\"clickbrowser\":1,\"displaymanager\":\"prebid-mobile\",\"displaymanagerver\":\"MOCK_SDK_VERSION\",\"ext\":{\"dlp\":1},\"instl\":0,\"secure\":1}],\"regs\":{\"coppa\":0}}
         """
         
         PBMAssertEq(strORTB, expectedOrtb)


### PR DESCRIPTION
#1196 

Part of [prebid/prebid-server#4501](https://github.com/prebid/prebid-server/issues/4501)

Sends physical screen pixels in `device.w`/`device.h` and opts in to server-side pxratio conversion by always including `ext.prebid.sdk.usepxratio: true` in bid requests. This allows Prebid Server to correctly convert physical pixels to DIPs when generating interstitial ad sizes for high-density screens.

## Changes

- `PBMDeviceInfoParameterBuilder`: switched from `screenSize` to `screenSizeInPixels` so `device.w`/`device.h` carry physical pixels (multiplied by `UIScreen.main.scale`); `device.pxratio` was already set to `UIScreen.main.scale`
- `DeviceAccessManager`: added `screenSizeInPixels()` returning screen dimensions in physical pixels
- `PBMORTBBidRequestExtPrebid`: always emits `ext.prebid.sdk.usepxratio: true`; `sdk` object is now included in every request (previously only when renderers were present); renderers are still appended when set

## Testing

- `MockDeviceAccessManager.screenSizeInPixels()` updated to match real implementation rounding (`Int(($0 * scale).rounded())`)
- `DeviceInfoParameterBuilderTest.testDeviceSize` updated to assert against `mockDeviceAccessManager.screenSizeInPixels()` dynamically rather than hardcoded values
- `PBMORTBAbstractTest` expected JSON strings updated to include `"usepxratio":true` in the `sdk` object