### PR TITLE
removed the zero-price check in the bid response to find a winning bid

### DIFF
--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/BidResponse.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/BidResponse.swift
@@ -72,7 +72,7 @@ public class BidResponse: NSObject {
                     let bid = Bid(bid: nextBid)
                     allBids.append(bid)
                     
-                    if winningBid == nil && bid.price > 0 && bid.isWinning {
+                    if winningBid == nil && bid.isWinning {
                         winningBid = bid
                     } else if let bidTargetingInfo = bid.targetingInfo {
                         targetingInfo.merge(bidTargetingInfo) { $1 }

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/PBMBidResponseTransformerTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/PBMBidResponseTransformerTest.swift
@@ -93,7 +93,7 @@ class PBMBidResponseTransformerTest: XCTestCase {
         let bidResponse = try! PBMBidResponseTransformer.transform(response)
         XCTAssertNotNil(bidResponse)
         XCTAssertEqual(bidResponse.allBids?.count, 1)
-        XCTAssertNil(bidResponse.winningBid)
+        XCTAssertNotNil(bidResponse.winningBid)
     }
     
     func testRealPrebidResponse() {


### PR DESCRIPTION
What changed
Removed the explicit zero-price check when evaluating bid responses to determine the winning bid.

Why
Filtering out bids with a price of 0 can prevent a valid bid from being selected, even though Prebid Server may legitimately return a zero-price bid as the highest (or only) available bid.
This behavior caused inconsistencies when determining the winning bid and could lead to no winner being selected.

Result
	•	Winning bid selection now relies on standard bid comparison logic
	•	Zero-price bids are handled consistently with other valid bids
	•	Behavior aligns with expected Prebid Server responses

Related issue
Fixes #1237