### PR TITLE
Fix burl auction macro replacement

### DIFF
--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/Bid.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/Bid.swift
@@ -35,9 +35,7 @@ public class Bid: NSObject {
     /// Billing notice URL called by the exchange when a winning bid
     /// becomes billable based on exchange-specific business policy
     /// (e.g., typically delivered, viewed, etc.). 
-    @objc public var burl: String? {
-        bid.burl
-    }
+    @objc public var burl: String?
     
     /// Win notice URL called by the exchange if the bid wins (not necessarily indicative of a delivered,
     /// viewed, or billable ad); optional means of serving ad markup.
@@ -137,6 +135,7 @@ public class Bid: NSObject {
     init(bid: ORTBBid<ORTBBidExt>) {
         self.bid = bid
         let macrosHelper = ORTBMacrosHelper(bidPrice: bid.price ?? 0.0)
+        burl = macrosHelper.replaceMacros(in: bid.burl)
         adm = macrosHelper.replaceMacros(in: bid.adm)
         nurl = macrosHelper.replaceMacros(in: bid.nurl)
     }


### PR DESCRIPTION
## Summary

- Fix `burl` (billing URL) not having OpenRTB auction macros (e.g., `${AUCTION_PRICE}`) resolved before being used for impression tracking
- Changed `burl` from a computed property (returning raw `bid.burl`) to a stored property initialized with `ORTBMacrosHelper.replaceMacros(in:)`, consistent with how `adm` and `nurl` are already handled
- Ensures billing URLs fire with the correct resolved bid price for accurate revenue attribution