### PR TITLE
Frozen window locker after clickthrough 

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/Prebid/PBMCore/PBMSafariVCOpener.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/Prebid/PBMCore/PBMSafariVCOpener.m
@@ -43,6 +43,7 @@
 
 @property (nonatomic, strong, nullable) SFSafariViewController * safariViewController;
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, PBMWindowLocker *> *windowLockers;
+@property (nonatomic, strong, nullable) NSNumber *currentWindowLockerKey;
 
 @end
 
@@ -147,10 +148,13 @@
             return NO;
         }
         
+        NSNumber *key = @(viewControllerForPresentingModals.view.window.hash);
         PBMOpenMeasurementSession * const measurementSession = self.measurementSessionProvider();
         PBMWindowLocker *windowLocker = [self windowLockerForWindow:viewControllerForPresentingModals.view.window
                                                   measurementSession:measurementSession];
         [windowLocker lock];
+        
+        self.currentWindowLockerKey = key;
         
         if (self.onWillLoadURLInClickthrough != nil) {
             self.onWillLoadURLInClickthrough();
@@ -183,6 +187,10 @@
 #pragma mark SFSafariViewControllerDelegate
 
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
+    if (self.currentWindowLockerKey) {
+        [self.windowLockers removeObjectForKey:self.currentWindowLockerKey];
+        self.currentWindowLockerKey = nil;
+    }
     
     if (self.onClickthroughPoppedBlock != nil) {
         self.onClickthroughPoppedBlock(nil);


### PR DESCRIPTION
#972 
Multiple-clicking ads leave a frozen semi-transparent window locker on the screen

**Solution**
Use shared window locker instance per window instead of creating new ones, which could be left on the screen due to synchronization issue with lock/unlock