### PR TITLE
Resolves crash related to nullable advertisingIdentifier

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/Networking/Parameters/PBMDeviceInfoParameterBuilder.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/Networking/Parameters/PBMDeviceInfoParameterBuilder.m
@@ -86,6 +86,9 @@
     NSNumber *lmt = @(!self.deviceAccessManager.advertisingTrackingEnabled);
     
     NSString *ifa = [Targeting.shared isAllowedAccessDeviceData] ? self.deviceAccessManager.advertisingIdentifier : nil;
+    if (ifa.length == 0) {
+        ifa = nil;
+    }
     
     bidRequest.device.lmt = lmt;
     bidRequest.device.ifa = ifa;

--- a/PrebidMobile/Swift/PrebidMobileRendering/Utilities/DeviceAccessManager.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Utilities/DeviceAccessManager.swift
@@ -82,7 +82,10 @@ public class DeviceAccessManager: NSObject {
     // MARK: - IDFA & Tracking
 
     @objc public func advertisingIdentifier() -> String {
-        ASIdentifierManager.shared().advertisingIdentifier.uuidString
+        let advertisingIdentifier = ASIdentifierManager.shared()
+            .perform(#selector(getter: ASIdentifierManager.advertisingIdentifier))?
+            .takeUnretainedValue() as? NSUUID
+        return advertisingIdentifier?.uuidString ?? ""
     }
 
     @objc public func advertisingTrackingEnabled() -> Bool {

--- a/PrebidMobileTests/RenderingTests/Mocks/MockDeviceAccessManager.swift
+++ b/PrebidMobileTests/RenderingTests/Mocks/MockDeviceAccessManager.swift
@@ -19,13 +19,14 @@ import CoreGraphics
 @testable import PrebidMobile
 
 fileprivate let advertisingTrackingEnabledDefault = true
+fileprivate let advertisingIdentifierDefault = "abc123"
 fileprivate let defaultUserLanguageCode = "ml"
 
 class MockDeviceAccessManager: DeviceAccessManager {
     
     static let nullUUID = "00000000-0000-0000-0000-000000000000"
     static let mockIdentifierForVendor = "B78D99E3-5BD1-49AF-A669-0D77B464C5B9"
-    static let mockAdvertisingIdentifier = "abc123"
+    static var mockAdvertisingIdentifier = advertisingIdentifierDefault
     static var mockAdvertisingTrackingEnabled = advertisingTrackingEnabledDefault
     @available(iOS 14, *)
     static var mockAppTrackingTransparencyStatus = ATTrackingManager.AuthorizationStatus.notDetermined
@@ -84,6 +85,7 @@ class MockDeviceAccessManager: DeviceAccessManager {
     }
     
     class func reset() {
+        self.mockAdvertisingIdentifier = advertisingIdentifierDefault
         self.mockAdvertisingTrackingEnabled = advertisingTrackingEnabledDefault
         self.mockUserLanguageCode = defaultUserLanguageCode
     }

--- a/PrebidMobileTests/RenderingTests/Tests/PBMDeviceAccessManagerTests.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMDeviceAccessManagerTests.swift
@@ -16,6 +16,8 @@
 import Foundation
 import XCTest
 import UIKit
+import AdSupport
+import ObjectiveC
 
 @testable import PrebidMobile
 
@@ -42,6 +44,27 @@ class PBMDeviceAccessManagerTests : XCTestCase {
     func testAdvertisingIdentifier() {
         let adID = deviceAccessManager.advertisingIdentifier()
         XCTAssert(adID.count > 0)
+    }
+    
+    func testAdvertisingIdentifierWhenASIdentifierManagerReturnsNil() {
+        let selector = #selector(getter: ASIdentifierManager.advertisingIdentifier)
+        guard let managerClass = object_getClass(ASIdentifierManager.shared()),
+              let method = class_getInstanceMethod(managerClass, selector) else {
+            XCTFail("Expected ASIdentifierManager to respond to advertisingIdentifier")
+            return
+        }
+        
+        let originalImplementation = method_getImplementation(method)
+        let nilAdvertisingIdentifier: @convention(block) (AnyObject) -> NSUUID? = { _ in nil }
+        let nilImplementation = imp_implementationWithBlock(nilAdvertisingIdentifier)
+        
+        method_setImplementation(method, nilImplementation)
+        defer {
+            method_setImplementation(method, originalImplementation)
+            imp_removeBlock(nilImplementation)
+        }
+        
+        XCTAssertEqual(deviceAccessManager.advertisingIdentifier(), "")
     }
     
     func testAdvertisingTrackingEnabled() {

--- a/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/DeviceInfoParameterBuilderTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/ParameterBuilderTests/DeviceInfoParameterBuilderTest.swift
@@ -76,6 +76,19 @@ class DeviceInfoParameterBuilderTest: XCTestCase {
             PBMAssertEq(self.bidRequest.device.extAtts.atts as? UInt, ATTrackingManager.AuthorizationStatus.notDetermined.rawValue)
         }
     }
+    
+    func testEmptyAdvertisingIdentifier() {
+        MockDeviceAccessManager.mockAdvertisingIdentifier = ""
+        
+        if #available(iOS 14, *) {
+            MockDeviceAccessManager.mockAppTrackingTransparencyStatus = .authorized
+        }
+        
+        self.deviceInfoParameterBuilder.build(self.bidRequest)
+        
+        XCTAssertNil(self.bidRequest.device.ifa)
+        PBMAssertEq(self.bidRequest.device.extAtts.ifv, MockDeviceAccessManager.mockIdentifierForVendor)
+    }
 
     func testDeviceDetails() {
         self.deviceInfoParameterBuilder.build(self.bidRequest)


### PR DESCRIPTION
## Summary

Fixes a crash (`EXC_BREAKPOINT` in `UUID._unconditionallyBridgeFromObjectiveC`) that occurs when `ASIdentifierManager.shared().advertisingIdentifier` returns `nil` at the Objective-C runtime level, despite Apple's header annotating the property as `nonnull`.

Closes #1273.

## Root cause

`-[ASIdentifierManager advertisingIdentifier]` is declared `nonnull` in Apple's headers, so Swift imports it as a non-optional `UUID`. In rare device states (XPC/daemon unavailable, early boot, MDM/Screen Time restrictions, memory pressure) the method returns `nil` anyway. When Swift accesses the property, the compiler-generated bridging thunk calls `UUID._unconditionallyBridgeFromObjectiveC` to force the ObjC `NSUUID?` into a Swift `UUID`, and that call traps on `nil`.

## Why not the fix suggested in the issue

The issue suggests:

    @objc public func advertisingIdentifier() -> String {
        ASIdentifierManager.shared().advertisingIdentifier?.uuidString ?? ""
    }

This doesn't actually fix the crash, and doesn't compile as written:

- Because the property is imported as **non-optional** `UUID` (due to the `nonnull` annotation), `?.` can't be applied to it - Swift will reject optional-chaining on a non-optional type.
- More importantly, the trap doesn't happen at the point of consuming the value - it happens **inside the property access itself**, in the synthesized ObjC→Swift bridging thunk. By the time you could apply `??`, the crash has already occurred. Wrapping the *result* in optional-handling can't help if the *access* is what crashes.

In short: this is a case of an API lying about its nullability, and the fix has to happen below the level where Swift's automatic bridging kicks in - not after it.

## Fix implemented

`DeviceAccessManager.advertisingIdentifier()` now bypasses the synthesized property getter entirely and invokes the underlying ObjC selector manually via `NSObject.perform(_:)`:

    @objc public func advertisingIdentifier() -> String {
        let advertisingIdentifier = ASIdentifierManager.shared()
            .perform(#selector(getter: ASIdentifierManager.advertisingIdentifier))?
            .takeUnretainedValue() as? NSUUID
        return advertisingIdentifier?.uuidString ?? ""
    }

`perform(_:)` sends the message directly (effectively `objc_msgSend`) and returns `Unmanaged<AnyObject>?`, without going through the compiler's `nonnull`-enforcing bridge. This lets a genuine `nil` return value surface safely as `Unmanaged<AnyObject>?.none`, which we then optionally cast to `NSUUID` and unwrap with `??`. No trap is possible regardless of what the underlying daemon returns.

### Secondary fix: empty `ifa` no longer blocks the `ifv` fallback

`PBMDeviceInfoParameterBuilder.buildBidRequest:` treats an empty-string `ifa` the same as `nil`:

    NSString *ifa = [Targeting.shared isAllowedAccessDeviceData] ? self.deviceAccessManager.advertisingIdentifier : nil;
    if (ifa.length == 0) {
        ifa = nil;
    }

Previously, an empty (but non-nil) `ifa` would fail the `!ifa` check used to decide whether to fall back to `device.extAtts.ifv` (identifierForVendor), so a bid request could go out with neither a usable `ifa` nor an `ifv`. Now an empty identifier is normalized to `nil`, so the existing `ifv` fallback logic engages correctly.