### PR TITLE
Fix crash from duplicate network callbacks in PBMBidRequester (#1195)

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/Prebid/PBMCore/PBMBidRequester.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/Prebid/PBMCore/PBMBidRequester.m
@@ -97,23 +97,34 @@
                  callback:^(PrebidServerResponse * _Nonnull serverResponse) {
         @strongify(self);
         if (!self) { return; }
-        
-        void (^ const completion)(BidResponse *, NSError *) = self.completion;
-        self.completion = nil;
-        
+
+        // Fix for GitHub Issue #1195: Thread-safe completion handling
+        // Protect against duplicate callback invocations (redirects, retries, network bugs)
+        void (^ _Nullable completion)(BidResponse *, NSError *) = nil;
+        @synchronized(self) {
+            completion = self.completion;
+            if (!completion) {
+                // Completion already called or nil - this is a duplicate callback
+                PBMLogInfo(@"WARNING: Network callback invoked multiple times. Ignoring duplicate callback. Thread: %@", [NSThread currentThread]);
+                return;
+            }
+            // Clear completion to prevent duplicate invocations
+            self.completion = nil;
+        }
+
         if (serverResponse.statusCode == 204) {
             completion(nil, PBMError.blankResponse);
             return;
         }
-        
+
         if (serverResponse.error) {
             PBMLogInfo(@"Bid Request Error: %@", [serverResponse.error localizedDescription]);
             completion(nil, serverResponse.error);
             return;
         }
-        
+
         PBMLogInfo(@"Bid Response: %@", [[NSString alloc] initWithData:serverResponse.rawData encoding:NSUTF8StringEncoding]);
-        
+
         NSError *trasformationError = nil;
         BidResponse * const _Nullable bidResponse = [PBMBidResponseTransformer transformResponse:serverResponse error:&trasformationError];
         


### PR DESCRIPTION
Potentially addresses #1195 

## Root Cause:
Network layer occasionally invokes the callback multiple times (redirects/retries).  First call reads `self.completion`, sets it to `nil`, and invokes it.  Second call reads nil completion and crashes at offset 0x10 trying to invoke the previously deallocated completion block.

## The Fix:
Wrapped completion access in @synchronized(self) with nil check.  If completion is `nil`, log warning and return early. Prevents crash while ensuring callback only executes once.

### Crash Signature (Verified):
- `EXC_BAD_ACCESS KERN_INVALID_ADDRESS at 0x0000000000000010`
- Location: `PBMBidRequester.m:154 (makeRequestWithCompletion callback)`

###  Testing:
Added two tests simulating duplicate callbacks (sequential + concurrent).  All existing tests pass.