### PR TITLE
Add didInjectView callback to PrebidMobilePluginRenderer 

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMAdViewManager.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMAdViewManager.m
@@ -117,6 +117,7 @@
             
             [[self.adViewManagerDelegate displayView] addSubview:creativeView];
             [self.currentCreative displayWithRootViewController:viewController];
+            [self.adViewManagerDelegate adLoaded:[self.currentTransaction getAdDetails]];
         });
     }
 }
@@ -361,8 +362,6 @@
         
         //Otherwise attempt to show the creative.
         [self setupCreative:[transaction getFirstCreative]];
-        
-        [self.adViewManagerDelegate adLoaded:[transaction getAdDetails]];
     });
 }
 

--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMAdViewManager.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMAdViewManager.m
@@ -117,7 +117,6 @@
             
             [[self.adViewManagerDelegate displayView] addSubview:creativeView];
             [self.currentCreative displayWithRootViewController:viewController];
-            [self.adViewManagerDelegate adLoaded:[self.currentTransaction getAdDetails]];
         });
     }
 }
@@ -362,6 +361,8 @@
         
         //Otherwise attempt to show the creative.
         [self setupCreative:[transaction getFirstCreative]];
+        
+        [self.adViewManagerDelegate adLoaded:[transaction getAdDetails]];
     });
 }
 

--- a/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PrebidMobilePluginRenderer.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PrebidMobilePluginRenderer.swift
@@ -73,4 +73,7 @@ public protocol PrebidMobilePluginRenderer: AnyObject {
         loadingDelegate: InterstitialControllerLoadingDelegate,
         interactionDelegate: InterstitialControllerInteractionDelegate
     ) -> PrebidMobileInterstitialControllerProtocol?
+    
+    /// Notifies that the ad view has been injected into the banner view.
+    @objc optional func didInjectView(_ view: UIView, into bannerView: UIView)
 }

--- a/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PrebidMobilePluginRenderer.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PrebidMobilePluginRenderer.swift
@@ -74,6 +74,10 @@ public protocol PrebidMobilePluginRenderer: AnyObject {
         interactionDelegate: InterstitialControllerInteractionDelegate
     ) -> PrebidMobileInterstitialControllerProtocol?
     
-    /// Notifies that the ad view has been injected into the banner view.
+    /// Notifies the plugin renderer that an ad view has been injected into the banner view.
+    ///
+    /// - Parameters:
+    ///   - view: The ad view that was injected.
+    ///   - bannerView: The banner view into which the ad view was injected.
     @objc optional func didInjectView(_ view: UIView, into bannerView: UIView)
 }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -365,11 +365,11 @@ public class BannerView:
             }
             
             self.installDeployedViewConstraints(view: view)
-            self.notifyRendererDidInjectView(view)
             self.deployedView = view
             if let displayView = self.deployedView as? DisplayView {
                 displayView.videoPlaybackDelegate = self
             }
+            self.notifyRendererDidInjectView(view)
         }
     }
     
@@ -419,16 +419,13 @@ public class BannerView:
     
     private func notifyRendererDidInjectView(_ injectedView: UIView) {
         guard let bid = lastBidResponse?.winningBid else {
-            print("Failed to find last bid. Skipped final rendering phase.")
+            Log.debug("Failed to find last bid. Skipped final rendering phase.")
             return
         }
         
         // Notify plugin if it implements this method
-        let plugin: any PrebidMobilePluginRenderer = PrebidMobilePluginRegister.shared.getPluginForPreferredRenderer(bid: bid)
-        let selector = NSSelectorFromString("didInjectView:into:")
-        if (plugin as AnyObject).responds(to: selector) {
-            (plugin as AnyObject).perform(selector, with: injectedView, with: self)
-        }
+        let plugin = PrebidMobilePluginRegister.shared.getPluginForPreferredRenderer(bid: bid)
+        plugin.didInjectView?(injectedView, into: self)
     }
 }
 

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -365,6 +365,7 @@ public class BannerView:
             }
             
             self.installDeployedViewConstraints(view: view)
+            self.notifyRendererDidInjectView(view)
             self.deployedView = view
             if let displayView = self.deployedView as? DisplayView {
                 displayView.videoPlaybackDelegate = self
@@ -412,6 +413,22 @@ public class BannerView:
         centerY.priority = .defaultHigh
         
         NSLayoutConstraint.activate([widthConstraint, heightConstraint, centerX, centerY])
+    }
+    
+    // MARK: Renderer notification
+    
+    private func notifyRendererDidInjectView(_ injectedView: UIView) {
+        guard let bid = lastBidResponse?.winningBid else {
+            print("Failed to find last bid. Skipped final rendering phase.")
+            return
+        }
+        
+        // Notify plugin if it implements this method
+        let plugin: any PrebidMobilePluginRenderer = PrebidMobilePluginRegister.shared.getPluginForPreferredRenderer(bid: bid)
+        let selector = NSSelectorFromString("didInjectView:into:")
+        if (plugin as AnyObject).responds(to: selector) {
+            (plugin as AnyObject).perform(selector, with: injectedView, with: self)
+        }
     }
 }
 

--- a/PrebidMobileTests/RenderingTests/Mocks/MockPrebidMobilePluginRenderer.swift
+++ b/PrebidMobileTests/RenderingTests/Mocks/MockPrebidMobilePluginRenderer.swift
@@ -21,11 +21,21 @@ class MockPrebidMobilePluginRenderer: PrebidMobilePluginRenderer {
     let name: String
     let version: String
     var data: [String: Any]?
-    
+
+    var didInjectViewCallCount = 0
+    var capturedInjectedView: UIView?
+    var capturedBannerView: UIView?
+
     init(name: String, version: String, data: [String: Any]? = nil) {
         self.name = name
         self.version = version
         self.data = data
+    }
+
+    func didInjectView(_ view: UIView, into bannerView: UIView) {
+        didInjectViewCallCount += 1
+        capturedInjectedView = view
+        capturedBannerView = bannerView
     }
     
     func jsonDictionary() -> [String: Any] {

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/BannerViewTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/BannerViewTest.swift
@@ -23,6 +23,22 @@ class MockBannerView: BannerView {
     }
 }
 
+// Returns a bid response whose winning bid references a named plugin renderer.
+private class MockBannerViewWithCustomRenderer: BannerView {
+    var mockRendererName: String = ""
+    var mockRendererVersion: String = ""
+
+    override var lastBidResponse: BidResponse? {
+        let rawBid = RawSampleCustomRendererBidFabricator.makeSampleCustomRendererBid(
+            rendererName: mockRendererName,
+            rendererVersion: mockRendererVersion
+        )
+        let rawResponse = ORTBBidResponse<ORTBBidResponseExt, [String: Any], ORTBBidExt>(requestID: "")
+        rawResponse.seatbid = [.init(bid: [rawBid])]
+        return BidResponse(jsonDictionary: rawResponse.jsonDictionary)
+    }
+}
+
 class BannerViewTest: XCTestCase {
     override func tearDown() {
         Prebid.reset()
@@ -169,5 +185,108 @@ class BannerViewTest: XCTestCase {
         func videoPlaybackDidComplete(_ banner: PrebidMobile.BannerView) {
             events.insert(.complete)
         }
+    }
+}
+
+class BannerViewDidInjectViewTests: XCTestCase {
+
+    private let pluginName = "SampleRenderer"
+    private let pluginVersion = "1.0.0"
+    private let adSize = CGSize(width: 320, height: 50)
+
+    override func setUp() {
+        super.setUp()
+        PrebidMobilePluginRegister.shared.unregisterAllPlugins()
+    }
+
+    override func tearDown() {
+        PrebidMobilePluginRegister.shared.unregisterAllPlugins()
+        Prebid.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Happy path
+
+    func testDidInjectViewIsCalledOnMatchingPlugin() {
+        let renderer = makeMockRenderer()
+        PrebidMobilePluginRegister.shared.registerPlugin(renderer)
+
+        let bannerView = makeRendererBannerView()
+        bannerView.deployView(UIView())
+
+        flushMainQueue()
+
+        XCTAssertEqual(renderer.didInjectViewCallCount, 1)
+    }
+
+    func testDidInjectViewReceivesCorrectViewAndBannerView() {
+        let renderer = makeMockRenderer()
+        PrebidMobilePluginRegister.shared.registerPlugin(renderer)
+
+        let bannerView = makeRendererBannerView()
+        let injectedView = UIView()
+        bannerView.deployView(injectedView)
+
+        flushMainQueue()
+
+        XCTAssertIdentical(renderer.capturedInjectedView, injectedView)
+        XCTAssertIdentical(renderer.capturedBannerView, bannerView)
+    }
+
+    func testDidInjectViewCalledAgainOnSubsequentDeploy() {
+        let renderer = makeMockRenderer()
+        PrebidMobilePluginRegister.shared.registerPlugin(renderer)
+
+        let bannerView = makeRendererBannerView()
+        bannerView.deployView(UIView())
+        flushMainQueue()
+        bannerView.deployView(UIView())
+        flushMainQueue()
+
+        XCTAssertEqual(renderer.didInjectViewCallCount, 2)
+    }
+
+    // MARK: - No-op cases
+
+    func testDidInjectViewNotCalledWhenBidResponseIsNil() {
+        let renderer = makeMockRenderer()
+        PrebidMobilePluginRegister.shared.registerPlugin(renderer)
+
+        // Plain BannerView — lastBidResponse is nil because no ad has loaded.
+        let bannerView = BannerView(
+            frame: CGRect(origin: .zero, size: adSize),
+            configID: "test-id",
+            adSize: adSize
+        )
+        bannerView.deployView(UIView())
+
+        flushMainQueue()
+
+        XCTAssertEqual(renderer.didInjectViewCallCount, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func makeMockRenderer() -> MockPrebidMobilePluginRenderer {
+        MockPrebidMobilePluginRenderer(name: pluginName, version: pluginVersion)
+    }
+
+    private func makeRendererBannerView() -> MockBannerViewWithCustomRenderer {
+        let bannerView = MockBannerViewWithCustomRenderer(
+            frame: CGRect(origin: .zero, size: adSize),
+            configID: "test-id",
+            adSize: adSize,
+            eventHandler: BannerEventHandlerStandalone()
+        )
+        bannerView.mockRendererName = pluginName
+        bannerView.mockRendererVersion = pluginVersion
+        return bannerView
+    }
+
+    // Processes all pending main-queue work queued before this call.
+    private func flushMainQueue() {
+        let exp = expectation(description: "main queue flush")
+        DispatchQueue.main.async { exp.fulfill() }
+        waitForExpectations(timeout: 1.0)
     }
 }


### PR DESCRIPTION
### Summary
While developing our rendering plugin we've had a need to be notified of ad injection in order to perform a final rendering pass. This PR adds an optional `didInjectView(_:into:)` method to `PrebidMobilePluginRenderer`
so plugin renderers are notified after the ad view is injected into the banner.

BannerView calls the new method via `notifyRendererDidInjectView` after
injection. 

Parallel PR for Android [PR 941](https://github.com/prebid/prebid-mobile-android/pull/941) 