### PR TITLE
Fix Objective-C interoperability conflict by renaming UserUniqueID.id to uniqueId

### DIFF
--- a/PrebidMobile/Swift/ConfigurationAndTargeting/SharedId.swift
+++ b/PrebidMobile/Swift/ConfigurationAndTargeting/SharedId.swift
@@ -27,7 +27,7 @@ class SharedId {
         // If sharedId was used previously in this session, then use that id
         if let sessionId {
             if persistentStorageAllowed {
-                StorageUtils.sharedId = sessionId.uids.first?.id
+                StorageUtils.sharedId = sessionId.uids.first?.uniqueId
             }
             return sessionId
         }
@@ -43,7 +43,7 @@ class SharedId {
         let eid = externalUserId(from: UUID().uuidString)
         sessionId = eid
         if persistentStorageAllowed {
-            StorageUtils.sharedId = eid.uids.first?.id
+            StorageUtils.sharedId = eid.uids.first?.uniqueId
         }
         return eid
     }
@@ -54,6 +54,6 @@ class SharedId {
     }
     
     private func externalUserId(from identifier: String) -> ExternalUserId {
-        ExternalUserId(source: "pubcid.org", uids: [UserUniqueID(id: identifier, aType: 1)])
+        ExternalUserId(source: "pubcid.org", uids: [UserUniqueID(uniqueId: identifier, aType: 1)])
     }
 }

--- a/PrebidMobile/Swift/ExternalUserId.swift
+++ b/PrebidMobile/Swift/ExternalUserId.swift
@@ -68,8 +68,10 @@ public class ExternalUserId: NSObject, JSONConvertible {
 @objcMembers
 public class UserUniqueID: NSObject, JSONConvertible {
     
+    // MARK: - Properties
+
     /// Cookie or platform-native identifier.
-    public var id: String
+    public var uniqueId: String
     
     /// Type of user agent the match is from. It is highly recommended to set this, as many DSPs separate app-native IDs from browser-based IDs and require a type value for ID resolution.
     public var aType: NSNumber
@@ -77,14 +79,16 @@ public class UserUniqueID: NSObject, JSONConvertible {
     /// Optional vendor-specific extensions.
     public var ext: [String: Any]?
     
+    // MARK: - Initialization
+
     /// Initializes a new UserUniqueID object.
     ///
     /// - Parameters:
-    ///   - id: Cookie or platform-native identifier.
+    ///   - uniqueId: Cookie or platform-native identifier.
     ///   - aType: Type of user agent the match is from. Recommended for DSP ID resolution.
     ///   - ext: Optional vendor-specific extensions. Default is `nil`.
-    public init(id: String, aType: NSNumber, ext: [String : Any]? = nil) {
-        self.id = id
+    public init(uniqueId: String, aType: NSNumber, ext: [String : Any]? = nil) {
+        self.uniqueId = uniqueId
         self.aType = aType
         self.ext = ext
     }
@@ -92,7 +96,7 @@ public class UserUniqueID: NSObject, JSONConvertible {
     func toJSONDictionary() -> [String: Any] {
         var ret = [String: Any]()
         
-        ret["id"] = id
+        ret["id"] = uniqueId
         ret["atype"] = aType
         ret["ext"] = ext
         

--- a/PrebidMobileTests/RenderingTests/Tests/ExternalUserIdTests.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ExternalUserIdTests.swift
@@ -19,7 +19,7 @@ import XCTest
 class ExternalUserIdTests: XCTestCase {
     
     func testInitialization() {
-        let uids = [UserUniqueID(id: "uid1", aType: 1)]
+        let uids = [UserUniqueID(uniqueId: "uid1", aType: 1)]
         let ext: [String: Any] = ["key": "value"]
         let externalUserId = ExternalUserId(source: "source1", uids: uids, ext: ext)
         
@@ -30,7 +30,7 @@ class ExternalUserIdTests: XCTestCase {
     }
     
     func testToJSONDictionary() {
-        let uids = [UserUniqueID(id: "uid1", aType: 1)]
+        let uids = [UserUniqueID(uniqueId: "uid1", aType: 1)]
         let ext: [String: Any] = ["key": "value"]
         let externalUserId = ExternalUserId(source: "source1", uids: uids, ext: ext)
         

--- a/PrebidMobileTests/RenderingTests/Tests/UserUniqueIDTests.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/UserUniqueIDTests.swift
@@ -19,15 +19,15 @@ import XCTest
 class UserUniqueIDTests: XCTestCase {
     
     func testInitialization() {
-        let userUniqueID = UserUniqueID(id: "uid1", aType: 1, ext: ["key": "value"])
+        let userUniqueID = UserUniqueID(uniqueId: "uid1", aType: 1, ext: ["key": "value"])
         
-        XCTAssertEqual(userUniqueID.id, "uid1")
+        XCTAssertEqual(userUniqueID.uniqueId, "uid1")
         XCTAssertEqual(userUniqueID.aType, 1)
         XCTAssertEqual(userUniqueID.ext as? NSDictionary, ["key": "value"] as NSDictionary)
     }
     
     func testToJSONDictionary() {
-        let userUniqueID = UserUniqueID(id: "uid1", aType: 1, ext: ["key": "value"])
+        let userUniqueID = UserUniqueID(uniqueId: "uid1", aType: 1, ext: ["key": "value"])
         let json = userUniqueID.toJSONDictionary()
         
         XCTAssertEqual(json["id"] as? String, "uid1")

--- a/PrebidMobileTests/SharedIdTests.swift
+++ b/PrebidMobileTests/SharedIdTests.swift
@@ -42,7 +42,7 @@ final class SharedIdTests: XCTestCase {
         
         setLocalStorageAccessAllowed(true)
         
-        XCTAssertEqual(targeting.sharedId.uids.first?.id, "abc123")
+        XCTAssertEqual(targeting.sharedId.uids.first?.uniqueId, "abc123")
     }
     
     func testDoesNotUseValueInLocalStorageIfAccessNotAllowed() {
@@ -50,20 +50,20 @@ final class SharedIdTests: XCTestCase {
         
         setLocalStorageAccessAllowed(false)
         
-        XCTAssertNotEqual(targeting.sharedId.uids.first?.id, "abc123")
+        XCTAssertNotEqual(targeting.sharedId.uids.first?.uniqueId, "abc123")
     }
     
     func testGeneratedIdWrittenToLocalStorageIfAllowed() {
         setLocalStorageAccessAllowed(true)
         
-        let identifier = targeting.sharedId.uids.first?.id
+        let identifier = targeting.sharedId.uids.first?.uniqueId
         XCTAssertEqual(StorageUtils.sharedId, identifier)
     }
     
     func testGeneratedIdWrittenNotToLocalStorageIfNotAllowed() {
         setLocalStorageAccessAllowed(false)
         
-        let _ = targeting.sharedId.uids.first?.id // Generate an id
+        let _ = targeting.sharedId.uids.first?.uniqueId // Generate an id
         XCTAssertNil(StorageUtils.sharedId)
     }
     
@@ -71,19 +71,19 @@ final class SharedIdTests: XCTestCase {
         // Even if local storage is not allowed, we should persist an in-memory
         // identifier for the current app session
         setLocalStorageAccessAllowed(false)
-        let originalIdentifier = targeting.sharedId.uids.first?.id
+        let originalIdentifier = targeting.sharedId.uids.first?.uniqueId
         
-        XCTAssertEqual(targeting.sharedId.uids.first?.id, originalIdentifier)
+        XCTAssertEqual(targeting.sharedId.uids.first?.uniqueId, originalIdentifier)
     }
     
     func testReturnsTheSameIdentifierUntilReset() {
-        let originalIdentifier = targeting.sharedId.uids.first?.id
+        let originalIdentifier = targeting.sharedId.uids.first?.uniqueId
         
-        XCTAssertEqual(targeting.sharedId.uids.first?.id, originalIdentifier)
+        XCTAssertEqual(targeting.sharedId.uids.first?.uniqueId, originalIdentifier)
         
         targeting.resetSharedId()
         
-        XCTAssertNotEqual(targeting.sharedId.uids.first?.id, originalIdentifier)
+        XCTAssertNotEqual(targeting.sharedId.uids.first?.uniqueId, originalIdentifier)
     }
     
     func testResettingClearsIdFromLocalStorage() {


### PR DESCRIPTION
# Summary

This PR addresses a name conflict in the iOS interoperability layer when importing the Prebid Mobile SDK from Kotlin Multiplatform via cinterop / SPM.

The Prebid SDK exposes a property named `id` in `UserUniqueID`. While this is valid in Swift / Objective-C contexts, it collides with the Objective-C id type alias during header generation, which can corrupt the generated `PrebidMobile-Swift.h` file.
https://developer.apple.com/documentation/objectivec/id

In our case, the generated header contained declarations such as:
```objc
5030 | /// Extended ID UID objects from the given source.
5031 | SWIFT_CLASS("_TtC12PrebidMobile12UserUniqueID")
5032 | @interface UserUniqueID : NSObject
5033 | /// Cookie or platform-native identifier.
5034 | @property (nonatomic, copy) NSString * _Nonnull id;
5035 | /// Type of user agent the match is from. It is highly recommended to set this, as many DSPs separate app-native IDs from browser-based IDs and require a type value for ID resolution.
5036 | @property (nonatomic, strong) NSNumber * _Nonnull aType;
5037 | /// Optional vendor-specific extensions.
5038 | @property (nonatomic, copy) NSDictionary<NSString *, id> * _Nullable ext;
5039 | /// Initializes a new UserUniqueID object.
5040 | /// \param id Cookie or platform-native identifier.
5041 | ///
5042 | /// \param aType Type of user agent the match is from. Recommended for DSP ID resolution.
5043 | ///
5044 | /// \param ext Optional vendor-specific extensions. Default is <code>nil</code>.
5045 | ///
5046 | - (nonnull instancetype)initWithId:(NSString * _Nonnull)id aType:(NSNumber * _Nonnull)aType ext:(NSDictionary<NSString *, id> * _Nullable)ext OBJC_DESIGNATED_INITIALIZER;
5047 | - (nonnull instancetype)init SWIFT_UNAVAILABLE;
5048 | + (nonnull instancetype)new SWIFT_UNAVAILABLE_MSG("-init is unavailable");
5049 | @end
```

which led to the following compilation error during iOS integration:
`PrebidMobile-Swift.h:5046:123: error: unknown type name id`

# Changes

To avoid the conflict, the `id` property in `UserUniqueId` has been renamed to `uniqueId`.
This change removes the ambiguity in the generated Objective-C bridge code and prevents header corruption during iOS builds.

# Impact

- Fixes iOS build failures caused by invalid generated headers
- Improves interoperability with Objective-C / Swift in Kotlin Multiplatform projects
- Keeps the SDK compatible with Apple’s id type alias usage