### PR TITLE
Add missing GAMEventHandler callbacks for click and impression events

### DIFF
--- a/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
+++ b/EventHandlers/PrebidMobileGAMEventHandlers/Sources/GAMBannerEventHandler.swift
@@ -128,7 +128,11 @@ public class GAMBannerEventHandler :
     }
     
     public func bannerViewDidRecordImpression(_ bannerView: GoogleMobileAds.BannerView) {
-        // TODO
+        interactionDelegate?.didDisplayAd()
+    }
+
+    public func bannerViewDidRecordClick(_ bannerView: GoogleMobileAds.BannerView) {
+        interactionDelegate?.willLeaveApp()
     }
     
     public func bannerViewWillPresentScreen(_ bannerView: GoogleMobileAds.BannerView) {

--- a/Example/PrebidDemo/PrebidDemoSwift/Examples/GAM/RenderingAPI/GAMDisplayBannerViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/Examples/GAM/RenderingAPI/GAMDisplayBannerViewController.swift
@@ -62,6 +62,18 @@ class GAMDisplayBannerViewController: BannerBaseViewController, PrebidMobile.Ban
         self
     }
     
+    func bannerViewDidDisplay(_ bannerView: PrebidMobile.BannerView) {
+        PrebidDemoLogger.shared.info("Banner view did display (impression recorded)")
+    }
+    
+    func bannerViewWillLeaveApplication(_ bannerView: PrebidMobile.BannerView) {
+        PrebidDemoLogger.shared.info("Banner view will leave application (click recorded)")
+    }
+
+    func bannerViewWillPresentModal(_ bannerView: PrebidMobile.BannerView) {
+        PrebidDemoLogger.shared.info("Banner view will present modal (click recorded)")
+    }
+
     func bannerView(_ bannerView: PrebidMobile.BannerView, didFailToReceiveAdWith error: Error) {
         PrebidDemoLogger.shared.error("Banner view did fail to receive ad with error: \(error)")
     }

--- a/Example/PrebidDemo/PrebidDemoSwift/Examples/GAM/RenderingAPI/GAMVideoBannerViewController.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/Examples/GAM/RenderingAPI/GAMVideoBannerViewController.swift
@@ -66,6 +66,18 @@ class GAMVideoBannerViewController: BannerBaseViewController, PrebidMobile.Banne
         self
     }
     
+    func bannerViewDidDisplay(_ bannerView: PrebidMobile.BannerView) {
+        PrebidDemoLogger.shared.info("Banner view did display (impression recorded)")
+    }
+    
+    func bannerViewWillLeaveApplication(_ bannerView: PrebidMobile.BannerView) {
+        PrebidDemoLogger.shared.info("Banner view will leave application (click recorded)")
+    }
+
+    func bannerViewWillPresentModal(_ bannerView: PrebidMobile.BannerView) {
+        PrebidDemoLogger.shared.info("Banner view will present modal (click recorded)")
+    }
+
     func bannerView(_ bannerView: PrebidMobile.BannerView, didFailToReceiveAdWith error: Error) {
         PrebidDemoLogger.shared.error("Banner view did fail to receive ad with error: \(error)")
     }

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMBannerController.swift
@@ -39,6 +39,7 @@ class PrebidGAMBannerController:
     
     private let adViewDidReceiveAdButton = EventReportContainer()
     private let adViewDidFailToLoadAdButton = EventReportContainer()
+    private let adViewDidDisplayButton = EventReportContainer()
     private let adViewWillPresentScreenButton = EventReportContainer()
     private let adViewDidDismissScreenButton = EventReportContainer()
     private let adViewWillLeaveApplicationButton = EventReportContainer()
@@ -136,6 +137,10 @@ class PrebidGAMBannerController:
         adViewDidFailToLoadAdButton.isEnabled = true
     }
     
+    func bannerViewDidDisplay(_ bannerView: PrebidMobile.BannerView) {
+        adViewDidDisplayButton.isEnabled = true
+    }
+    
     func bannerViewWillPresentModal(_ bannerView: PrebidMobile.BannerView) {
         adViewWillPresentScreenButton.isEnabled = true
     }
@@ -164,6 +169,7 @@ class PrebidGAMBannerController:
     private func setupActions() {
         rootController?.setupAction(adViewDidReceiveAdButton, "adViewDidReceiveAd called")
         rootController?.setupAction(adViewDidFailToLoadAdButton, "adViewDidFailToLoadAd called")
+        rootController?.setupAction(adViewDidDisplayButton, "bannerViewDidDisplay called")
         rootController?.setupAction(adViewWillPresentScreenButton, "adViewWillPresentScreen called")
         rootController?.setupAction(adViewDidDismissScreenButton, "adViewDidDismissScreen called")
         rootController?.setupAction(adViewWillLeaveApplicationButton, "adViewWillLeaveApplication called")
@@ -177,6 +183,7 @@ class PrebidGAMBannerController:
     private func resetEvents() {
         adViewDidReceiveAdButton.isEnabled = false
         adViewDidFailToLoadAdButton.isEnabled = false
+        adViewDidDisplayButton.isEnabled = false
         adViewWillPresentScreenButton.isEnabled = false
         adViewDidDismissScreenButton.isEnabled = false
         adViewWillLeaveApplicationButton.isEnabled = false

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerEventInteractionDelegate.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerEventInteractionDelegate.swift
@@ -37,6 +37,11 @@ import UIKit
     func willLeaveApp()
 
     /*!
+     @abstract Call this when the ad server SDK records an impression
+     */
+    func didDisplayAd()
+    
+    /*!
      @abstract Returns a view controller instance to be used by ad server SDK for showing modals
      @result a UIViewController instance for showing modals
      */

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -287,6 +287,7 @@ public class BannerView:
               }
         
         eventHandler.trackImpression()
+        didDisplayAd()
     }
     
     public func viewControllerForModalPresentation(
@@ -328,7 +329,13 @@ public class BannerView:
         
         invokeDelegateSelector(#selector(BannerViewDelegate.bannerViewWillLeaveApplication))
     }
-    
+
+    public func didDisplayAd() {
+        assert(Thread.isMainThread, assertionMessageMainThread)
+        
+        invokeDelegateSelector(#selector(BannerViewDelegate.bannerViewDidDisplay))
+    }
+
     public var viewControllerForPresentingModal: UIViewController? {
         guard let delegate = self.delegate,
               delegate.responds(to: #selector(BannerViewDelegate.bannerViewPresentationController)) else {

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerViewDelegate.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerViewDelegate.swift
@@ -50,4 +50,8 @@ import UIKit
     /// the current view controller.
     /// - Parameter bannerView: The BannerView instance sending the message.
     @objc optional func bannerViewDidDismissModal(_ bannerView: BannerView)
+
+    /// Notifies the delegate that the banner ad has been displayed and an impression has been tracked.
+    /// - Parameter bannerView: The BannerView instance sending the message.
+    @objc optional func bannerViewDidDisplay(_ bannerView: BannerView)
 }


### PR DESCRIPTION
## Summary
This PR implements missing GADBannerViewDelegate callback methods.

## Changes

### 1. Implement Missing GADBannerViewDelegate Methods

#### Added `bannerViewDidRecordImpression(_:)` implementation
- Implemented the GADBannerViewDelegate method in `GAMBannerEventHandler.swift`
- Forwards impression events from Google Ad Manager to `BannerViewDelegate.bannerViewDidDisplay(_:)`
- Added `didDisplayAd()` method to `BannerEventInteractionDelegate` protocol to support this flow
- Implemented `didDisplayAd()` in `BannerView` to notify the delegate

#### Added `bannerViewDidRecordClick(_:)` implementation
- Implemented the GADBannerViewDelegate method in `GAMBannerEventHandler.swift`
- Forwards click events from Google Ad Manager to `BannerViewDelegate.bannerViewWillLeaveApplication(_:)`
- Uses existing `willLeaveApp()` method in `BannerEventInteractionDelegate`