### PR TITLE
Fix SKAdNetwork click flow for bid servers returning itunesitem, sourceapp, and timestamp as strings

### DIFF
--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/ORTBBidExtSkadn.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/ORTBBidExtSkadn.swift
@@ -69,8 +69,8 @@ open class ORTBBidExtSkadn: NSObject, PBMJsonCodable {
         version             = json[.version]
         network             = json[.network]
         campaign            = json[.campaign]
-        itunesitem          = json[.itunesitem]
-        sourceapp           = json[.sourceapp]
+        itunesitem          = json.numberOrString(.itunesitem)
+        sourceapp           = json.numberOrString(.sourceapp)
         sourceidentifier    = json[.sourceidentifier]
         fidelities          = json[.fidelities]
         skoverlay           = json[.skoverlay]

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/ORTBSkadnFidelity.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/ORTBSkadnFidelity.swift
@@ -45,7 +45,7 @@ import Foundation
 
         fidelity    = json[.fidelity]
         nonce       = json[.nonce]
-        timestamp   = json[.timestamp]
+        timestamp   = json.numberOrString(.timestamp)
         signature   = json[.signature]
     }
     

--- a/PrebidMobile/Swift/Utils/JSONParsing.swift
+++ b/PrebidMobile/Swift/Utils/JSONParsing.swift
@@ -106,6 +106,12 @@ struct JSONObject<Key: RawRepresentable> where Key.RawValue == String {
         }
     }
     
+    // For fields where the IAB spec defines strings but Apple APIs require NSNumber.
+    func numberOrString(_ key: Key) -> NSNumber? {
+        let raw = dict[key.rawValue]
+        return (raw as? String).flatMap { Int64($0) }.map { NSNumber(value: $0) } ?? (raw as? NSNumber)
+    }
+
     func backwardsCompatiblePassthrough(key: Key) -> [ORTBExtPrebidPassthrough]? {
         // The prebid spec defines in various parts of the schema the "passthrough" key
         // which is supposed to map to a JSON object. However it was mistakenly implemented


### PR DESCRIPTION
## Summary

Fixes silent SKAdNetwork attribution failure when bid servers return `itunesitem`, `sourceapp`,
and `timestamp` as JSON strings instead of integers.

Per the [IAB OpenRTB SKAdNetwork spec](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/skadnetwork.md), these fields are defined as **strings** in the bid response. However, the SDK was parsing them with a strict `as? NSNumber` cast causing `SkadnParametersManager` to receive `nil` values and silently skip the entire `SKStoreProductViewController` flow. No error, no log, no App Store deeplink.

Apple's StoreKit API requires these values as `NSNumber`, so the SDK must bridge the type mismatch.

## Changes

- Added `numberOrString(_:)` helper to `JSONObject` that tries `String → Int64 → NSNumber` first (spec-compliant path), then falls back to a raw `NSNumber` for servers already sending the correct type.
- Applied the helper to `itunesitem` and `sourceapp` in `ORTBBidExtSkadn`.
- Applied the helper to `timestamp` in `ORTBSkadnFidelity`

## References
- Upstream issue: prebid/prebid-mobile-ios#1255
- IAB OpenRTB SKAdNetwork spec: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/skadnetwork.md
- Apple StoreKit ad network install validation keys: https://developer.apple.com/documentation/storekit/ad-network-install-validation-keys