### PR TITLE
Fix: Enforce size constraints for GAM banner rendering

### DIFF
--- a/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
+++ b/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
@@ -242,6 +242,10 @@ public class GAMBannerEventHandler :
         
         if let banner = banner,
            let adSize = dfpAdSize {
+            // Enforce size constraints on banner. Ad will not render without correct constraints.
+            banner.banner.widthAnchor.constraint(equalToConstant: adSize.width).isActive = true
+            banner.banner.heightAnchor.constraint(equalToConstant: adSize.height).isActive = true
+            
             loadingDelegate?.adServerDidWin(banner.banner, adSize: adSize)
         }
     }

--- a/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
+++ b/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
@@ -206,6 +206,7 @@ public class GAMBannerEventHandler :
             
             if let banner = banner,
                let adSize = dfpAdSize {
+                setSizeConstraints(banner.banner, forAdSize: adSize)
                 loadingDelegate?.adServerDidWin(banner.banner, adSize: adSize)
             }
         }
@@ -242,12 +243,15 @@ public class GAMBannerEventHandler :
         
         if let banner = banner,
            let adSize = dfpAdSize {
-            // Enforce size constraints on banner. Ad will not render without correct constraints.
-            banner.banner.widthAnchor.constraint(equalToConstant: adSize.width).isActive = true
-            banner.banner.heightAnchor.constraint(equalToConstant: adSize.height).isActive = true
-            
+            setSizeConstraints(banner.banner, forAdSize: adSize)
             loadingDelegate?.adServerDidWin(banner.banner, adSize: adSize)
         }
+    }
+    
+    func setSizeConstraints(_ banner: GoogleMobileAds.BannerView, forAdSize adSize: CGSize) {
+        // Ad will not render without correct constraints.
+        banner.widthAnchor.constraint(equalToConstant: adSize.width).isActive = true
+        banner.heightAnchor.constraint(equalToConstant: adSize.height).isActive = true
     }
     
     func recycleCurrentBanner() {
@@ -258,4 +262,5 @@ public class GAMBannerEventHandler :
     class func convertGADSizes(_ inSizes: [NSValue]) -> [CGSize] {
         inSizes.map { cgSize(for: GoogleMobileAds.adSizeFor(nsValue: $0)) }
     }
+    
 }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -401,22 +401,24 @@ public class BannerView:
     private func installDeployedViewConstraints(view: UIView) {
         view.translatesAutoresizingMaskIntoConstraints = false
         
-        addConstraints([
-            NSLayoutConstraint(item: self,
-                               attribute: .width,
-                               relatedBy: .equal,
-                               toItem: view,
-                               attribute: .width,
-                               multiplier: 1,
-                               constant: 0),
-            
-            NSLayoutConstraint(item: self,
-                               attribute: .height,
-                               relatedBy: .equal,
-                               toItem: view,
-                               attribute: .height,
-                               multiplier: 1, constant: 0)
-        ])
+        // Fill to parent, instead of shrink to child
+        // This fixes an issue for GAM where if incorrect width/height is set on parent,
+        // the ad would fail to render. By enforcing ad size in GAMBannerEventHandler and
+        // setting BannerView to fill to parent, ad will always center-in-view and render.
+        if let superview = view.superview {
+            let widthConstraint = view.widthAnchor.constraint(equalTo: superview.widthAnchor)
+            let heightConstraint = view.heightAnchor.constraint(equalTo: superview.heightAnchor)
+            widthConstraint.priority = .defaultHigh
+            heightConstraint.priority = .defaultHigh
+            NSLayoutConstraint.activate([widthConstraint, heightConstraint])
+        }
+
+        // Fix ambiguous layout warning by adding missing constraints
+        let centerX = view.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+        let centerY = view.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        centerX.priority = .defaultHigh
+        centerY.priority = .defaultHigh
+        NSLayoutConstraint.activate([centerX, centerY])
     }
 }
 

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -401,24 +401,17 @@ public class BannerView:
     private func installDeployedViewConstraints(view: UIView) {
         view.translatesAutoresizingMaskIntoConstraints = false
         
-        // Fill to parent, instead of shrink to child
-        // This fixes an issue for GAM where if incorrect width/height is set on parent,
-        // the ad would fail to render. By enforcing ad size in GAMBannerEventHandler and
-        // setting BannerView to fill to parent, ad will always center-in-view and render.
-        if let superview = view.superview {
-            let widthConstraint = view.widthAnchor.constraint(equalTo: superview.widthAnchor)
-            let heightConstraint = view.heightAnchor.constraint(equalTo: superview.heightAnchor)
-            widthConstraint.priority = .defaultHigh
-            heightConstraint.priority = .defaultHigh
-            NSLayoutConstraint.activate([widthConstraint, heightConstraint])
-        }
-
-        // Fix ambiguous layout warning by adding missing constraints
+        let widthConstraint = self.widthAnchor.constraint(equalTo: view.widthAnchor)
+        let heightConstraint = self.heightAnchor.constraint(equalTo: view.heightAnchor)
         let centerX = view.centerXAnchor.constraint(equalTo: self.centerXAnchor)
         let centerY = view.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        
+        widthConstraint.priority = .defaultHigh
+        heightConstraint.priority = .defaultHigh
         centerX.priority = .defaultHigh
         centerY.priority = .defaultHigh
-        NSLayoutConstraint.activate([centerX, centerY])
+        
+        NSLayoutConstraint.activate([widthConstraint, heightConstraint, centerX, centerY])
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue I'm seeing with GAM when using BannerView where if an incorrect width/height is set on the parent view, the ad will fail to render. By enforcing ad size on the GAM banner itself inside GAMBannerEventHandler, and setting BannerView to fill to its parent view, the ad will always center-in-view and render. 
For Prebid rendering, this change shouldn't affect anything, since PBMWebView already sets the width and height for ads coming from Prebid server.
Also fixes warnings about ambiguous layout constraints in BannerView's child view by simply adding X and Y constraints. iOS Autolayout can make accurate guesses most of the time but it's better just to have them set, and with 750 priority, so the developer can override them if needed.

<img width="410" height="155" alt="Screenshot 2025-12-18 at 5 58 16 PM" src="https://github.com/user-attachments/assets/e21726ef-acbc-4b3a-9946-0ec0452b59e4" />

