### PR TITLE
Add thread-safe access to custom headers

### DIFF
--- a/PrebidMobile/Swift/PrebidMobileRendering/Networking/PrebidServerConnection.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Networking/PrebidServerConnection.swift
@@ -247,7 +247,7 @@ public class PrebidServerConnection: NSObject, PrebidServerConnectionProtocol, U
         }
         
         // Prebid custom headers
-        for (key, value) in Prebid.shared.getCustomHeaders() {
+        for (key, value) in Prebid.shared.customHeaders {
             request.addValue(value, forHTTPHeaderField: key)
         }
         


### PR DESCRIPTION
Problem : 

This PR fixes a thread safety issue that caused production crashes in some of our Apps. The crash occurred when `PrebidServerConnection.createRequest()` accessed `customHeaders` from multiple dispatch queues concurrently.  

Currently the headers on our side can update dynamically. This can be triggered because of some privacy flags being updated by the user on desktop, or some other use cases. 


Implement thread-safe custom headers to prevent race conditions when accessing headers from multiple threads. Uses a serial dispatch queue to synchronize all custom header operations.

Changes:
- Add customHeaderQueue dispatch queue for synchronization
- Update addCustomHeader() to use sync for thread-safe writes
- Update clearCustomHeaders() to use sync for thread-safe clearing
- Add getCustomHeaders() method for safe external access
- Update PrebidServerConnection to use getCustomHeaders() getter