### PR TITLE
Improves error message for GMA SDK 10.7.0+ compatibility

### DIFF
--- a/InternalTestApp/PrebidMobileDemoRendering/AppDelegate.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/AppDelegate.swift
@@ -45,7 +45,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Prebid.shared.shouldDisableStatusCheck = true
                 
         //Set up SDK.
-        try? Prebid.initializeSDK(serverURL: "https://prebid-server-test-j.prebid.org/openrtb2/auction") { status, error in
+        let swiftVersionString = string(for: MobileAds.shared.versionNumber)
+
+        try? Prebid.initializeSDK(serverURL: "https://prebid-server-test-j.prebid.org/openrtb2/auction", gadMobileAdsVersion: swiftVersionString) { status, error in
             switch status {
             case .succeeded:
                 print("Prebid successfully initialized")

--- a/PrebidMobile/Swift/ConfigurationAndTargeting/PrebidSDKInitializer.swift
+++ b/PrebidMobile/Swift/ConfigurationAndTargeting/PrebidSDKInitializer.swift
@@ -42,7 +42,11 @@ class PrebidSDKInitializer {
         }
         
         guard gadObject.responds(to: NSSelectorFromString("sdkVersion")) else {
-            Log.error("There is no sdkVersion property in GoogleMobileAds object.")
+            if gadObject.responds(to: NSSelectorFromString("versionNumber")) {
+                Log.error("Starting with GMA SDK 10.7.0, the 'sdkVersion' property has been removed. Please use Prebid.initializeSDK(serverURL:gadMobileAdsVersion:completion:) and pass the version string from GADMobileAds.sharedInstance().versionNumber")
+            } else {
+                Log.error("There is no sdkVersion property in GoogleMobileAds object.")
+            }
             return
         }
         


### PR DESCRIPTION
- Updates error message to guide developers to use versionNumber property instead of deprecated sdkVersion
- Refactors error handling with clearer if-else structure
- Updates demo app to demonstrate proper SDK initialization with GMA SDK 10.7.0+

🤖 Generated with [Claude Code](https://claude.com/claude-code)