### PR TITLE
Third-party plugin renderers in adapters

### DIFF
--- a/EventHandlers/PrebidMobileAdMobAdapters/Sources/AdMobAdaptersError.swift
+++ b/EventHandlers/PrebidMobileAdMobAdapters/Sources/AdMobAdaptersError.swift
@@ -26,6 +26,7 @@ enum AdMobAdaptersError {
     case noAd
     case adNotValid
     case adExpired
+    case rendererCreationFailed
 }
 
 extension AdMobAdaptersError: LocalizedError {
@@ -42,6 +43,7 @@ extension AdMobAdaptersError: LocalizedError {
         case .noAd                          : return "No ad available"
         case .adNotValid                    : return "Ad is not valid"
         case .adExpired                     : return "Ad expired"
+        case .rendererCreationFailed        : return "Failed to create ad renderer"
         }
     }
 }

--- a/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobBannerAdapter.swift
+++ b/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobBannerAdapter.swift
@@ -28,7 +28,7 @@ public class PrebidAdMobBannerAdapter:
         displayView ?? UIView()
     }
     
-    var displayView: (UIView & PrebidMobileDisplayViewProtocol)?
+    var displayView: PrebidMobileDisplayViewProtocol?
     
     weak var delegate: GoogleMobileAds.MediationBannerAdEventDelegate?
     var adConfiguration: GoogleMobileAds.MediationBannerAdConfiguration?

--- a/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobBannerAdapter.swift
+++ b/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobBannerAdapter.swift
@@ -28,7 +28,7 @@ public class PrebidAdMobBannerAdapter:
         displayView ?? UIView()
     }
     
-    var displayView: DisplayView?
+    var displayView: (UIView & PrebidMobileDisplayViewProtocol)?
     
     weak var delegate: GoogleMobileAds.MediationBannerAdEventDelegate?
     var adConfiguration: GoogleMobileAds.MediationBannerAdConfiguration?
@@ -80,11 +80,21 @@ public class PrebidAdMobBannerAdapter:
         }
         
         let frame = CGRect(origin: .zero, size: bid.size)
+        let renderingConfig = AdUnitConfig(configId: configId, size: bid.size)
         
-        displayView = DisplayView(frame: frame, bid: bid, configId: configId)
-        displayView?.interactionDelegate = self
-        displayView?.loadingDelegate = self
+        guard let view = PluginRendererFactory.createBannerView(
+            with: frame,
+            bid: bid,
+            adConfiguration: renderingConfig,
+            loadingDelegate: self,
+            interactionDelegate: self
+        ) else {
+            let error = AdMobAdaptersError.rendererCreationFailed
+            delegate = completionHandler(nil, error)
+            return
+        }
         
+        displayView = view
         displayView?.loadAd()
     }
     

--- a/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobInterstitialAdapter.swift
+++ b/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobInterstitialAdapter.swift
@@ -79,7 +79,7 @@ public class PrebidAdMobInterstitialAdapter:
         
         let renderingConfig = AdUnitConfig(configId: configId)
         renderingConfig.adConfiguration.isInterstitialAd = true
-        renderingConfig.adConfiguration.isRewarded = bid.rewardedConfig != nil
+        renderingConfig.adConfiguration.isRewarded = false
         
         guard let controller = PluginRendererFactory.createInterstitialController(
             bid: bid,

--- a/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobInterstitialAdapter.swift
+++ b/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobInterstitialAdapter.swift
@@ -26,7 +26,7 @@ public class PrebidAdMobInterstitialAdapter:
     
     // MARK: - Private Properties
     
-    var interstitialController: InterstitialController?
+    var interstitialController: PrebidMobileInterstitialControllerProtocol?
     weak var rootViewController: UIViewController?
     var adAvailable = false
     
@@ -77,10 +77,22 @@ public class PrebidAdMobInterstitialAdapter:
             return
         }
         
-        interstitialController = InterstitialController(bid: bid, configId: configId)
-        interstitialController?.loadingDelegate = self
-        interstitialController?.interactionDelegate = self
+        let renderingConfig = AdUnitConfig(configId: configId)
+        renderingConfig.adConfiguration.isInterstitialAd = true
+        renderingConfig.adConfiguration.isRewarded = bid.rewardedConfig != nil
         
+        guard let controller = PluginRendererFactory.createInterstitialController(
+            bid: bid,
+            adConfiguration: renderingConfig,
+            loadingDelegate: self,
+            interactionDelegate: self
+        ) else {
+            let error = AdMobAdaptersError.rendererCreationFailed
+            delegate = completionHandler(nil, error)
+            return
+        }
+
+        interstitialController = controller
         interstitialController?.loadAd()
     }
     

--- a/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobRewardedAdapter.swift
+++ b/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobRewardedAdapter.swift
@@ -25,7 +25,7 @@ public class PrebidAdMobRewardedAdapter:
     
     // MARK: - Private Properties
     
-    var interstitialController: InterstitialController?
+    var interstitialController: PrebidMobileInterstitialControllerProtocol?
     weak var rootViewController: UIViewController?
     var adAvailable = false
     
@@ -53,7 +53,7 @@ public class PrebidAdMobRewardedAdapter:
     
     func createInterstitialController(
         with adConfiguration: GoogleMobileAds.MediationRewardedAdConfiguration
-    ) -> Result<InterstitialController, Error> {
+    ) -> Result<PrebidMobileInterstitialControllerProtocol, Error> {
         guard let serverParameter = adConfiguration.credentials.settings["parameter"] as? String else {
             return .failure(AdMobAdaptersError.noServerParameter)
         }
@@ -80,20 +80,30 @@ public class PrebidAdMobRewardedAdapter:
             return .failure(AdMobAdaptersError.noConfigIDInEventExtras)
         }
         
-        let interstitialController = InterstitialController(bid: bid, configId: configId)
-        interstitialController.loadingDelegate = self
-        interstitialController.interactionDelegate = self
-        interstitialController.isRewarded = true
+        let videoControlsConfig = eventExtrasDictionary[PBMMediationVideoAdConfiguration] as? VideoControlsConfiguration
+        let videoParameters = eventExtrasDictionary[PBMMediationVideoParameters] as? VideoParameters
+        let renderingConfig = AdUnitConfig(configId: configId)
+        renderingConfig.adConfiguration.isInterstitialAd = true
+        renderingConfig.adConfiguration.isRewarded = true
         
-        if let videoAdConfig = eventExtrasDictionary[PBMMediationVideoAdConfiguration] as? VideoControlsConfiguration {
-            interstitialController.videoControlsConfig = videoAdConfig
+        if let videoControlsConfig = videoControlsConfig {
+            renderingConfig.adConfiguration.videoControlsConfig = videoControlsConfig
         }
         
-        if let videoParameters = eventExtrasDictionary[PBMMediationVideoParameters] as? VideoParameters {
-            interstitialController.videoParameters = videoParameters
+        if let videoParameters = videoParameters {
+            renderingConfig.adConfiguration.videoParameters = videoParameters
         }
         
-        return .success(interstitialController)
+        guard let controller = PluginRendererFactory.createInterstitialController(
+            bid: bid,
+            adConfiguration: renderingConfig,
+            loadingDelegate: self,
+            interactionDelegate: self
+        ) else {
+            return .failure(AdMobAdaptersError.rendererCreationFailed)
+        }
+
+        return .success(controller)
     }
     
     // MARK: - GADMediationRewardedAd

--- a/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobVideoInterstitialAdapter.swift
+++ b/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobVideoInterstitialAdapter.swift
@@ -26,7 +26,7 @@ public class PrebidAdMobVideoInterstitialAdapter:
     
     // MARK: - Private Properties
     
-    var interstitialController: InterstitialController?
+    var interstitialController: PrebidMobileInterstitialControllerProtocol?
     weak var rootViewController: UIViewController?
     var adAvailable = false
     
@@ -77,19 +77,33 @@ public class PrebidAdMobVideoInterstitialAdapter:
             return
         }
         
-        interstitialController = InterstitialController(bid: bid, configId: configId)
-        interstitialController?.loadingDelegate = self
-        interstitialController?.interactionDelegate = self
-        interstitialController?.adFormats = [.video]
+        let videoControlsConfig = eventExtrasDictionary[PBMMediationVideoAdConfiguration] as? VideoControlsConfiguration
+        let videoParameters = eventExtrasDictionary[PBMMediationVideoParameters] as? VideoParameters
+        let renderingConfig = AdUnitConfig(configId: configId)
+        renderingConfig.adConfiguration.isInterstitialAd = true
+        renderingConfig.adConfiguration.isRewarded = bid.rewardedConfig != nil
+        renderingConfig.adFormats = [.video]
         
-        if let videoAdConfig = eventExtrasDictionary[PBMMediationVideoAdConfiguration] as? VideoControlsConfiguration {
-            interstitialController?.videoControlsConfig = videoAdConfig
+        if let videoControlsConfig = videoControlsConfig {
+            renderingConfig.adConfiguration.videoControlsConfig = videoControlsConfig
         }
         
-        if let videoParameters = eventExtrasDictionary[PBMMediationVideoParameters] as? VideoParameters {
-            interstitialController?.videoParameters = videoParameters
+        if let videoParameters = videoParameters {
+            renderingConfig.adConfiguration.videoParameters = videoParameters
         }
         
+        guard let controller = PluginRendererFactory.createInterstitialController(
+            bid: bid,
+            adConfiguration: renderingConfig,
+            loadingDelegate: self,
+            interactionDelegate: self
+        ) else {
+            let error = AdMobAdaptersError.rendererCreationFailed
+            delegate = completionHandler(nil, error)
+            return
+        }
+
+        interstitialController = controller
         interstitialController?.loadAd()
     }
     

--- a/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobVideoInterstitialAdapter.swift
+++ b/EventHandlers/PrebidMobileAdMobAdapters/Sources/PrebidAdMobVideoInterstitialAdapter.swift
@@ -81,7 +81,7 @@ public class PrebidAdMobVideoInterstitialAdapter:
         let videoParameters = eventExtrasDictionary[PBMMediationVideoParameters] as? VideoParameters
         let renderingConfig = AdUnitConfig(configId: configId)
         renderingConfig.adConfiguration.isInterstitialAd = true
-        renderingConfig.adConfiguration.isRewarded = bid.rewardedConfig != nil
+        renderingConfig.adConfiguration.isRewarded = false
         renderingConfig.adFormats = [.video]
         
         if let videoControlsConfig = videoControlsConfig {

--- a/EventHandlers/PrebidMobileMAXAdapters/Sources/MAXAdaptersError.swift
+++ b/EventHandlers/PrebidMobileMAXAdapters/Sources/MAXAdaptersError.swift
@@ -21,6 +21,7 @@ enum MAXAdaptersError {
     case wrongServerParameter
     case noBidInLocalExtraParameters
     case noConfigIdInLocalExtraParameters
+    case rendererCreationFailed
 }
 
 extension MAXAdaptersError: LocalizedError {
@@ -37,6 +38,8 @@ extension MAXAdaptersError: LocalizedError {
             return "Bid object is absent in the local extra parameters"
         case .noConfigIdInLocalExtraParameters:
             return "Config id is absent in the local extra parameters"
+        case .rendererCreationFailed:
+            return "Failed to create ad renderer"
         }
     }
 }

--- a/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter+MAAdViewAdapter.swift
+++ b/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter+MAAdViewAdapter.swift
@@ -58,10 +58,21 @@ extension PrebidMAXMediationAdapter:
         }
         
         let frame = CGRect(origin: .zero, size: bid.size)
-        displayView = DisplayView(frame: frame, bid: bid, configId: configId)
-        displayView?.interactionDelegate = self
-        displayView?.loadingDelegate = self
+        let renderingConfig = AdUnitConfig(configId: configId, size: bid.size)
         
+        guard let view = PluginRendererFactory.createBannerView(
+            with: frame,
+            bid: bid,
+            adConfiguration: renderingConfig,
+            loadingDelegate: self,
+            interactionDelegate: self
+        ) else {
+            let error = MAAdapterError(nsError: MAXAdaptersError.rendererCreationFailed)
+            bannerDelegate?.didFailToLoadAdViewAdWithError(error)
+            return
+        }
+
+        displayView = view
         displayView?.loadAd()
     }
     

--- a/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter+MAInterstitialAdapter+MARewardedAdapter.swift
+++ b/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter+MAInterstitialAdapter+MARewardedAdapter.swift
@@ -108,7 +108,7 @@ extension PrebidMAXMediationAdapter: MAInterstitialAdapter,
             .localExtraParameters[PBMMediationVideoParameters] as? VideoParameters
         let renderingConfig = AdUnitConfig(configId: configId)
         renderingConfig.adConfiguration.isInterstitialAd = true
-        renderingConfig.adConfiguration.isRewarded = isRewarded || bid.rewardedConfig != nil
+        renderingConfig.adConfiguration.isRewarded = isRewarded
         
         if let videoControlsConfig = videoControlsConfig {
             renderingConfig.adConfiguration.videoControlsConfig = videoControlsConfig

--- a/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter+MAInterstitialAdapter+MARewardedAdapter.swift
+++ b/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter+MAInterstitialAdapter+MARewardedAdapter.swift
@@ -29,7 +29,7 @@ extension PrebidMAXMediationAdapter: MAInterstitialAdapter,
     ) {
         interstitialDelegate = delegate
         
-        switch createInterstitialController(with: parameters) {
+        switch createInterstitialController(with: parameters, isRewarded: false) {
         case .success(let controller):
             self.interstitialController = controller
             interstitialController?.loadAd()
@@ -43,7 +43,7 @@ extension PrebidMAXMediationAdapter: MAInterstitialAdapter,
         if interstitialAdAvailable {
             interstitialController?.show()
         } else {
-            interstitialDelegate?.didFailToLoadInterstitialAdWithError(MAAdapterError.adNotReady)
+            interstitialDelegate?.didFailToDisplayInterstitialAdWithError(MAAdapterError.adNotReady)
         }
     }
     
@@ -52,10 +52,9 @@ extension PrebidMAXMediationAdapter: MAInterstitialAdapter,
     public func loadRewardedAd(for parameters: MAAdapterResponseParameters, andNotify delegate: MARewardedAdapterDelegate) {
         rewardedDelegate = delegate
         
-        switch createInterstitialController(with: parameters) {
+        switch createInterstitialController(with: parameters, isRewarded: true) {
         case .success(let controller):
             interstitialController = controller
-            interstitialController?.isRewarded = true
             interstitialController?.loadAd()
         case .failure(let error):
             let maError = MAAdapterError(nsError: error)
@@ -70,13 +69,14 @@ extension PrebidMAXMediationAdapter: MAInterstitialAdapter,
         if interstitialAdAvailable {
             interstitialController?.show()
         } else {
-            interstitialDelegate?.didFailToLoadInterstitialAdWithError(MAAdapterError.adNotReady)
+            rewardedDelegate?.didFailToDisplayRewardedAdWithError(MAAdapterError.adNotReady)
         }
     }
     
     private func createInterstitialController(
-        with parameters: MAAdapterResponseParameters
-    ) -> Result<InterstitialController, Error> {
+        with parameters: MAAdapterResponseParameters,
+        isRewarded: Bool
+    ) -> Result<PrebidMobileInterstitialControllerProtocol, Error> {
         
         guard let serverParameter = parameters
             .serverParameters[MAXCustomParametersKey] as? [String: String] else {
@@ -102,21 +102,32 @@ extension PrebidMAXMediationAdapter: MAInterstitialAdapter,
             return .failure(MAXAdaptersError.noConfigIdInLocalExtraParameters)
         }
         
-        let interstitialController = InterstitialController(bid: bid, configId: configId)
-        interstitialController.loadingDelegate = self
-        interstitialController.interactionDelegate = self
+        let videoControlsConfig = parameters
+            .localExtraParameters[PBMMediationVideoAdConfiguration] as? VideoControlsConfiguration
+        let videoParameters = parameters
+            .localExtraParameters[PBMMediationVideoParameters] as? VideoParameters
+        let renderingConfig = AdUnitConfig(configId: configId)
+        renderingConfig.adConfiguration.isInterstitialAd = true
+        renderingConfig.adConfiguration.isRewarded = isRewarded || bid.rewardedConfig != nil
         
-        if let videoAdConfig = parameters
-            .localExtraParameters[PBMMediationVideoAdConfiguration] as? VideoControlsConfiguration {
-            interstitialController.videoControlsConfig = videoAdConfig
+        if let videoControlsConfig = videoControlsConfig {
+            renderingConfig.adConfiguration.videoControlsConfig = videoControlsConfig
         }
         
-        if let videoParameters = parameters
-            .localExtraParameters[PBMMediationVideoParameters] as? VideoParameters {
-            interstitialController.videoParameters = videoParameters
+        if let videoParameters = videoParameters {
+            renderingConfig.adConfiguration.videoParameters = videoParameters
         }
         
-        return .success(interstitialController)
+        guard let controller = PluginRendererFactory.createInterstitialController(
+            bid: bid,
+            adConfiguration: renderingConfig,
+            loadingDelegate: self,
+            interactionDelegate: self
+        ) else {
+            return .failure(MAXAdaptersError.rendererCreationFailed)
+        }
+
+        return .success(controller)
     }
     
     // MARK: - InterstitialControllerLoadingDelegate

--- a/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter.swift
+++ b/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter.swift
@@ -25,12 +25,12 @@ public class PrebidMAXMediationAdapter: ALMediationAdapter {
     // MARK: - Banner
     
     public weak var bannerDelegate: MAAdViewAdapterDelegate?
-    var displayView: DisplayView?
+    var displayView: (UIView & PrebidMobileDisplayViewProtocol)?
     
     // MARK: - Interstitial
     
     public weak var interstitialDelegate: MAInterstitialAdapterDelegate?
-    public var interstitialController: InterstitialController?
+    public var interstitialController: PrebidMobileInterstitialControllerProtocol?
     public var interstitialAdAvailable = false
     
     // MARK: - Rewarded

--- a/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter.swift
+++ b/EventHandlers/PrebidMobileMAXAdapters/Sources/PrebidMAXMediationAdapter.swift
@@ -25,7 +25,7 @@ public class PrebidMAXMediationAdapter: ALMediationAdapter {
     // MARK: - Banner
     
     public weak var bannerDelegate: MAAdViewAdapterDelegate?
-    var displayView: (UIView & PrebidMobileDisplayViewProtocol)?
+    var displayView: PrebidMobileDisplayViewProtocol?
     
     // MARK: - Interstitial
     

--- a/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/Model/TestCasesManager.swift
@@ -886,7 +886,7 @@ struct TestCaseManager {
                     source: "liveramp.com",
                     uids: [
                         UserUniqueID(
-                            id: "XY1000bIVBVah9ium-sZ3ykhPiXQbEcUpn4GjCtxrrw2BRDGM",
+                            uniqueId: "XY1000bIVBVah9ium-sZ3ykhPiXQbEcUpn4GjCtxrrw2BRDGM",
                             aType: 1
                         )
                     ]
@@ -2715,7 +2715,25 @@ struct TestCaseManager {
                         
                 setupCustomParams(for: admobBannerController.prebidConfigId)
             }),
-            
+
+            TestCase(title: "Banner 320x50 (AdMob, Custom Renderer)",
+                     tags: [.banner, .admob, .server],
+                     exampleVCStoryboardID: "AdapterViewController",
+                     configurationClosure: { vc in
+                guard let adapterVC = vc as? AdapterViewController else {
+                    return
+                }
+
+                let admobBannerController = PrebidAdMobBannerViewController(rootController: adapterVC)
+                admobBannerController.adMobAdUnitId = "ca-app-pub-5922967660082475/9483570409"
+                admobBannerController.adUnitSize = CGSize(width: 320, height: 50)
+                admobBannerController.prebidConfigId = "prebid-demo-display-banner-320-50-custom-ad-view-renderer"
+                admobBannerController.useSampleCustomRenderer = true
+                adapterVC.setup(adapter: admobBannerController)
+
+                setupCustomParams(for: admobBannerController.prebidConfigId)
+            }),
+
             TestCase(title: "Banner 320x50 Events (AdMob) [OK, OXB Adapter]",
                      tags: [.banner, .admob, .server],
                      exampleVCStoryboardID: "AdapterViewController",
@@ -2841,7 +2859,25 @@ struct TestCaseManager {
                         
                 setupCustomParams(for: admobInterstitialController.prebidConfigId)
             }),
-            
+
+            TestCase(title: "Display Interstitial 320x480 (AdMob, Custom Renderer)",
+                     tags: [.interstitial, .admob, .server],
+                     exampleVCStoryboardID: "AdapterViewController",
+                     configurationClosure: { vc in
+                guard let adapterVC = vc as? AdapterViewController else {
+                    return
+                }
+
+                let admobInterstitialController = PrebidAdMobInterstitialViewController(rootController: adapterVC)
+                admobInterstitialController.adMobAdUnitId = "ca-app-pub-5922967660082475/3383099861"
+                admobInterstitialController.adFormats = [.banner]
+                admobInterstitialController.prebidConfigId = "prebid-demo-display-interstitial-320-480-custom-interstitial-renderer"
+                admobInterstitialController.useSampleCustomRenderer = true
+                adapterVC.setup(adapter: admobInterstitialController)
+
+                setupCustomParams(for: admobInterstitialController.prebidConfigId)
+            }),
+
             TestCase(title: "Display Interstitial 320x480 (AdMob) [noBids, AdMob Ad]",
                      tags: [.interstitial, .admob, .server],
                      exampleVCStoryboardID: "AdapterViewController",
@@ -3461,7 +3497,25 @@ struct TestCaseManager {
                         
                 setupCustomParams(for: maxBannerController.prebidConfigId)
             }),
-            
+
+            TestCase(title: "Banner 320x50 (MAX, Custom Renderer)",
+                     tags: [.banner, .max, .server],
+                     exampleVCStoryboardID: "AdapterViewController",
+                     configurationClosure: { vc in
+                guard let adapterVC = vc as? AdapterViewController else {
+                    return
+                }
+
+                let maxBannerController = PrebidMAXBannerController(rootController: adapterVC)
+                maxBannerController.maxAdUnitId = "5f111f4bcd0f58ca"
+                maxBannerController.adUnitSize = CGSize(width: 320, height: 50)
+                maxBannerController.prebidConfigId = "prebid-demo-display-banner-320-50-custom-ad-view-renderer"
+                maxBannerController.useSampleCustomRenderer = true
+                adapterVC.setup(adapter: maxBannerController)
+
+                setupCustomParams(for: maxBannerController.prebidConfigId)
+            }),
+
             TestCase(title: "Banner 320x50 Events (MAX) [OK, OXB Adapter]",
                      tags: [.banner, .max, .server],
                      exampleVCStoryboardID: "AdapterViewController",
@@ -3586,7 +3640,25 @@ struct TestCaseManager {
                         
                 setupCustomParams(for: maxInterstitialController.prebidConfigId)
             }),
-            
+
+            TestCase(title: "Display Interstitial 320x480 (MAX, Custom Renderer)",
+                     tags: [.interstitial, .max, .server],
+                     exampleVCStoryboardID: "AdapterViewController",
+                     configurationClosure: { vc in
+                guard let adapterVC = vc as? AdapterViewController else {
+                    return
+                }
+
+                let maxInterstitialController = PrebidMAXInterstitialController(rootController: adapterVC)
+                maxInterstitialController.adFormats = [.banner]
+                maxInterstitialController.maxAdUnitId = "78f9d445b8a1add7"
+                maxInterstitialController.prebidConfigId = "prebid-demo-display-interstitial-320-480-custom-interstitial-renderer"
+                maxInterstitialController.useSampleCustomRenderer = true
+                adapterVC.setup(adapter: maxInterstitialController)
+
+                setupCustomParams(for: maxInterstitialController.prebidConfigId)
+            }),
+
             TestCase(title: "Display Interstitial 320x480 (MAX) [noBids, MAX Ad]",
                      tags: [.interstitial, .max, .server],
                      exampleVCStoryboardID: "AdapterViewController",

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
@@ -91,10 +91,6 @@ class PrebidAdMobBannerViewController:
     }
     
     func loadAd() {
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
-
         registerSampleCustomRendererIfNeeded()
 
         configIdLabel.isHidden = false
@@ -125,7 +121,15 @@ class PrebidAdMobBannerViewController:
             adUnit?.adFormat = adFormat
         }
         
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+        
         adUnit?.fetchDemand { [weak self] result in
+            if self?.storedAuctionResponse != nil {
+                Prebid.shared.storedAuctionResponse = nil
+            }
+
             guard let self = self,
                   let adBannerView = self.adBannerView,
                   let container = self.rootController?.bannerView

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobBannerViewController.swift
@@ -38,6 +38,8 @@ class PrebidAdMobBannerViewController:
     var adUnitSize = CGSize()
     var additionalAdSizes = [CGSize]()
     var adFormat: PrebidMobile.AdFormat?
+    var storedAuctionResponse: String?
+    var useSampleCustomRenderer = false
     
     var request = Request()
     
@@ -63,6 +65,7 @@ class PrebidAdMobBannerViewController:
     private var adUnit: MediationBannerAdUnit?
     
     private var mediationDelegate: AdMobMediationBannerUtils?
+    private var sampleCustomRenderer: SampleRenderer?
     
     // MARK: - AdaptedController
     
@@ -77,11 +80,23 @@ class PrebidAdMobBannerViewController:
         setupAdapterController()
     }
     
+    deinit {
+        if let sampleCustomRenderer = sampleCustomRenderer {
+            Prebid.unregisterPluginRenderer(sampleCustomRenderer)
+        }
+    }
+
     func configurationController() -> BaseConfigurationController? {
         return PrebidBannerConfigurationController(controller: self)
     }
     
     func loadAd() {
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+
+        registerSampleCustomRendererIfNeeded()
+
         configIdLabel.isHidden = false
         configIdLabel.text = "Config ID: \(prebidConfigId)"
         
@@ -239,5 +254,13 @@ class PrebidAdMobBannerViewController:
     @objc private func stopRefresh() {
         stopRefreshButton.isEnabled = false
         adUnit?.stopRefresh()
+    }
+
+    private func registerSampleCustomRendererIfNeeded() {
+        guard useSampleCustomRenderer, sampleCustomRenderer == nil else { return }
+
+        let renderer = SampleRenderer()
+        Prebid.registerPluginRenderer(renderer)
+        sampleCustomRenderer = renderer
     }
 }

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
@@ -80,10 +80,6 @@ class PrebidAdMobInterstitialViewController:
         configIdLabel.isHidden = false
         configIdLabel.text = "Config ID: \(prebidConfigId)"
         
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
-        
         registerSampleCustomRendererIfNeeded()
 
         mediationDelegate = AdMobMediationInterstitialUtils(gadRequest: request)
@@ -122,7 +118,15 @@ class PrebidAdMobInterstitialViewController:
             adUnit?.adFormats = adFormats
         }
         
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+        
         adUnit?.fetchDemand { [weak self] result in
+            if self?.storedAuctionResponse != nil {
+                Prebid.shared.storedAuctionResponse = nil
+            }
+
             guard let self = self else { return }
             InterstitialAd.load(with: self.adMobAdUnitId, request: self.request) { [weak self] ad, error in
                 guard let self = self else { return }

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobInterstitialViewController.swift
@@ -26,6 +26,7 @@ class PrebidAdMobInterstitialViewController:
     
     var prebidConfigId = ""
     var storedAuctionResponse: String?
+    var useSampleCustomRenderer = false
 
     var adMobAdUnitId = ""
     
@@ -46,6 +47,7 @@ class PrebidAdMobInterstitialViewController:
     
     private var adUnit: MediationInterstitialAdUnit?
     private var mediationDelegate: AdMobMediationInterstitialUtils?
+    private var sampleCustomRenderer: SampleRenderer?
     
     var request = Request()
     
@@ -64,6 +66,12 @@ class PrebidAdMobInterstitialViewController:
         setupAdapterController()
     }
     
+    deinit {
+        if let sampleCustomRenderer = sampleCustomRenderer {
+            Prebid.unregisterPluginRenderer(sampleCustomRenderer)
+        }
+    }
+
     func configurationController() -> BaseConfigurationController? {
         return BaseConfigurationController(controller: self)
     }
@@ -76,6 +84,8 @@ class PrebidAdMobInterstitialViewController:
             Prebid.shared.storedAuctionResponse = storedAuctionResponse
         }
         
+        registerSampleCustomRendererIfNeeded()
+
         mediationDelegate = AdMobMediationInterstitialUtils(gadRequest: request)
         adUnit = MediationInterstitialAdUnit(
             configId: prebidConfigId,
@@ -192,5 +202,13 @@ class PrebidAdMobInterstitialViewController:
             adapterViewController.showButton.isEnabled = false
             interstitial?.present(from: adapterViewController)
         }
+    }
+
+    private func registerSampleCustomRendererIfNeeded() {
+        guard useSampleCustomRenderer, sampleCustomRenderer == nil else { return }
+
+        let renderer = SampleRenderer()
+        Prebid.registerPluginRenderer(renderer)
+        sampleCustomRenderer = renderer
     }
 }

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
@@ -66,10 +66,6 @@ class PrebidAdMobRewardedViewController:
     }
     
     func loadAd() {
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
-
         registerSampleCustomRendererIfNeeded()
 
         configIdLabel.isHidden = false
@@ -78,7 +74,15 @@ class PrebidAdMobRewardedViewController:
         mediationDelegate = AdMobMediationRewardedUtils(gadRequest: request)
         adUnit = MediationRewardedAdUnit(configId: prebidConfigId, mediationDelegate: mediationDelegate!)
         
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+        
         adUnit?.fetchDemand { [weak self] result in
+            if self?.storedAuctionResponse != nil {
+                Prebid.shared.storedAuctionResponse = nil
+            }
+
             guard let self = self else { return }
             RewardedAd.load(with: self.adMobAdUnitId, request: self.request) { [weak self] ad, error in
                 guard let self = self else { return }

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/AdMob/PrebidAdMobRewardedViewController.swift
@@ -25,6 +25,8 @@ class PrebidAdMobRewardedViewController:
         FullScreenContentDelegate {
     
     var prebidConfigId = ""
+    var storedAuctionResponse: String?
+    var useSampleCustomRenderer = false
 
     var adMobAdUnitId = ""
     
@@ -43,6 +45,7 @@ class PrebidAdMobRewardedViewController:
     
     private var adUnit: MediationRewardedAdUnit?
     private var mediationDelegate: AdMobMediationRewardedUtils?
+    private var sampleCustomRenderer: SampleRenderer?
     
     var request = Request()
     
@@ -52,11 +55,23 @@ class PrebidAdMobRewardedViewController:
         setupAdapterController()
     }
     
+    deinit {
+        if let sampleCustomRenderer = sampleCustomRenderer {
+            Prebid.unregisterPluginRenderer(sampleCustomRenderer)
+        }
+    }
+
     func configurationController() -> BaseConfigurationController? {
         return BaseConfigurationController(controller: self)
     }
     
     func loadAd() {
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+
+        registerSampleCustomRendererIfNeeded()
+
         configIdLabel.isHidden = false
         configIdLabel.text = "Config ID: \(prebidConfigId)"
         
@@ -149,5 +164,13 @@ class PrebidAdMobRewardedViewController:
                 print("User rewarded")
             })
         }
+    }
+
+    private func registerSampleCustomRendererIfNeeded() {
+        guard useSampleCustomRenderer, sampleCustomRenderer == nil else { return }
+
+        let renderer = SampleRenderer()
+        Prebid.registerPluginRenderer(renderer)
+        sampleCustomRenderer = renderer
     }
 }

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/GAM/PrebidGAMInterstitialController.swift
@@ -65,10 +65,7 @@ class PrebidGAMInterstitialController: NSObject, AdaptedController, PrebidConfig
         configIdLabel.text = "Config ID: \(prebidConfigId)"
         
         let eventHandler = GAMInterstitialEventHandler(adUnitID: gamAdUnitId)
-        
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
+        Prebid.shared.storedAuctionResponse = storedAuctionResponse
         
         interstitialController = InterstitialRenderingAdUnit(configID: prebidConfigId,
                                                              minSizePercentage: CGSize(width: 30, height: 30),
@@ -105,6 +102,10 @@ class PrebidGAMInterstitialController: NSObject, AdaptedController, PrebidConfig
         }
         
         interstitialController?.loadAd()
+
+        if storedAuctionResponse != nil {
+            Prebid.shared.storedAuctionResponse = nil
+        }
     }
     
     // MARK: - GADInterstitialDelegate

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
@@ -76,10 +76,6 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
     }
     
     func loadAd() {
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
-
         registerSampleCustomRendererIfNeeded()
 
         configIdLabel.isHidden = false
@@ -110,7 +106,15 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
             adUnit?.adFormat = adFormat
         }
         
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+        
         adUnit?.fetchDemand { [weak self] result in
+            if self?.storedAuctionResponse != nil {
+                Prebid.shared.storedAuctionResponse = nil
+            }
+
             guard let self = self,
                   let adBannerView = self.adBannerView,
                   let container = self.rootController?.bannerView else {

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXBannerController.swift
@@ -28,6 +28,8 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
     
     var prebidConfigId = ""
     var maxAdUnitId = ""
+    var storedAuctionResponse: String?
+    var useSampleCustomRenderer = false
     
     var isAdaptive = false
     
@@ -36,6 +38,7 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
     private var adBannerView: MAAdView?
     private var adUnit: MediationBannerAdUnit?
     private var mediationDelegate: MAXMediationBannerUtils?
+    private var sampleCustomRenderer: SampleRenderer?
     
     private let reloadButton = ThreadCheckingButton()
     private let stopRefreshButton = ThreadCheckingButton()
@@ -62,11 +65,23 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
         setupAdapterController()
     }
     
+    deinit {
+        if let sampleCustomRenderer = sampleCustomRenderer {
+            Prebid.unregisterPluginRenderer(sampleCustomRenderer)
+        }
+    }
+
     func configurationController() -> BaseConfigurationController? {
         return PrebidBannerConfigurationController(controller: self)
     }
     
     func loadAd() {
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+
+        registerSampleCustomRendererIfNeeded()
+
         configIdLabel.isHidden = false
         configIdLabel.text = "Config ID: \(prebidConfigId)"
         
@@ -191,6 +206,14 @@ class PrebidMAXBannerController: NSObject, AdaptedController, PrebidConfigurable
         reloadButton.isEnabled = false
         adBannerView?.stopAutoRefresh()
         adUnit?.stopRefresh()
+    }
+
+    private func registerSampleCustomRendererIfNeeded() {
+        guard useSampleCustomRenderer, sampleCustomRenderer == nil else { return }
+
+        let renderer = SampleRenderer()
+        Prebid.registerPluginRenderer(renderer)
+        sampleCustomRenderer = renderer
     }
 }
 

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
@@ -75,10 +75,6 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
     }
     
     func loadAd() {
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
-        
         registerSampleCustomRendererIfNeeded()
 
         configIdLabel.isHidden = false
@@ -121,7 +117,15 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
             adUnit?.adFormats = adFormats
         }
         
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+        
         adUnit?.fetchDemand { [weak self] result in
+            if self?.storedAuctionResponse != nil {
+                Prebid.shared.storedAuctionResponse = nil
+            }
+
             guard let self = self else { return }
             
             if result != .prebidDemandFetchSuccess {

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXInterstitialController.swift
@@ -22,6 +22,7 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
     
     var prebidConfigId: String = ""
     var storedAuctionResponse: String?
+    var useSampleCustomRenderer = false
     
     var maxAdUnitId = ""
     
@@ -29,6 +30,7 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
     
     private var adUnit: MediationInterstitialAdUnit?
     private var mediationDelegate: MAXMediationInterstitialUtils?
+    private var sampleCustomRenderer: SampleRenderer?
     
     private var interstitial: MAInterstitialAd?
     
@@ -62,6 +64,12 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
         setupAdapterController()
     }
     
+    deinit {
+        if let sampleCustomRenderer = sampleCustomRenderer {
+            Prebid.unregisterPluginRenderer(sampleCustomRenderer)
+        }
+    }
+
     func configurationController() -> BaseConfigurationController? {
         return BaseConfigurationController(controller: self)
     }
@@ -71,6 +79,8 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
             Prebid.shared.storedAuctionResponse = storedAuctionResponse
         }
         
+        registerSampleCustomRendererIfNeeded()
+
         configIdLabel.isHidden = false
         configIdLabel.text = "Config ID: \(prebidConfigId)"
         
@@ -164,6 +174,14 @@ class PrebidMAXInterstitialController: NSObject, AdaptedController, PrebidConfig
             adapterViewController?.showButton.isEnabled = false
             interstitial.show()
         }
+    }
+
+    private func registerSampleCustomRendererIfNeeded() {
+        guard useSampleCustomRenderer, sampleCustomRenderer == nil else { return }
+
+        let renderer = SampleRenderer()
+        Prebid.registerPluginRenderer(renderer)
+        sampleCustomRenderer = renderer
     }
 }
 

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
@@ -66,10 +66,6 @@ class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurab
     }
     
     func loadAd() {
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
-
         registerSampleCustomRendererIfNeeded()
 
         configIdLabel.isHidden = false
@@ -81,7 +77,15 @@ class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurab
         mediationDelegate = MAXMediationRewardedUtils(rewardedAd: rewarded!)
         adUnit = MediationRewardedAdUnit(configId: prebidConfigId, mediationDelegate: mediationDelegate!)
         
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+        
         adUnit?.fetchDemand { [weak self] result in
+            if self?.storedAuctionResponse != nil {
+                Prebid.shared.storedAuctionResponse = nil
+            }
+
             guard let self = self else { return }
             
             if result != .prebidDemandFetchSuccess {

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/MAX/PrebidMAXRewardedController.swift
@@ -21,11 +21,14 @@ import PrebidMobileMAXAdapters
 class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurableController {
     
     var prebidConfigId: String = ""
+    var storedAuctionResponse: String?
+    var useSampleCustomRenderer = false
     
     var maxAdUnitId = ""
     
     private var adUnit: MediationRewardedAdUnit?
     private var mediationDelegate: MAXMediationRewardedUtils?
+    private var sampleCustomRenderer: SampleRenderer?
     
     private var rewarded: MARewardedAd?
     
@@ -52,11 +55,23 @@ class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurab
         setupAdapterController()
     }
     
+    deinit {
+        if let sampleCustomRenderer = sampleCustomRenderer {
+            Prebid.unregisterPluginRenderer(sampleCustomRenderer)
+        }
+    }
+
     func configurationController() -> BaseConfigurationController? {
         return BaseConfigurationController(controller: self)
     }
     
     func loadAd() {
+        if let storedAuctionResponse = storedAuctionResponse {
+            Prebid.shared.storedAuctionResponse = storedAuctionResponse
+        }
+
+        registerSampleCustomRendererIfNeeded()
+
         configIdLabel.isHidden = false
         configIdLabel.text = "Config ID: \(prebidConfigId)"
         
@@ -121,6 +136,14 @@ class PrebidMAXRewardedController: NSObject, AdaptedController, PrebidConfigurab
             adapterViewController?.showButton.isEnabled = false
             rewarded.show()
         }
+    }
+
+    private func registerSampleCustomRendererIfNeeded() {
+        guard useSampleCustomRenderer, sampleCustomRenderer == nil else { return }
+
+        let renderer = SampleRenderer()
+        Prebid.registerPluginRenderer(renderer)
+        sampleCustomRenderer = renderer
     }
 }
 

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/CustomRenderer/CustomRendererInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/CustomRenderer/CustomRendererInterstitialController.swift
@@ -72,10 +72,7 @@ class CustomRendererInterstitialController:
     func loadAd() {
         configIdLabel.isHidden = false
         configIdLabel.text = "Config ID: \(prebidConfigId)"
-        
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
+        Prebid.shared.storedAuctionResponse = storedAuctionResponse
 
         interstitialController = InterstitialRenderingAdUnit(
             configID: prebidConfigId,
@@ -114,6 +111,10 @@ class CustomRendererInterstitialController:
         }
         
         interstitialController?.loadAd()
+
+        if storedAuctionResponse != nil {
+            Prebid.shared.storedAuctionResponse = nil
+        }
     }
     
     // MARK: - GADInterstitialDelegate

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/CustomRenderer/Renderers/SampleRenderer.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/CustomRenderer/Renderers/SampleRenderer.swift
@@ -28,7 +28,7 @@ public class SampleRenderer: NSObject, PrebidMobilePluginRenderer {
         adConfiguration: AdUnitConfig,
         loadingDelegate: DisplayViewLoadingDelegate,
         interactionDelegate: DisplayViewInteractionDelegate
-    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+    ) -> PrebidMobileDisplayViewProtocol? {
         let bannerView = SampleAdView(frame: frame)
         
         bannerView.interactionDelegate = interactionDelegate

--- a/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidInterstitialController.swift
+++ b/InternalTestApp/PrebidMobileDemoRendering/ViewControllers/Adapters/Prebid/OpenX/PrebidInterstitialController.swift
@@ -72,10 +72,7 @@ class PrebidInterstitialController:
     func loadAd() {
         configIdLabel.isHidden = false
         configIdLabel.text = "Config ID: \(prebidConfigId)"
-        
-        if let storedAuctionResponse = storedAuctionResponse {
-            Prebid.shared.storedAuctionResponse = storedAuctionResponse
-        }
+        Prebid.shared.storedAuctionResponse = storedAuctionResponse
 
         interstitialController = InterstitialRenderingAdUnit(
             configID: prebidConfigId,
@@ -116,6 +113,10 @@ class PrebidInterstitialController:
         }
         
         interstitialController?.loadAd()
+
+        if storedAuctionResponse != nil {
+            Prebid.shared.storedAuctionResponse = nil
+        }
     }
     
     // MARK: - GADInterstitialDelegate

--- a/PrebidMobile.xcodeproj/project.pbxproj
+++ b/PrebidMobile.xcodeproj/project.pbxproj
@@ -793,7 +793,10 @@
 		A908694429E05ED500B37479 /* PrebidMobilePluginRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A908694329E05ED500B37479 /* PrebidMobilePluginRenderer.swift */; };
 		A908694629E05F7900B37479 /* PrebidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A908694529E05F7900B37479 /* PrebidRenderer.swift */; };
 		E557D4B72ED219CB00E5580A /* UserAgentPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = E557D4B62ED219CB00E5580A /* UserAgentPersistence.swift */; };
+		E5D79CAE2FAE93BF00C0C44A /* PluginRendererFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D79CAD2FAE93BF00C0C44A /* PluginRendererFactory.swift */; };
+		E5D79CB02FAE951C00C0C44A /* PluginRendererFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D79CAF2FAE951C00C0C44A /* PluginRendererFactoryTest.swift */; };
 		E5D88C022F4517FA00E801C3 /* ViewExposureCheckerSystemUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D88C012F4517FA00E801C3 /* ViewExposureCheckerSystemUITests.swift */; };
+		FA12590120260425000000A1 /* FunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA12590120260425000000A2 /* FunctionsTests.swift */; };
 		FA5AD5E42271FA4100C8F274 /* ConstantsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5AD5E32271FA4100C8F274 /* ConstantsTest.swift */; };
 		FA9D7F2722E8A83D006FCBEF /* AdViewUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9D7F2622E8A83D006FCBEF /* AdViewUtilsTests.swift */; };
 		FAA29904242D1C27002ACBF2 /* TargetingObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAA29903242D1C27002ACBF2 /* TargetingObjCTests.m */; };
@@ -804,7 +807,6 @@
 		FAA299102434C141002ACBF2 /* AdViewUtilsObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAA2990F2434C141002ACBF2 /* AdViewUtilsObjCTests.m */; };
 		FAA299122434C769002ACBF2 /* UtilsObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = FAA299112434C769002ACBF2 /* UtilsObjCTests.m */; };
 		FAC837D82321583500565051 /* CollectionExtensionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC837D72321583500565051 /* CollectionExtensionTest.swift */; };
-		FA12590120260425000000A1 /* FunctionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA12590120260425000000A2 /* FunctionsTests.swift */; };
 		FAEE4D08262DC2B200AD9966 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE4CDD262DC2B200AD9966 /* Constants.swift */; };
 		FAEE4D0A262DC2B200AD9966 /* Global.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE4CDF262DC2B200AD9966 /* Global.swift */; };
 		FAEE4D0B262DC2B200AD9966 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEE4CE0262DC2B200AD9966 /* Dispatcher.swift */; };
@@ -1677,8 +1679,11 @@
 		A908694329E05ED500B37479 /* PrebidMobilePluginRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrebidMobilePluginRenderer.swift; sourceTree = "<group>"; };
 		A908694529E05F7900B37479 /* PrebidRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrebidRenderer.swift; sourceTree = "<group>"; };
 		E557D4B62ED219CB00E5580A /* UserAgentPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentPersistence.swift; sourceTree = "<group>"; };
+		E5D79CAD2FAE93BF00C0C44A /* PluginRendererFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginRendererFactory.swift; sourceTree = "<group>"; };
+		E5D79CAF2FAE951C00C0C44A /* PluginRendererFactoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginRendererFactoryTest.swift; sourceTree = "<group>"; };
 		E5D88C012F4517FA00E801C3 /* ViewExposureCheckerSystemUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExposureCheckerSystemUITests.swift; sourceTree = "<group>"; };
 		F9F0999C2C78CC8A007DB464 /* SDKConsoleLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SDKConsoleLogger.swift; sourceTree = "<group>"; };
+		FA12590120260425000000A2 /* FunctionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionsTests.swift; sourceTree = "<group>"; };
 		FA4A88432497A99D00FDCBB6 /* Swizzling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swizzling.swift; sourceTree = "<group>"; };
 		FA5AD5E32271FA4100C8F274 /* ConstantsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantsTest.swift; sourceTree = "<group>"; };
 		FA85F9B4264946FC00B8BE72 /* TestUtils.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = TestUtils.xcodeproj; path = ../tools/TestUtils/TestUtils.xcodeproj; sourceTree = "<group>"; };
@@ -1692,7 +1697,6 @@
 		FAA299112434C769002ACBF2 /* UtilsObjCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UtilsObjCTests.m; sourceTree = "<group>"; };
 		FAAA00BD2322733E009DC7D6 /* PrebidMobile.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PrebidMobile.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FAC837D72321583500565051 /* CollectionExtensionTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionExtensionTest.swift; sourceTree = "<group>"; };
-		FA12590120260425000000A2 /* FunctionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FunctionsTests.swift; sourceTree = "<group>"; };
 		FAEE4CDD262DC2B200AD9966 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		FAEE4CDF262DC2B200AD9966 /* Global.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Global.swift; sourceTree = "<group>"; };
 		FAEE4CE0262DC2B200AD9966 /* Dispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatcher.swift; sourceTree = "<group>"; };
@@ -3260,6 +3264,7 @@
 				53514CC52D01B5AF00A480C0 /* InterstitialRenderingAdUnitTest.swift */,
 				53514CC72D01B5F200A480C0 /* RewardedAdUnitTest.swift */,
 				533135C5282A869800AA1E4D /* BidTest.swift */,
+				E5D79CAF2FAE951C00C0C44A /* PluginRendererFactoryTest.swift */,
 			);
 			path = Prebid;
 			sourceTree = "<group>";
@@ -3449,6 +3454,7 @@
 				A908694129E05EAF00B37479 /* PrebidMobilePluginRegister.swift */,
 				A908694329E05ED500B37479 /* PrebidMobilePluginRenderer.swift */,
 				53BFCD302CFE435D00A3287A /* PrebidMobilePluginRenderer+Extensions.swift */,
+				E5D79CAD2FAE93BF00C0C44A /* PluginRendererFactory.swift */,
 			);
 			path = PluginRenderer;
 			sourceTree = "<group>";
@@ -3942,6 +3948,7 @@
 				922AFD2B2737258200732C53 /* PBMCreativeViewabilityTrackerTest.swift in Sources */,
 				922AFCF927370B9800732C53 /* LogObjCTest.m in Sources */,
 				9720387C2358771600F8025A /* NativeRequestTests.swift in Sources */,
+				E5D79CB02FAE951C00C0C44A /* PluginRendererFactoryTest.swift in Sources */,
 				922AFD372737281D00732C53 /* PBMHTMLCreativeTest_Base.swift in Sources */,
 				925D5E462737F0ED00A8A2B5 /* TestPBMFunctions.swift in Sources */,
 				922AFC9727352DDB00732C53 /* MockPBMAdModelEventTracker.swift in Sources */,
@@ -4547,6 +4554,7 @@
 				92C3A83827F98B9700DC05E9 /* AdConfiguration.swift in Sources */,
 				53842BB829E561750069A4B7 /* PrebidImagesRepository.swift in Sources */,
 				53BFCD312CFE435D00A3287A /* PrebidMobilePluginRenderer+Extensions.swift in Sources */,
+				E5D79CAE2FAE93BF00C0C44A /* PluginRendererFactory.swift in Sources */,
 				53BFCD112CF9156000A3287A /* PrebidMobileInterstitialControllerProtocol.swift in Sources */,
 				92C85D5A27A96AC50080BAC5 /* NativeTitle.swift in Sources */,
 				5A8448022DB7117400446F70 /* CreativeModel.swift in Sources */,

--- a/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PluginRendererFactory.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PluginRendererFactory.swift
@@ -40,7 +40,7 @@ public class PluginRendererFactory: NSObject {
         adConfiguration: AdUnitConfig,
         loadingDelegate: DisplayViewLoadingDelegate,
         interactionDelegate: DisplayViewInteractionDelegate
-    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+    ) -> PrebidMobileDisplayViewProtocol? {
         let renderer = PrebidMobilePluginRegister.shared.getPluginForPreferredRenderer(bid: bid)
         Log.info("PluginRendererFactory banner renderer: \(renderer.name)")
 
@@ -74,22 +74,6 @@ public class PluginRendererFactory: NSObject {
     ///   - interactionDelegate: Delegate for interstitial interaction events.
     /// - Returns: An interstitial controller conforming to `PrebidMobileInterstitialControllerProtocol`, or `nil` on failure.
     public static func createInterstitialController(
-        bid: Bid,
-        adConfiguration: AdUnitConfig,
-        loadingDelegate: InterstitialControllerLoadingDelegate,
-        interactionDelegate: InterstitialControllerInteractionDelegate
-    ) -> PrebidMobileInterstitialControllerProtocol? {
-        return resolveInterstitialController(
-            bid: bid,
-            adConfiguration: adConfiguration,
-            loadingDelegate: loadingDelegate,
-            interactionDelegate: interactionDelegate
-        )
-    }
-
-    // MARK: - Private
-
-    private static func resolveInterstitialController(
         bid: Bid,
         adConfiguration: AdUnitConfig,
         loadingDelegate: InterstitialControllerLoadingDelegate,

--- a/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PluginRendererFactory.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PluginRendererFactory.swift
@@ -1,0 +1,119 @@
+/*   Copyright 2018-2025 Prebid.org, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
+import UIKit
+
+/// A factory that resolves the appropriate plugin renderer for a given bid
+/// and creates banner views or interstitial controllers through it.
+///
+/// Callers should prepare the `AdUnitConfig` before invoking this factory. The
+/// factory only handles renderer resolution and SDK-renderer fallback, so
+/// caller-owned configuration such as banner size, interstitial flags, rewarded
+/// flags, video controls, and video parameters is preserved.
+@objcMembers
+public class PluginRendererFactory: NSObject {
+
+    /// Creates a banner view using a caller-prepared ad unit configuration.
+    ///
+    /// - Parameters:
+    ///   - frame: The frame for the banner view.
+    ///   - bid: The bid containing renderer preference metadata.
+    ///   - adConfiguration: Prepared ad unit configuration.
+    ///   - loadingDelegate: Delegate for ad loading events.
+    ///   - interactionDelegate: Delegate for ad interaction events.
+    /// - Returns: A banner view conforming to `PrebidMobileDisplayViewProtocol`, or `nil` on failure.
+    public static func createBannerView(
+        with frame: CGRect,
+        bid: Bid,
+        adConfiguration: AdUnitConfig,
+        loadingDelegate: DisplayViewLoadingDelegate,
+        interactionDelegate: DisplayViewInteractionDelegate
+    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+        let renderer = PrebidMobilePluginRegister.shared.getPluginForPreferredRenderer(bid: bid)
+        Log.info("PluginRendererFactory banner renderer: \(renderer.name)")
+
+        if let view = renderer.createBannerView(
+            with: frame,
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        ) {
+            return view
+        }
+
+        Log.warn("Preferred renderer returned nil for banner. Falling back to SDK default renderer.")
+        let fallbackRenderer = PrebidMobilePluginRegister.shared.sdkRenderer
+        return fallbackRenderer.createBannerView(
+            with: frame,
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+    }
+
+    /// Creates an interstitial controller using a caller-prepared ad unit configuration.
+    ///
+    /// - Parameters:
+    ///   - bid: The bid containing renderer preference metadata.
+    ///   - adConfiguration: Prepared ad unit configuration.
+    ///   - loadingDelegate: Delegate for interstitial loading events.
+    ///   - interactionDelegate: Delegate for interstitial interaction events.
+    /// - Returns: An interstitial controller conforming to `PrebidMobileInterstitialControllerProtocol`, or `nil` on failure.
+    public static func createInterstitialController(
+        bid: Bid,
+        adConfiguration: AdUnitConfig,
+        loadingDelegate: InterstitialControllerLoadingDelegate,
+        interactionDelegate: InterstitialControllerInteractionDelegate
+    ) -> PrebidMobileInterstitialControllerProtocol? {
+        return resolveInterstitialController(
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+    }
+
+    // MARK: - Private
+
+    private static func resolveInterstitialController(
+        bid: Bid,
+        adConfiguration: AdUnitConfig,
+        loadingDelegate: InterstitialControllerLoadingDelegate,
+        interactionDelegate: InterstitialControllerInteractionDelegate
+    ) -> PrebidMobileInterstitialControllerProtocol? {
+        let renderer = PrebidMobilePluginRegister.shared.getPluginForPreferredRenderer(bid: bid)
+        Log.info("PluginRendererFactory interstitial renderer: \(renderer.name)")
+
+        if let controller = renderer.createInterstitialController(
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        ) {
+            return controller
+        }
+
+        Log.warn("Preferred renderer returned nil for interstitial. Falling back to SDK default renderer.")
+        let fallbackRenderer = PrebidMobilePluginRegister.shared.sdkRenderer
+        return fallbackRenderer.createInterstitialController(
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+    }
+}

--- a/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PrebidMobilePluginRenderer.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/PluginRenderer/PrebidMobilePluginRenderer.swift
@@ -57,7 +57,7 @@ public protocol PrebidMobilePluginRenderer: AnyObject {
         adConfiguration: AdUnitConfig,
         loadingDelegate: DisplayViewLoadingDelegate,
         interactionDelegate: DisplayViewInteractionDelegate
-    ) -> (UIView & PrebidMobileDisplayViewProtocol)?
+    ) -> PrebidMobileDisplayViewProtocol?
     
     /// Creates and returns an implementation of `PrebidMobileInterstitialControllerProtocol` for a given bid response.
     /// Returns nil in the case of an internal error or if no renderer is provided.

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/BannerAdLoader.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/BannerAdLoader.swift
@@ -97,7 +97,7 @@ class BannerAdLoader: NSObject, AdLoaderProtocol, DisplayViewLoadingDelegate, Ba
 
     // MARK: - Private
 
-    private func createBannerView(with bid: Bid, adUnitConfig: AdUnitConfig) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+    private func createBannerView(with bid: Bid, adUnitConfig: AdUnitConfig) -> PrebidMobileDisplayViewProtocol? {
         guard let delegate else { return nil }
 
         let displayFrame = CGRect(origin: .zero, size: bid.size)

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/BannerAdLoader.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/BannerAdLoader.swift
@@ -99,27 +99,14 @@ class BannerAdLoader: NSObject, AdLoaderProtocol, DisplayViewLoadingDelegate, Ba
 
     private func createBannerView(with bid: Bid, adUnitConfig: AdUnitConfig) -> (UIView & PrebidMobileDisplayViewProtocol)? {
         guard let delegate else { return nil }
-        
-        
-        let renderer = PrebidMobilePluginRegister.shared.getPluginForPreferredRenderer(bid: bid)
-        Log.info("Renderer: \(String(describing: renderer))")
 
         let displayFrame = CGRect(origin: .zero, size: bid.size)
-
-        if let view = renderer.createBannerView(with: displayFrame,
-                                                bid: bid,
-                                                adConfiguration: adUnitConfig,
-                                                loadingDelegate: self,
-                                                interactionDelegate: delegate) {
-            return view
-        }
-
-        Log.warn("SDK couldn't retrieve an implementation of PrebidMobileDisplayViewManagerProtocol. Using fallback renderer.")
-        let fallbackRenderer = PrebidMobilePluginRegister.shared.sdkRenderer
-        return fallbackRenderer.createBannerView(with: displayFrame,
-                                                 bid: bid,
-                                                 adConfiguration: adUnitConfig,
-                                                 loadingDelegate: self,
-                                                 interactionDelegate: delegate)
+        return PluginRendererFactory.createBannerView(
+            with: displayFrame,
+            bid: bid,
+            adConfiguration: adUnitConfig,
+            loadingDelegate: self,
+            interactionDelegate: delegate
+        )
     }
 }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/InterstitialAdLoader.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/AdLoading/InterstitialAdLoader.swift
@@ -102,22 +102,11 @@ final class InterstitialAdLoader: NSObject, AdLoaderProtocol, InterstitialContro
     private func createController(with bid: Bid, adUnitConfig: AdUnitConfig) -> PrebidMobileInterstitialControllerProtocol? {
         guard let delegate else { return nil }
 
-        let renderer = PrebidMobilePluginRegister.shared.getPluginForPreferredRenderer(bid: bid)
-        Log.info("Renderer: \(renderer)")
-        
-        if let controller = renderer.createInterstitialController(bid: bid,
-                                                                  adConfiguration: adUnitConfig,
-                                                                  loadingDelegate: self,
-                                                                  interactionDelegate: delegate) {
-            return controller
-        }
-                
-        Log.warn("SDK couldn't retrieve an implementation of PrebidMobileInterstitialControllerProtocol. SDK will use the PrebidMobile SDK renderer.")
-        
-        let sdkRenderer = PrebidMobilePluginRegister.shared.sdkRenderer
-        return sdkRenderer.createInterstitialController(bid: bid,
-                                                        adConfiguration: adUnitConfig,
-                                                        loadingDelegate: self,
-                                                        interactionDelegate: delegate)
+        return PluginRendererFactory.createInterstitialController(
+            bid: bid,
+            adConfiguration: adUnitConfig,
+            loadingDelegate: self,
+            interactionDelegate: delegate
+        )
     }
 }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCacheRenderers/PrebidMobileDisplayViewProtocol.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCacheRenderers/PrebidMobileDisplayViewProtocol.swift
@@ -13,10 +13,10 @@
 // limitations under the License.
 //
     
-import Foundation
+import UIKit
 
 /// This protocol is used to load and display the ad content in a view.
-@objc public protocol PrebidMobileDisplayViewProtocol {
+@objc public protocol PrebidMobileDisplayViewProtocol where Self: UIView {
     
     /// Loads the ad content into the display view.
     /// - Important: This method is expected to call the `loadingDelegate` once the

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCacheRenderers/PrebidRenderer.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCacheRenderers/PrebidRenderer.swift
@@ -29,7 +29,7 @@ public class PrebidRenderer: NSObject, PrebidMobilePluginRenderer {
         adConfiguration: AdUnitConfig,
         loadingDelegate: DisplayViewLoadingDelegate,
         interactionDelegate: DisplayViewInteractionDelegate
-    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+    ) -> PrebidMobileDisplayViewProtocol? {
         let displayView = DisplayView(
             frame: frame,
             bid: bid,

--- a/PrebidMobileTests/RenderingTests/Mocks/MockPrebidMobilePluginRenderer.swift
+++ b/PrebidMobileTests/RenderingTests/Mocks/MockPrebidMobilePluginRenderer.swift
@@ -40,7 +40,7 @@ class MockPrebidMobilePluginRenderer: PrebidMobilePluginRenderer {
         adConfiguration: AdUnitConfig,
         loadingDelegate: any DisplayViewLoadingDelegate,
         interactionDelegate: any DisplayViewInteractionDelegate
-    ) -> (any UIView & PrebidMobileDisplayViewProtocol)? {
+    ) -> PrebidMobileDisplayViewProtocol? {
         return nil
     }
     

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/PluginRendererFactoryTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/PluginRendererFactoryTest.swift
@@ -439,7 +439,7 @@ extension PluginRendererFactoryTest {
         configId: String,
         loadingDelegate: DisplayViewLoadingDelegate,
         interactionDelegate: DisplayViewInteractionDelegate
-    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+    ) -> PrebidMobileDisplayViewProtocol? {
         let adConfiguration = AdUnitConfig(configId: configId, size: bid.size)
         return createBannerView(
             with: frame,
@@ -456,7 +456,7 @@ extension PluginRendererFactoryTest {
         adConfiguration: AdUnitConfig,
         loadingDelegate: DisplayViewLoadingDelegate,
         interactionDelegate: DisplayViewInteractionDelegate
-    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+    ) -> PrebidMobileDisplayViewProtocol? {
         PluginRendererFactory.createBannerView(
             with: frame,
             bid: bid,
@@ -543,7 +543,7 @@ class MockTrackingPluginRenderer: NSObject, PrebidMobilePluginRenderer {
     var createBannerViewCalled = false
     var createInterstitialControllerCalled = false
 
-    var bannerViewToReturn: (UIView & PrebidMobileDisplayViewProtocol)?
+    var bannerViewToReturn: PrebidMobileDisplayViewProtocol?
     var interstitialControllerToReturn: PrebidMobileInterstitialControllerProtocol?
 
     var lastBannerBid: Bid?
@@ -562,7 +562,7 @@ class MockTrackingPluginRenderer: NSObject, PrebidMobilePluginRenderer {
         adConfiguration: AdUnitConfig,
         loadingDelegate: DisplayViewLoadingDelegate,
         interactionDelegate: DisplayViewInteractionDelegate
-    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+    ) -> PrebidMobileDisplayViewProtocol? {
         createBannerViewCalled = true
         lastBannerBid = bid
         lastBannerAdConfiguration = adConfiguration

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/PluginRendererFactoryTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/PluginRendererFactoryTest.swift
@@ -1,0 +1,638 @@
+/*   Copyright 2018-2025 Prebid.org, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
+import XCTest
+@testable import PrebidMobile
+
+// MARK: - Tests
+
+class PluginRendererFactoryTest: XCTestCase {
+
+    let pluginRegister = PrebidMobilePluginRegister.shared
+
+    let loadingDelegate = StubDisplayViewLoadingDelegate()
+    let interactionDelegate = StubDisplayViewInteractionDelegate()
+    let interstitialLoadingDelegate = StubInterstitialLoadingDelegate()
+    let interstitialInteractionDelegate = StubInterstitialInteractionDelegate()
+
+    override func setUp() {
+        super.setUp()
+        pluginRegister.unregisterAllPlugins()
+    }
+
+    override func tearDown() {
+        pluginRegister.unregisterAllPlugins()
+        super.tearDown()
+    }
+
+    // MARK: - Banner Tests
+
+    func testCreateBannerView_WithDefaultRenderer_ReturnsDisplayView() {
+        // No custom renderer registered — should use PrebidRenderer (SDK default)
+        let bid = makeBid()
+        let frame = CGRect(origin: .zero, size: bid.size)
+
+        let view = createBannerView(
+            with: frame,
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+
+        XCTAssertNotNil(view)
+        XCTAssertTrue(view is DisplayView)
+    }
+
+    func testCreateBannerView_WithCustomRenderer_UsesCustomRenderer() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockView = MockDisplayView()
+        mockRenderer.bannerViewToReturn = mockView
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+        let frame = CGRect(origin: .zero, size: bid.size)
+
+        let view = createBannerView(
+            with: frame,
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.createBannerViewCalled)
+        XCTAssertTrue(view === mockView)
+    }
+
+    func testCreateBannerView_CustomRendererReturnsNil_FallsBackToSDKRenderer() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        mockRenderer.bannerViewToReturn = nil  // returns nil
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+        let frame = CGRect(origin: .zero, size: bid.size)
+
+        let view = createBannerView(
+            with: frame,
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.createBannerViewCalled)
+        // Should fall back to SDK renderer (DisplayView)
+        XCTAssertNotNil(view)
+        XCTAssertTrue(view is DisplayView)
+    }
+
+    func testCreateBannerView_RendererVersionMismatch_FallsBackToSDKRenderer() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockView = MockDisplayView()
+        mockRenderer.bannerViewToReturn = mockView
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        // Bid requests version "3.0" but registered renderer is "2.0"
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "3.0")
+        let frame = CGRect(origin: .zero, size: bid.size)
+
+        let view = createBannerView(
+            with: frame,
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+
+        // Version mismatch means PrebidMobilePluginRegister returns sdkRenderer
+        XCTAssertFalse(mockRenderer.createBannerViewCalled)
+        XCTAssertNotNil(view)
+        XCTAssertTrue(view is DisplayView)
+    }
+
+    func testCreateBannerView_PassesCorrectAdConfiguration() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockView = MockDisplayView()
+        mockRenderer.bannerViewToReturn = mockView
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0", width: 728, height: 90)
+        let frame = CGRect(origin: .zero, size: bid.size)
+
+        let _ = createBannerView(
+            with: frame,
+            bid: bid,
+            configId: "my-config-id",
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+
+        XCTAssertEqual(mockRenderer.lastBannerAdConfiguration?.configId, "my-config-id")
+    }
+
+    func testCreateBannerView_WithPreparedAdConfiguration_PassesSameConfiguration() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockView = MockDisplayView()
+        mockRenderer.bannerViewToReturn = mockView
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0", width: 300, height: 250)
+        let frame = CGRect(origin: .zero, size: bid.size)
+        let preparedSize = CGSize(width: 1, height: 1)
+        let adConfiguration = AdUnitConfig(configId: "prepared-config", size: preparedSize)
+
+        let _ = createBannerView(
+            with: frame,
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.lastBannerAdConfiguration === adConfiguration)
+        XCTAssertEqual(mockRenderer.lastBannerAdConfiguration?.configId, "prepared-config")
+        XCTAssertEqual(mockRenderer.lastBannerAdConfiguration?.adConfiguration.size, preparedSize)
+    }
+
+    // MARK: - Interstitial Tests
+
+    func testCreateInterstitialController_WithDefaultRenderer_ReturnsInterstitialController() {
+        let bid = makeBid()
+
+        let controller = createInterstitialController(
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertNotNil(controller)
+        XCTAssertTrue(controller is InterstitialController)
+    }
+
+    func testCreateInterstitialController_WithCustomRenderer_UsesCustomRenderer() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockController = MockInterstitialController()
+        mockRenderer.interstitialControllerToReturn = mockController
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+
+        let controller = createInterstitialController(
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.createInterstitialControllerCalled)
+        XCTAssertTrue(controller === mockController)
+    }
+
+    func testCreateInterstitialController_CustomRendererReturnsNil_FallsBackToSDKRenderer() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        mockRenderer.interstitialControllerToReturn = nil
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+
+        let controller = createInterstitialController(
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.createInterstitialControllerCalled)
+        XCTAssertNotNil(controller)
+        XCTAssertTrue(controller is InterstitialController)
+    }
+
+    func testCreateInterstitialController_SetsIsInterstitialAd() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockController = MockInterstitialController()
+        mockRenderer.interstitialControllerToReturn = mockController
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+
+        let _ = createInterstitialController(
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.lastInterstitialAdConfiguration?.adConfiguration.isInterstitialAd == true)
+    }
+
+    func testCreateInterstitialController_WithPreparedAdConfiguration_PassesSameConfiguration() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockController = MockInterstitialController()
+        mockRenderer.interstitialControllerToReturn = mockController
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+        let adConfiguration = AdUnitConfig(configId: "prepared-config")
+        adConfiguration.adConfiguration.isInterstitialAd = true
+        adConfiguration.adConfiguration.isRewarded = true
+        adConfiguration.adFormats = [.video]
+
+        let _ = createInterstitialController(
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.lastInterstitialAdConfiguration === adConfiguration)
+        XCTAssertTrue(mockRenderer.lastInterstitialAdConfiguration?.adConfiguration.isInterstitialAd == true)
+        XCTAssertTrue(mockRenderer.lastInterstitialAdConfiguration?.adConfiguration.isRewarded == true)
+        XCTAssertEqual(mockRenderer.lastInterstitialAdConfiguration?.adFormats, [.video])
+    }
+
+    func testCreateInterstitialController_WithPreparedAdConfiguration_DoesNotOverrideInterstitialFlag() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockController = MockInterstitialController()
+        mockRenderer.interstitialControllerToReturn = mockController
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+        let adConfiguration = AdUnitConfig(configId: "prepared-config")
+        adConfiguration.adConfiguration.isInterstitialAd = false
+
+        let _ = createInterstitialController(
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.lastInterstitialAdConfiguration === adConfiguration)
+        XCTAssertFalse(mockRenderer.lastInterstitialAdConfiguration?.adConfiguration.isInterstitialAd == true)
+    }
+
+    // MARK: - Extended Interstitial Tests (Video/Rewarded)
+
+    func testCreateInterstitialController_WithRewardedFlag_SetsIsRewarded() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockController = MockInterstitialController()
+        mockRenderer.interstitialControllerToReturn = mockController
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+
+        let _ = createInterstitialController(
+            bid: bid,
+            configId: "test-config",
+            isRewarded: true,
+            adFormats: nil,
+            videoControlsConfig: nil,
+            videoParameters: nil,
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertTrue(mockRenderer.lastInterstitialAdConfiguration?.adConfiguration.isRewarded == true)
+    }
+
+    func testCreateInterstitialController_WithVideoAdFormats_SetsAdFormats() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockController = MockInterstitialController()
+        mockRenderer.interstitialControllerToReturn = mockController
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+
+        let _ = createInterstitialController(
+            bid: bid,
+            configId: "test-config",
+            isRewarded: false,
+            adFormats: [.video],
+            videoControlsConfig: nil,
+            videoParameters: nil,
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertEqual(mockRenderer.lastInterstitialAdConfiguration?.adFormats, [.video])
+    }
+
+    func testCreateInterstitialController_WithVideoParameters_SetsVideoParameters() {
+        let mockRenderer = MockTrackingPluginRenderer(name: "CustomRenderer", version: "2.0")
+        let mockController = MockInterstitialController()
+        mockRenderer.interstitialControllerToReturn = mockController
+
+        pluginRegister.registerPlugin(mockRenderer)
+
+        let bid = makeBid(rendererName: "CustomRenderer", rendererVersion: "2.0")
+        let videoParams = VideoParameters(mimes: ["video/mp4"])
+
+        let _ = createInterstitialController(
+            bid: bid,
+            configId: "test-config",
+            isRewarded: false,
+            adFormats: nil,
+            videoControlsConfig: nil,
+            videoParameters: videoParams,
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertEqual(
+            mockRenderer.lastInterstitialAdConfiguration?.adConfiguration.videoParameters.mimes,
+            ["video/mp4"]
+        )
+    }
+
+    func testCreateBannerView_NoRendererPreference_UsesPrebidRenderer() {
+        // Bid has no renderer metadata — should use default PrebidRenderer
+        let bid = makeBid()
+        let frame = CGRect(origin: .zero, size: bid.size)
+
+        let view = createBannerView(
+            with: frame,
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+
+        XCTAssertNotNil(view)
+        XCTAssertTrue(view is DisplayView)
+    }
+
+    func testCreateInterstitialController_NoRendererPreference_UsesPrebidRenderer() {
+        let bid = makeBid()
+
+        let controller = createInterstitialController(
+            bid: bid,
+            configId: "test-config",
+            loadingDelegate: interstitialLoadingDelegate,
+            interactionDelegate: interstitialInteractionDelegate
+        )
+
+        XCTAssertNotNil(controller)
+        XCTAssertTrue(controller is InterstitialController)
+    }
+}
+
+// MARK: - Helpers
+
+extension PluginRendererFactoryTest {
+
+    func makeBid(
+        rendererName: String? = nil,
+        rendererVersion: String? = nil,
+        width: Int = 320,
+        height: Int = 50
+    ) -> Bid {
+        let rawBid = ORTBBid<ORTBBidExt>(bidID: "test", impid: "imp1", price: 1.5)
+        rawBid.w = NSNumber(value: width)
+        rawBid.h = NSNumber(value: height)
+        rawBid.ext = .init()
+        rawBid.ext?.prebid = .init()
+        rawBid.ext?.prebid?.targeting = [
+            "hb_pb": "1.50",
+            "hb_bidder": "appnexus",
+            "hb_cache_id": "cache123"
+        ]
+
+        if let rendererName = rendererName, let rendererVersion = rendererVersion {
+            rawBid.ext?.prebid?.meta = [
+                Bid.KEY_RENDERER_NAME: rendererName,
+                Bid.KEY_RENDERER_VERSION: rendererVersion
+            ]
+        }
+
+        return Bid(bid: rawBid)
+    }
+
+    func createBannerView(
+        with frame: CGRect,
+        bid: Bid,
+        configId: String,
+        loadingDelegate: DisplayViewLoadingDelegate,
+        interactionDelegate: DisplayViewInteractionDelegate
+    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+        let adConfiguration = AdUnitConfig(configId: configId, size: bid.size)
+        return createBannerView(
+            with: frame,
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+    }
+
+    func createBannerView(
+        with frame: CGRect,
+        bid: Bid,
+        adConfiguration: AdUnitConfig,
+        loadingDelegate: DisplayViewLoadingDelegate,
+        interactionDelegate: DisplayViewInteractionDelegate
+    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+        PluginRendererFactory.createBannerView(
+            with: frame,
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+    }
+
+    func createInterstitialController(
+        bid: Bid,
+        configId: String,
+        loadingDelegate: InterstitialControllerLoadingDelegate,
+        interactionDelegate: InterstitialControllerInteractionDelegate
+    ) -> PrebidMobileInterstitialControllerProtocol? {
+        createInterstitialController(
+            bid: bid,
+            configId: configId,
+            isRewarded: false,
+            adFormats: nil,
+            videoControlsConfig: nil,
+            videoParameters: nil,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+    }
+
+    func createInterstitialController(
+        bid: Bid,
+        configId: String,
+        isRewarded: Bool,
+        adFormats: Set<AdFormat>?,
+        videoControlsConfig: VideoControlsConfiguration?,
+        videoParameters: VideoParameters?,
+        loadingDelegate: InterstitialControllerLoadingDelegate,
+        interactionDelegate: InterstitialControllerInteractionDelegate
+    ) -> PrebidMobileInterstitialControllerProtocol? {
+        let adConfiguration = AdUnitConfig(configId: configId)
+        adConfiguration.adConfiguration.isInterstitialAd = true
+        adConfiguration.adConfiguration.isRewarded = isRewarded || bid.rewardedConfig != nil
+
+        if let adFormats = adFormats {
+            adConfiguration.adFormats = adFormats
+        }
+
+        if let videoControlsConfig = videoControlsConfig {
+            adConfiguration.adConfiguration.videoControlsConfig = videoControlsConfig
+        }
+
+        if let videoParameters = videoParameters {
+            adConfiguration.adConfiguration.videoParameters = videoParameters
+        }
+
+        return createInterstitialController(
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+    }
+
+    func createInterstitialController(
+        bid: Bid,
+        adConfiguration: AdUnitConfig,
+        loadingDelegate: InterstitialControllerLoadingDelegate,
+        interactionDelegate: InterstitialControllerInteractionDelegate
+    ) -> PrebidMobileInterstitialControllerProtocol? {
+        PluginRendererFactory.createInterstitialController(
+            bid: bid,
+            adConfiguration: adConfiguration,
+            loadingDelegate: loadingDelegate,
+            interactionDelegate: interactionDelegate
+        )
+    }
+}
+
+// MARK: - Mock Renderer That Tracks Calls
+
+class MockTrackingPluginRenderer: NSObject, PrebidMobilePluginRenderer {
+    let name: String
+    let version: String
+    var data: [String: Any]?
+
+    var createBannerViewCalled = false
+    var createInterstitialControllerCalled = false
+
+    var bannerViewToReturn: (UIView & PrebidMobileDisplayViewProtocol)?
+    var interstitialControllerToReturn: PrebidMobileInterstitialControllerProtocol?
+
+    var lastBannerBid: Bid?
+    var lastBannerAdConfiguration: AdUnitConfig?
+    var lastInterstitialBid: Bid?
+    var lastInterstitialAdConfiguration: AdUnitConfig?
+
+    init(name: String, version: String) {
+        self.name = name
+        self.version = version
+    }
+
+    func createBannerView(
+        with frame: CGRect,
+        bid: Bid,
+        adConfiguration: AdUnitConfig,
+        loadingDelegate: DisplayViewLoadingDelegate,
+        interactionDelegate: DisplayViewInteractionDelegate
+    ) -> (UIView & PrebidMobileDisplayViewProtocol)? {
+        createBannerViewCalled = true
+        lastBannerBid = bid
+        lastBannerAdConfiguration = adConfiguration
+        return bannerViewToReturn
+    }
+
+    func createInterstitialController(
+        bid: Bid,
+        adConfiguration: AdUnitConfig,
+        loadingDelegate: InterstitialControllerLoadingDelegate,
+        interactionDelegate: InterstitialControllerInteractionDelegate
+    ) -> PrebidMobileInterstitialControllerProtocol? {
+        createInterstitialControllerCalled = true
+        lastInterstitialBid = bid
+        lastInterstitialAdConfiguration = adConfiguration
+        return interstitialControllerToReturn
+    }
+}
+
+// MARK: - Mock Display View
+
+class MockDisplayView: UIView, PrebidMobileDisplayViewProtocol {
+    var loadAdCalled = false
+
+    func loadAd() {
+        loadAdCalled = true
+    }
+}
+
+// MARK: - Mock Interstitial Controller
+
+class MockInterstitialController: NSObject, PrebidMobileInterstitialControllerProtocol {
+    var loadAdCalled = false
+    var showCalled = false
+
+    func loadAd() {
+        loadAdCalled = true
+    }
+
+    func show() {
+        showCalled = true
+    }
+}
+
+// MARK: - Stub Delegates
+
+class StubDisplayViewLoadingDelegate: NSObject, DisplayViewLoadingDelegate {
+    func displayViewDidLoadAd(_ displayView: UIView) {}
+    func displayView(_ displayView: UIView, didFailWithError error: Error) {}
+}
+
+class StubDisplayViewInteractionDelegate: NSObject, DisplayViewInteractionDelegate {
+    func trackImpression(forDisplayView: UIView) {}
+    func viewControllerForModalPresentation(fromDisplayView: UIView) -> UIViewController? { nil }
+    func didLeaveApp(from displayView: UIView) {}
+    func willPresentModal(from displayView: UIView) {}
+    func didDismissModal(from displayView: UIView) {}
+}
+
+class StubInterstitialLoadingDelegate: NSObject, InterstitialControllerLoadingDelegate {
+    func interstitialControllerDidLoadAd(_ interstitialController: PrebidMobileInterstitialControllerProtocol) {}
+    func interstitialController(_ interstitialController: PrebidMobileInterstitialControllerProtocol, didFailWithError error: Error) {}
+}
+
+class StubInterstitialInteractionDelegate: NSObject, InterstitialControllerInteractionDelegate {
+    func trackImpression(forInterstitialController: PrebidMobileInterstitialControllerProtocol) {}
+    func interstitialControllerDidClickAd(_ interstitialController: PrebidMobileInterstitialControllerProtocol) {}
+    func interstitialControllerDidCloseAd(_ interstitialController: PrebidMobileInterstitialControllerProtocol) {}
+    func interstitialControllerDidDisplay(_ interstitialController: PrebidMobileInterstitialControllerProtocol) {}
+    func interstitialControllerDidComplete(_ interstitialController: PrebidMobileInterstitialControllerProtocol) {}
+    func viewControllerForModalPresentation(fromInterstitialController: PrebidMobileInterstitialControllerProtocol) -> UIViewController? { nil }
+    func interstitialControllerDidLeaveApp(_ interstitialController: PrebidMobileInterstitialControllerProtocol) {}
+}


### PR DESCRIPTION
#1071 

- Added `PluginRendererFactory` as the shared renderer-resolution entry point for banner and interstitial rendering.
- Updated GAM loaders and AdMob/MAX adapters to resolve renderers through the plugin renderer registry instead of directly instantiating `DisplayView` / `InterstitialController`.
- Switched adapter-held banner/interstitial references to protocol types so custom third-party renderers can provide their own views/controllers.
- Moved adapter-specific interstitial/rewarded/video configuration into `AdUnitConfig` before renderer creation, so custom renderers receive a fully prepared config.
- Added unit coverage for default renderer usage, custom renderer usage, fallback behavior, rewarded/video config passthrough, and preserving caller-prepared config.