### PR TITLE
Fix load callbacks firing before creative attachment

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMAdViewManager.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMAdViewManager.m
@@ -32,6 +32,8 @@
 @property (nonatomic, nullable, readonly) id<PBMTransaction> currentTransaction; // computed
 @property (nonatomic, assign) BOOL videoInterstitialDidClose;
 
+- (void)displayCreativeView:(UIView *)creativeView rootViewController:(UIViewController *)viewController;
+
 @end
 
 @implementation PBMAdViewManager_Objc
@@ -110,14 +112,17 @@
             return;
         }
         
-        @weakify(self);
-        dispatch_async(dispatch_get_main_queue(), ^{
-            @strongify(self);
-            if (!self) { return; }
-            
-            [[self.adViewManagerDelegate displayView] addSubview:creativeView];
-            [self.currentCreative displayWithRootViewController:viewController];
-        });
+        if (NSThread.isMainThread) {
+            [self displayCreativeView:creativeView rootViewController:viewController];
+        } else {
+            @weakify(self);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                @strongify(self);
+                if (!self) { return; }
+                
+                [self displayCreativeView:creativeView rootViewController:viewController];
+            });
+        }
     }
 }
 
@@ -341,6 +346,11 @@
 }
 
 #pragma mark - Internal Methods
+
+- (void)displayCreativeView:(UIView *)creativeView rootViewController:(UIViewController *)viewController {
+    [[self.adViewManagerDelegate displayView] addSubview:creativeView];
+    [self.currentCreative displayWithRootViewController:viewController];
+}
 
 - (void)onTransactionIsReady:(id<PBMTransaction>)transaction {
     for ( id<PBMAbstractCreative> creative in transaction.creatives) {

--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMAdViewManager.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMAdViewManager.m
@@ -32,8 +32,6 @@
 @property (nonatomic, nullable, readonly) id<PBMTransaction> currentTransaction; // computed
 @property (nonatomic, assign) BOOL videoInterstitialDidClose;
 
-- (void)displayCreativeView:(UIView *)creativeView rootViewController:(UIViewController *)viewController;
-
 @end
 
 @implementation PBMAdViewManager_Objc

--- a/PrebidMobileTests/RenderingTests/Tests/AdViewManagerTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/AdViewManagerTest.swift
@@ -43,6 +43,8 @@ class AdViewManagerTest: XCTestCase, AdViewManagerDelegate {
     var adViewManager:AdViewManager!
     var adLoadManager:PBMAdLoadManagerBase!
     var videoCreative: PBMVideoCreative?
+    var testDisplayView: UIView!
+    var adLoadedHandler: (() -> Void)?
     
     var currentlyDisplaying = false
     var loadError:NSError?
@@ -56,6 +58,8 @@ class AdViewManagerTest: XCTestCase, AdViewManagerDelegate {
         
         adViewManager.adViewManagerDelegate = self
         Prebid.forcedIsViewable = false
+        testDisplayView = UIView()
+        adLoadedHandler = nil
         loadError = nil;
     }
     
@@ -79,6 +83,8 @@ class AdViewManagerTest: XCTestCase, AdViewManagerDelegate {
     override func tearDown() {
         adLoadManager = nil
         adViewManager = nil
+        testDisplayView = nil
+        adLoadedHandler = nil
         logToFile = nil
         
         nilExpectations()
@@ -119,6 +125,29 @@ class AdViewManagerTest: XCTestCase, AdViewManagerDelegate {
         adViewManager.handleExternalTransaction(transaction)
         
         XCTAssertIdentical(adViewManager.externalTransaction, transaction)
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+    
+    func testAdLoadedAfterDisplayViewContainsCreative() {
+        nilExpectations()
+        adLoadedExpectation = expectation(description: "adLoadedExpectation")
+        displayViewExpectation = expectation(description: "displayViewExpectation")
+        adDidDisplayExpectation = expectation(description: "adDidDisplayExpectation")
+        viewControllerForModalPresentationExpectation = expectation(description: "Expected a viewControllerForModalPresentationExpectation delegate to fire")
+        
+        Prebid.forcedIsViewable = true
+        
+        adLoadedHandler = { [weak self] in
+            guard let self else {
+                XCTFail("Expected test instance to be available")
+                return
+            }
+            
+            XCTAssertEqual(self.testDisplayView.subviews.count, 1)
+        }
+        
+        adViewManager.handleExternalTransaction(UtilitiesForTesting.createTransactionWithHTMLCreative(withView: true))
+        
         waitForExpectations(timeout: 3, handler: nil)
     }
     
@@ -356,7 +385,7 @@ class AdViewManagerTest: XCTestCase, AdViewManagerDelegate {
     
     var displayView: UIView {
         fulfillOrFail(displayViewExpectation, "displayViewExpectation")
-        return UIView()
+        return testDisplayView
     }
     
     var interstitialDisplayProperties: InterstitialDisplayProperties {
@@ -365,6 +394,7 @@ class AdViewManagerTest: XCTestCase, AdViewManagerDelegate {
     }
     
     func adLoaded(_ pbmAdDetails: AdDetails) {
+        adLoadedHandler?()
         fulfillOrFail(adLoadedExpectation, "adLoadedExpectation")
     }
     


### PR DESCRIPTION
#1220 

# Summary

Fixed the banner/custom renderer load callback ordering so the load callback is not fired before the creative view is attached.

- Updated `PBMAdViewManager.m` so banner creative insertion runs immediately when already on the main thread. If called off-main, it still dispatches to the main queue. This prevents `adLoaded` / `displayViewDidLoadAd` from firing before the creative view has been added to the display view.
- Added a regression test in `AdViewManagerTest.swift` to verify that the display view already contains the creative when `adLoaded` fires.