### PR TITLE
Bid selector for winner override

### DIFF
--- a/PrebidMobile.xcodeproj/project.pbxproj
+++ b/PrebidMobile.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		38F03B332576624C00E026A2 /* TrackerManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F03B322576624C00E026A2 /* TrackerManagerTests.swift */; };
 		3CD0ADEE2C5125E9006CDA6B /* PluginRegisterTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD0ADED2C5125E9006CDA6B /* PluginRegisterTest.swift */; };
 		3CD0ADF32C512E5E006CDA6B /* RawSampleCustomRendererBidFabricator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD0ADF22C512E5E006CDA6B /* RawSampleCustomRendererBidFabricator.swift */; };
+		41FFEFA489529CEC008320F1 /* BidSelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A0ED7484461E30C1311DB3 /* BidSelectorTests.swift */; };
 		47D9A008EA5B9DF894E98CA2 /* ACJRefreshTest_0.json in Resources */ = {isa = PBXBuildFile; fileRef = 47D9AF9402144C399D6D4A1C /* ACJRefreshTest_0.json */; };
 		47D9A16ECCE6B2FB6D603053 /* MockCTTelephonyNetworkInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D9A0E0865B22D90C20EF00 /* MockCTTelephonyNetworkInfo.swift */; };
 		47D9A173B721CE2B39D98A82 /* MockMeasurementSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D9AA7EC422522283555E44 /* MockMeasurementSession.swift */; };
@@ -91,6 +92,7 @@
 		47D9AFCC0A845432C0CC1CD9 /* vast_om_verification_from_extension.xml in Resources */ = {isa = PBXBuildFile; fileRef = 47D9AEB6F79C7B8EE3EEF00A /* vast_om_verification_from_extension.xml */; };
 		47D9AFD469AA0D5B6CE79D43 /* MockDelayedReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D9AF39FFB17935DB0C57B5 /* MockDelayedReachability.swift */; };
 		47D9AFFB2F592206309C5FF0 /* ACJInterstitial.json in Resources */ = {isa = PBXBuildFile; fileRef = 47D9ADF3B4DA145410B2AFF6 /* ACJInterstitial.json */; };
+		51213290D6662D5F0D45A136 /* PrebidBidSelecting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7443B0E5DD514061AF0D7890 /* PrebidBidSelecting.swift */; };
 		53019E6127E9E40700D509C1 /* LogTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53019E6027E9E40700D509C1 /* LogTest.swift */; };
 		530382F2283197E100B2B111 /* PrebidServerResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530382F1283197E100B2B111 /* PrebidServerResponse.swift */; };
 		53137BD42D563CF400E417CE /* SKOverlayManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53137BD32D563CF400E417CE /* SKOverlayManager.swift */; };
@@ -596,6 +598,7 @@
 		606FAC5222022932008EAE5E /* AdUnitSwizzleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 606FAC5122022932008EAE5E /* AdUnitSwizzleHelper.swift */; };
 		60C0381F2204AF5D0082B32C /* DispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 979177962201AF5F00E624CE /* DispatcherTests.swift */; };
 		60C038242204AF5D0082B32C /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97826AA621FB4F1B001E2C05 /* Constants.swift */; };
+		8FA2462D60835942C37BF7A2 /* MediationNativeAdUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B765F69998410D0170245AAF /* MediationNativeAdUnitTest.swift */; };
 		92028EA627F0D89E00783470 /* NativeAdConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92028EA527F0D89E00783470 /* NativeAdConfiguration.swift */; };
 		920E8D6D28084BF200E6313B /* VideoControlsConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920E8D6C28084BF200E6313B /* VideoControlsConfigTests.swift */; };
 		922AFC8827352B0100732C53 /* MockUserAgentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922AFC8727352B0100732C53 /* MockUserAgentService.swift */; };
@@ -793,6 +796,7 @@
 		A908694229E05EAF00B37479 /* PrebidMobilePluginRegister.swift in Sources */ = {isa = PBXBuildFile; fileRef = A908694129E05EAF00B37479 /* PrebidMobilePluginRegister.swift */; };
 		A908694429E05ED500B37479 /* PrebidMobilePluginRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A908694329E05ED500B37479 /* PrebidMobilePluginRenderer.swift */; };
 		A908694629E05F7900B37479 /* PrebidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A908694529E05F7900B37479 /* PrebidRenderer.swift */; };
+		B5A95CD57D70C1BC05EF449C /* PrebidBidSelectingObjCTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BE3F47A7860BB9B87DFA66F6 /* PrebidBidSelectingObjCTest.m */; };
 		E557D4B72ED219CB00E5580A /* UserAgentPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = E557D4B62ED219CB00E5580A /* UserAgentPersistence.swift */; };
 		E5D79CAE2FAE93BF00C0C44A /* PluginRendererFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D79CAD2FAE93BF00C0C44A /* PluginRendererFactory.swift */; };
 		E5D79CB02FAE951C00C0C44A /* PluginRendererFactoryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D79CAF2FAE951C00C0C44A /* PluginRendererFactoryTest.swift */; };
@@ -912,6 +916,7 @@
 		47D9A230B9C99352DE486DD3 /* document_with_one_wrapper_ad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = document_with_one_wrapper_ad.xml; sourceTree = "<group>"; };
 		47D9A2491192A084AE14E1E9 /* MockNSThread.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNSThread.swift; sourceTree = "<group>"; };
 		47D9A26C7251DF5F35B0CDB5 /* large.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file.mp4; path = large.mp4; sourceTree = "<group>"; };
+		47D9A33C1000000000000002 /* cached_bid_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = cached_bid_response.json; sourceTree = "<group>"; };
 		47D9A356DC60E61416DC1739 /* ACJSingleAdWithoutSDKParams.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ACJSingleAdWithoutSDKParams.json; sourceTree = "<group>"; };
 		47D9A35FC91B425F274DFD8D /* ACJNonChainingAdUnit.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = ACJNonChainingAdUnit.json; sourceTree = "<group>"; };
 		47D9A36B91A82F353CEB1C3B /* small.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file.mp4; path = small.mp4; sourceTree = "<group>"; };
@@ -923,7 +928,6 @@
 		47D9A630F7F8443F29F48813 /* MockAlertController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockAlertController.swift; sourceTree = "<group>"; };
 		47D9A65561D54EB501103D1F /* MockPBMCreativeModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPBMCreativeModel.swift; sourceTree = "<group>"; };
 		47D9A6CCD40A2B6F9BC571F3 /* SSC_test_empty_fields.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = SSC_test_empty_fields.json; sourceTree = "<group>"; };
-		47D9A33C1000000000000002 /* cached_bid_response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = cached_bid_response.json; sourceTree = "<group>"; };
 		47D9A6D9917A568CEDA774F5 /* small.m4v */ = {isa = PBXFileReference; lastKnownFileType = file.m4v; path = small.m4v; sourceTree = "<group>"; };
 		47D9A721F20C97168D2E7349 /* prebid_vast_response.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = prebid_vast_response.xml; sourceTree = "<group>"; };
 		47D9A788E8D0FBF93345D2AD /* document_with_one_inline_ad.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = document_with_one_inline_ad.xml; sourceTree = "<group>"; };
@@ -1461,6 +1465,7 @@
 		60C0382B2204BB190082B32C /* PrebidMobileTest-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PrebidMobileTest-Bridging-Header.h"; sourceTree = "<group>"; };
 		60D792FB217E229B0080F428 /* PrebidMobileTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PrebidMobileTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		60D79302217E229B0080F428 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7443B0E5DD514061AF0D7890 /* PrebidBidSelecting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PrebidBidSelecting.swift; sourceTree = "<group>"; };
 		92028EA527F0D89E00783470 /* NativeAdConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAdConfiguration.swift; sourceTree = "<group>"; };
 		920E8D6C28084BF200E6313B /* VideoControlsConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoControlsConfigTests.swift; sourceTree = "<group>"; };
 		922AFC8727352B0100732C53 /* MockUserAgentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserAgentService.swift; sourceTree = "<group>"; };
@@ -1680,6 +1685,9 @@
 		A908694129E05EAF00B37479 /* PrebidMobilePluginRegister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrebidMobilePluginRegister.swift; sourceTree = "<group>"; };
 		A908694329E05ED500B37479 /* PrebidMobilePluginRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrebidMobilePluginRenderer.swift; sourceTree = "<group>"; };
 		A908694529E05F7900B37479 /* PrebidRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrebidRenderer.swift; sourceTree = "<group>"; };
+		B765F69998410D0170245AAF /* MediationNativeAdUnitTest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MediationNativeAdUnitTest.swift; sourceTree = "<group>"; };
+		BE3F47A7860BB9B87DFA66F6 /* PrebidBidSelectingObjCTest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PrebidBidSelectingObjCTest.m; sourceTree = "<group>"; };
+		C9A0ED7484461E30C1311DB3 /* BidSelectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BidSelectorTests.swift; sourceTree = "<group>"; };
 		E557D4B62ED219CB00E5580A /* UserAgentPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAgentPersistence.swift; sourceTree = "<group>"; };
 		E5D79CAD2FAE93BF00C0C44A /* PluginRendererFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginRendererFactory.swift; sourceTree = "<group>"; };
 		E5D79CAF2FAE951C00C0C44A /* PluginRendererFactoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginRendererFactoryTest.swift; sourceTree = "<group>"; };
@@ -1990,6 +1998,7 @@
 				53CDA4892D11AFD5004766F8 /* MediationRewardedAdUnitTest.swift */,
 				53CDA48A2D11AFD5004766F8 /* MediationUtilsTest.swift */,
 				53CDA48B2D11AFD5004766F8 /* MockMediationUtils.swift */,
+				B765F69998410D0170245AAF /* MediationNativeAdUnitTest.swift */,
 			);
 			path = MediationAPI;
 			sourceTree = "<group>";
@@ -2787,6 +2796,7 @@
 				5A663B572DB30DA6005DF07F /* WinNotifier.swift */,
 				5BC37831271F1CFF00444D5E /* TransactionFactory */,
 				2A9DDDD32C63665A000EA4A0 /* PBMEventDelegateHelper.swift */,
+				7443B0E5DD514061AF0D7890 /* PrebidBidSelecting.swift */,
 			);
 			path = PBMCore;
 			sourceTree = "<group>";
@@ -3268,6 +3278,8 @@
 				53514CC72D01B5F200A480C0 /* RewardedAdUnitTest.swift */,
 				533135C5282A869800AA1E4D /* BidTest.swift */,
 				E5D79CAF2FAE951C00C0C44A /* PluginRendererFactoryTest.swift */,
+				C9A0ED7484461E30C1311DB3 /* BidSelectorTests.swift */,
+				BE3F47A7860BB9B87DFA66F6 /* PrebidBidSelectingObjCTest.m */,
 			);
 			path = Prebid;
 			sourceTree = "<group>";
@@ -4174,6 +4186,9 @@
 				925D5E6E2737F51E00A8A2B5 /* PBMVastLoaderTestWrapperPlusInline.swift in Sources */,
 				922AFCD327353C5700732C53 /* MockServerMimeType.m in Sources */,
 				922AFD292737255700732C53 /* PBMCreativeFactoryTest.swift in Sources */,
+				41FFEFA489529CEC008320F1 /* BidSelectorTests.swift in Sources */,
+				8FA2462D60835942C37BF7A2 /* MediationNativeAdUnitTest.swift in Sources */,
+				B5A95CD57D70C1BC05EF449C /* PrebidBidSelectingObjCTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4574,6 +4589,7 @@
 				5A6167F12DB9E5870018E6B6 /* JSONParsing.swift in Sources */,
 				53E45A0327FCD09C0095C0B2 /* BannerParameters.swift in Sources */,
 				FAEE4D1F262DC2B200AD9966 /* Utils.swift in Sources */,
+				51213290D6662D5F0D45A136 /* PrebidBidSelecting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PrebidMobile/Objc/PrebidMobileRendering/Prebid/PBMCore/PBMBidRequester.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/Prebid/PBMCore/PBMBidRequester.m
@@ -129,6 +129,8 @@
         BidResponse * const _Nullable bidResponse = [PBMBidResponseTransformer transformResponse:serverResponse error:&trasformationError];
         
         if (bidResponse && !trasformationError) {
+            [bidResponse applyBidSelector:self.adUnitConfiguration.bidSelector];
+
             if (self.sdkConfiguration.requireServerSideBidCache) {
                 NSInteger bidCount = bidResponse.allBids.count;
                 NSInteger removedBids = [bidResponse removeBidsWithoutSuccessfulCache];

--- a/PrebidMobile/Swift/AdUnits/AdUnit.swift
+++ b/PrebidMobile/Swift/AdUnits/AdUnit.swift
@@ -232,7 +232,16 @@ public class AdUnit: NSObject, DispatcherDelegate {
     func setUp(_ adObject: AnyObject?, with bidResponse: BidResponse) -> ResultCode {
         
         guard let winningBid = bidResponse.winningBid else {
-            
+
+            // If a publisher-supplied bid selector is active, its decision is final: returning
+            // `nil` means no bid should win, full stop -- it must not fall back to attaching an
+            // arbitrary bid's keywords and reporting success, even when forceSdkToChooseWinner
+            // is false. This only affects the selector-engaged path; behavior for publishers not
+            // using a selector at all (bidSelector == nil) is unchanged below.
+            if bidResponse.bidSelector != nil {
+                return .prebidDemandNoBids
+            }
+
             //When the new behavior is active
             if !Targeting.shared.forceSdkToChooseWinner {
                 

--- a/PrebidMobile/Swift/AdUnits/MultiformatAdUnit/PrebidAdUnit.swift
+++ b/PrebidMobile/Swift/AdUnits/MultiformatAdUnit/PrebidAdUnit.swift
@@ -204,6 +204,7 @@ public class PrebidAdUnit: NSObject {
         
         adUnit.adUnitConfig.adConfiguration.supportSKOverlay = request.supportSKOverlayForInterstitial
         adUnit.adUnitConfig.gpid = request.gpid
+        adUnit.adUnitConfig.bidSelector = request.bidSelector
     }
     
     // For tests, SDK internal

--- a/PrebidMobile/Swift/AdUnits/MultiformatAdUnit/PrebidRequest.swift
+++ b/PrebidMobile/Swift/AdUnits/MultiformatAdUnit/PrebidRequest.swift
@@ -28,7 +28,10 @@ public class PrebidRequest: NSObject {
     
     /// A flag that determines whether SKOverlay should be supported for interstitials
     public var supportSKOverlayForInterstitial: Bool = false
-    
+
+    /// A publisher-supplied strategy for choosing the winning bid. See `PrebidBidSelecting`.
+    public var bidSelector: PrebidBidSelecting?
+
     // MARK: - Internal properties
     
     private(set) var bannerParameters: BannerParameters?

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/BannerView.swift
@@ -76,6 +76,12 @@ public class BannerView:
         set { adUnitConfig.adPosition = newValue }
     }
 
+    /// A publisher-supplied strategy for choosing the winning bid. See `PrebidBidSelecting`.
+    public var bidSelector: PrebidBidSelecting? {
+        get { adUnitConfig.bidSelector }
+        set { adUnitConfig.bidSelector = newValue }
+    }
+
     public weak var delegate: BannerViewDelegate?
     public weak var videoPlaybackDelegate: BannerViewVideoPlaybackDelegate?
     

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
@@ -56,7 +56,13 @@ public class InterstitialRenderingAdUnit: NSObject, BaseInterstitialAdUnitProtoc
         get { adUnitConfig.adConfiguration.supportSKOverlay }
         set { adUnitConfig.adConfiguration.supportSKOverlay = newValue }
     }
-    
+
+    /// A publisher-supplied strategy for choosing the winning bid. See `PrebidBidSelecting`.
+    public var bidSelector: PrebidBidSelecting? {
+        get { adUnitConfig.bidSelector }
+        set { adUnitConfig.bidSelector = newValue }
+    }
+
     // MARK: - Video controls configuration
     
     /// The area of the close button in the video controls as a percentage.

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
@@ -56,7 +56,13 @@ public class RewardedAdUnit: NSObject, BaseInterstitialAdUnitProtocol {
         get { adUnitConfig.adConfiguration.supportSKOverlay }
         set { adUnitConfig.adConfiguration.supportSKOverlay = newValue }
     }
-    
+
+    /// A publisher-supplied strategy for choosing the winning bid. See `PrebidBidSelecting`.
+    public var bidSelector: PrebidBidSelecting? {
+        get { adUnitConfig.bidSelector }
+        set { adUnitConfig.bidSelector = newValue }
+    }
+
     // MARK: - Video controls configuration
     
     /// The area of the close button in the video controls as a percentage.

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBannerAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBannerAdUnit.swift
@@ -79,7 +79,13 @@ public class MediationBannerAdUnit : NSObject {
         get { adUnitConfig.additionalSizes }
         set { adUnitConfig.additionalSizes = newValue }
     }
-    
+
+    /// A publisher-supplied strategy for choosing the winning bid. See `PrebidBidSelecting`.
+    public var bidSelector: PrebidBidSelecting? {
+        get { adUnitConfig.bidSelector }
+        set { adUnitConfig.bidSelector = newValue }
+    }
+
     // MARK: Arbitrary ORTB Configuration
     
     /// Sets the impression-level OpenRTB configuration string for the ad unit.

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
@@ -62,7 +62,13 @@ public class MediationBaseInterstitialAdUnit : NSObject {
     public var configId: String {
         adUnitConfig.configId
     }
-    
+
+    /// A publisher-supplied strategy for choosing the winning bid. See `PrebidBidSelecting`.
+    public var bidSelector: PrebidBidSelecting? {
+        get { adUnitConfig.bidSelector }
+        set { adUnitConfig.bidSelector = newValue }
+    }
+
     let adUnitConfig: AdUnitConfig
     
     var bidRequester: BidRequester?

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationNativeAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationNativeAdUnit.swift
@@ -133,7 +133,13 @@ public class MediationNativeAdUnit : NSObject {
     public func getGlobalORTBConfig() -> String? {
         nativeAdUnit.adUnitConfig.globalORTBConfig
     }
-    
+
+    /// A publisher-supplied strategy for choosing the winning bid. See `PrebidBidSelecting`.
+    public var bidSelector: PrebidBidSelecting? {
+        get { nativeAdUnit.adUnitConfig.bidSelector }
+        set { nativeAdUnit.adUnitConfig.bidSelector = newValue }
+    }
+
     /// Makes bid request for the native ad unit and setups mediation parameters.
     /// - Parameter completion: The completion handler to call with the result code.
     public func fetchDemand(completion: ((ResultCode)->Void)?) {

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/AdUnitConfig.swift
@@ -88,6 +88,9 @@ public class AdUnitConfig: NSObject, NSCopying {
         set { adConfiguration.globalORTBConfig = newValue }
     }
 
+    /// A publisher-supplied strategy for choosing the winning bid. See `PrebidBidSelecting`.
+    public var bidSelector: PrebidBidSelecting?
+
     // MARK: - Public Methods
     
     public convenience init(configId: String) {
@@ -140,6 +143,7 @@ public class AdUnitConfig: NSObject, NSCopying {
         clone.gpid = self.gpid
         clone.adPosition = self.adPosition
         clone.pbAdSlot = self.pbAdSlot
+        clone.bidSelector = self.bidSelector
         
         clone.adConfiguration.impORTBConfig = self.adConfiguration.impORTBConfig
         clone.adConfiguration.globalORTBConfig = self.adConfiguration.globalORTBConfig

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/BidResponse.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/BidResponse.swift
@@ -29,7 +29,10 @@ public class BidResponse: NSObject {
     public private(set) var tmaxrequest: NSNumber?
     
     public private(set) var ext: ORTBBidResponseExt?
-    
+
+    /// The publisher-supplied bid selector currently in effect, if any. Set via `applyBidSelector(_:)`.
+    public private(set) var bidSelector: PrebidBidSelecting?
+
     private(set) var rawResponse: RawBidResponse?
     
     public convenience init(adUnitId: String?, targetingInfo: [String: String]?) {
@@ -103,21 +106,53 @@ public class BidResponse: NSObject {
         
         return removedBids
     }
-    
+
+    /// Sets the bid selector and immediately recomputes the winning bid and targeting info using it.
+    /// When `selector` is non-nil, it takes precedence over the default marker-driven winner selection.
+    /// - Parameter selector: The bid selector to apply, or `nil` to restore the default selection logic.
+    public func applyBidSelector(_ selector: PrebidBidSelecting?) {
+        bidSelector = selector
+        updateWinningBidAndTargetingInfo(from: allBids ?? [])
+    }
+
+    /// Standard winner-marker keys (see `Bid.isWinning`). These specifically identify "the" winner,
+    /// so they must never be attributed to a bid that isn't the (possibly selector-chosen) winner --
+    /// otherwise `targetingInfo` could still point at a different bid than `winningBid` does.
+    private static let winningBidMarkerKeys: Set<String> = ["hb_pb", "hb_bidder", "hb_cache_id"]
+
     private func updateWinningBidAndTargetingInfo(from bids: [Bid]) {
         var targetingInfo: [String : String] = [:]
         var winningBid: Bid?
-        
-        for bid in bids {
-            if winningBid == nil && bid.isWinning {
-                winningBid = bid
+        let selectorActive = bidSelector != nil
+
+        if let bidSelector {
+            let selectedBid = bidSelector.selectBid(from: bids)
+            if let selectedBid, !bids.contains(where: { $0 === selectedBid }) {
+                Log.warn("PrebidBidSelecting.selectBid(from:) returned a bid that is not part of the provided bids. Ignoring it.")
+            } else {
+                winningBid = selectedBid
             }
-            
-            if winningBid !== bid, let bidTargetingInfo = bid.targetingInfo {
-                targetingInfo.merge(bidTargetingInfo) { $1 }
+        } else {
+            for bid in bids {
+                if winningBid == nil && bid.isWinning {
+                    winningBid = bid
+                }
             }
         }
-        
+
+        for bid in bids {
+            guard winningBid !== bid, let bidTargetingInfo = bid.targetingInfo else { continue }
+            // Only strip the standard winner markers when a selector is actively overriding the
+            // winner -- that's the one scenario where a bid other than `winningBid` could still
+            // carry `hb_pb`/`hb_bidder`/`hb_cache_id` and mislead the ad server about who won.
+            // In default (no-selector) mode, leave this untouched: a bid with only a partial
+            // marker set (e.g. `hb_bidder` but no `hb_pb`) legitimately contributes it today.
+            let nonWinnerTargetingInfo = selectorActive
+                ? bidTargetingInfo.filter { !Self.winningBidMarkerKeys.contains($0.key) }
+                : bidTargetingInfo
+            targetingInfo.merge(nonWinnerTargetingInfo) { $1 }
+        }
+
         if let winningBidTargetingInfo = winningBid?.targetingInfo {
             targetingInfo.merge(winningBidTargetingInfo) { $1 }
         }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/PrebidBidSelecting.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/PrebidBidSelecting.swift
@@ -1,0 +1,31 @@
+/*   Copyright 2018-2025 Prebid.org, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/// A publisher-supplied strategy for choosing the winning bid out of the bids returned by Prebid Server.
+///
+/// When set, `selectBid(from:)` takes precedence over the SDK's default winner selection
+/// (based on the `hb_pb`/`hb_bidder` targeting markers) and over `Targeting.forceSdkToChooseWinner`.
+@objc public protocol PrebidBidSelecting: AnyObject {
+
+    /// Selects the winning bid from the given bids, or `nil` if none should win.
+    ///
+    /// Returning `nil` is final: no bid's targeting keywords are attached to the ad object and
+    /// no ad is rendered, regardless of `Targeting.forceSdkToChooseWinner`. The returned bid must
+    /// be one of the bids passed in; any other value is treated as `nil`.
+    /// - Parameter bids: All bids returned for the request.
+    func selectBid(from bids: [Bid]) -> Bid?
+}

--- a/PrebidMobileTests/AdUnitTests/AdUnitTests.swift
+++ b/PrebidMobileTests/AdUnitTests/AdUnitTests.swift
@@ -209,6 +209,34 @@ class AdUnitTests: XCTestCase {
         XCTAssertEqual(resultCode, expected)
     }
     
+    // Selector returns nil => demand suppressed, no keywords attached, regardless of
+    // forceSdkToChooseWinner. A selector's "no winner" decision must be final, unlike the
+    // default (no-selector) marker-based "no winner" case which still reports success below.
+    private final class NilBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? { nil }
+    }
+
+    func testSelectorNilWinner_suppressesDemandRegardlessOfForceSdkToChooseWinner() {
+        //given
+        Targeting.shared.forceSdkToChooseWinner = false
+
+        let expected = ResultCode.prebidDemandNoBids
+        let adUnit = AdUnit(configId: "138c4d03-0efb-4498-9dc6-cb5a9acb2ea4", size: CGSize(width: 300, height: 250), adFormats: [.banner])
+        Prebid.shared.useCacheForReportingWithRenderingAPI = false
+        let adObject = NSMutableDictionary()
+        let rawWinningBid = PBMBidResponseTransformer.makeValidResponse(bidPrice: 0.75)
+        let jsonDict = rawWinningBid.jsonDict
+        let bidResponse = BidResponse(jsonDictionary: jsonDict ?? [:])
+        bidResponse.applyBidSelector(NilBidSelector())
+
+        //when
+        let resultCode = adUnit.setUp(adObject, with: bidResponse)
+
+        //then
+        XCTAssertFalse((adObject.allKeys as? [String])?.contains("hb_bidder") ?? false)
+        XCTAssertEqual(resultCode, expected)
+    }
+
     //forceSdkToChooseWinner + Native Format Winner = Contains Targeting Info
     func testForcedWinnerAndWinningBidNativeFormat() {
         //given

--- a/PrebidMobileTests/RenderingTests/Tests/PBMAdUnitConfigTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMAdUnitConfigTest.swift
@@ -38,4 +38,26 @@ class PBMAdUnitConfigTest: XCTestCase {
         adUnitConfig.setPbAdSlot("test-ad-slot")
         XCTAssertEqual("test-ad-slot", adUnitConfig.getPbAdSlot())
     }
+
+    // MARK: - bidSelector
+
+    private final class StubBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? { bids.first }
+    }
+
+    func testBidSelectorDefaultsToNil() {
+        XCTAssertNil(adUnitConfig.bidSelector)
+    }
+
+    func testBidSelectorSurvivesCopy() {
+        let selector = StubBidSelector()
+        adUnitConfig.bidSelector = selector
+
+        let copy = adUnitConfig.copy() as! AdUnitConfig
+
+        // Must be the *same* selector instance (strong retention through copy),
+        // not just a non-nil value -- a `weak` property would pass a naive nil-check
+        // here while still losing the selector once the caller's own reference goes away.
+        XCTAssertTrue(copy.bidSelector === selector)
+    }
 }

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/BannerViewTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/BannerViewTest.swift
@@ -74,7 +74,23 @@ class BannerViewTest: XCTestCase {
         bannerView.refreshInterval = refreshInterval
         XCTAssertEqual(adUnitConfig.refreshInterval, refreshInterval)
     }
-    
+
+    func testBidSelectorForwardsToAdUnitConfig() {
+        let testID = "auid"
+        let primarySize = CGSize(width: 320, height: 50)
+
+        final class StubSelector: PrebidBidSelecting {
+            func selectBid(from bids: [Bid]) -> Bid? { bids.first }
+        }
+
+        let bannerView = MockBannerView(frame: CGRect(origin: .zero, size: primarySize), configID: testID, adSize: primarySize, eventHandler: BannerEventHandlerStandalone())
+        let selector = StubSelector()
+
+        bannerView.bidSelector = selector
+
+        XCTAssertTrue(bannerView.adUnitConfig.bidSelector === selector)
+    }
+
     func testAccountErrorPropagation() {
         let testID = "auid"
         

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/BidSelectorTests.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/BidSelectorTests.swift
@@ -1,0 +1,269 @@
+/*   Copyright 2018-2026 Prebid.org, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
+import XCTest
+
+@testable import PrebidMobile
+
+private final class StubBidSelector: PrebidBidSelecting {
+    private let selection: ([Bid]) -> Bid?
+
+    init(_ selection: @escaping ([Bid]) -> Bid?) {
+        self.selection = selection
+    }
+
+    func selectBid(from bids: [Bid]) -> Bid? {
+        selection(bids)
+    }
+}
+
+class BidSelectorTests: XCTestCase {
+
+    override func tearDown() {
+        super.tearDown()
+        Targeting.shared.forceSdkToChooseWinner = false
+        Prebid.reset()
+    }
+
+    // MARK: - Characterization: default (no selector) behavior is unchanged
+
+    func testNoSelectorByDefault_defaultMarkerLogicPicksWinner() {
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: nil)
+        ])
+
+        XCTAssertNil(bidResponse.bidSelector)
+        XCTAssertNotNil(bidResponse.winningBid)
+        XCTAssertEqual(bidResponse.winningBid?.targetingInfo?["hb_bidder"], "openx")
+    }
+
+    func testNoSelectorByDefault_unmarkedBidDoesNotWin() {
+        // A bid with no hb_pb/hb_bidder markers is not treated as winning by the
+        // SDK's default logic, even if its price is higher -- this must remain true
+        // when bidSelector is nil.
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "unmarked", price: 2.00, bidder: nil, cache: nil)
+        ])
+
+        XCTAssertNil(bidResponse.bidSelector)
+        XCTAssertNil(bidResponse.winningBid)
+    }
+
+    // MARK: - New behavior: selector overrides default marker-driven winner
+
+    func testSelectorOverridesDefaultWinner() {
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: nil),
+            Self.bidDictionary(id: "unmarked", price: 2.00, bidder: nil, cache: nil)
+        ])
+
+        // Default: the marker-driven bid wins, even though it's not the highest price.
+        XCTAssertEqual(bidResponse.winningBid?.targetingInfo?["hb_bidder"], "openx")
+
+        // Selector: always prefer the highest-price bid, regardless of markers.
+        let selector = StubBidSelector { bids in bids.max { $0.price < $1.price } }
+        bidResponse.applyBidSelector(selector)
+
+        XCTAssertTrue(bidResponse.bidSelector === selector)
+        XCTAssertEqual(bidResponse.winningBid?.price, 2.00)
+    }
+
+    func testSelectorReturningNil_resultsInNoWinningBid() {
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: nil)
+        ])
+
+        bidResponse.applyBidSelector(StubBidSelector { _ in nil })
+
+        XCTAssertNil(bidResponse.winningBid)
+    }
+
+    func testApplyBidSelectorNil_restoresDefaultMarkerLogic() {
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: nil),
+            Self.bidDictionary(id: "unmarked", price: 2.00, bidder: nil, cache: nil)
+        ])
+
+        bidResponse.applyBidSelector(StubBidSelector { bids in bids.max { $0.price < $1.price } })
+        XCTAssertEqual(bidResponse.winningBid?.price, 2.00)
+
+        bidResponse.applyBidSelector(nil)
+
+        XCTAssertNil(bidResponse.bidSelector)
+        XCTAssertEqual(bidResponse.winningBid?.targetingInfo?["hb_bidder"], "openx")
+    }
+
+    // MARK: - Selector takes precedence over Targeting.forceSdkToChooseWinner
+
+    func testSelectorTakesPrecedenceOverForceSdkToChooseWinner() {
+        Targeting.shared.forceSdkToChooseWinner = true
+
+        // No bid carries the full marker set, so default logic would report `.prebidDemandNoBids`
+        // via `AdUnit.setUp` once `forceSdkToChooseWinner` is true. A selector should still be
+        // able to pick a winner regardless of that flag.
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "unmarked", price: 2.00, bidder: nil, cache: nil)
+        ])
+
+        bidResponse.applyBidSelector(StubBidSelector { bids in bids.first })
+
+        XCTAssertNotNil(bidResponse.winningBid)
+        XCTAssertEqual(bidResponse.winningBid?.price, 2.00)
+    }
+
+    // MARK: - Selector is consulted again after cache filtering, not bypassed
+
+    func testSelectorConsultedAgainAfterRemoveBidsWithoutSuccessfulCache() {
+        let cache: [String: Any] = ["bids": ["url": "https://prebid-cache/cache?uuid=cache-id", "cacheId": "cache-id"]]
+
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: cache),
+            Self.bidDictionary(id: "unmarked", price: 2.00, bidder: nil, cache: cache)
+        ])
+
+        let selector = StubBidSelector { bids in bids.max { $0.price < $1.price } }
+        bidResponse.applyBidSelector(selector)
+        XCTAssertEqual(bidResponse.winningBid?.price, 2.00)
+
+        // Both bids have a successful server cache entry, so neither is removed here --
+        // what matters is that recomputation after filtering still goes through the
+        // selector rather than silently reverting to default marker-driven selection.
+        let removed = bidResponse.removeBidsWithoutSuccessfulCache()
+
+        XCTAssertEqual(removed, 0)
+        XCTAssertTrue(bidResponse.bidSelector === selector)
+        XCTAssertEqual(bidResponse.winningBid?.price, 2.00)
+    }
+
+    func testSelectorConsultedAgainAfterRemoveBidsWithoutSuccessfulCache_bidRemoved() {
+        let cache: [String: Any] = ["bids": ["url": "https://prebid-cache/cache?uuid=cache-id", "cacheId": "cache-id"]]
+
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: cache),
+            // This bid has no cache entry and will be filtered out by removeBidsWithoutSuccessfulCache().
+            Self.bidDictionary(id: "unmarked", price: 2.00, bidder: nil, cache: nil)
+        ])
+
+        let selector = StubBidSelector { bids in bids.max { $0.price < $1.price } }
+        bidResponse.applyBidSelector(selector)
+        XCTAssertEqual(bidResponse.winningBid?.price, 2.00)
+
+        _ = bidResponse.removeBidsWithoutSuccessfulCache()
+
+        // The higher-price bid is gone; the selector -- still active -- now falls back to
+        // the remaining marker-driven bid, proving it was re-invoked with the filtered set
+        // rather than the response silently keeping the old (now-removed) winner.
+        XCTAssertEqual(bidResponse.allBids?.count, 1)
+        XCTAssertEqual(bidResponse.winningBid?.price, 0.75)
+        XCTAssertEqual(bidResponse.winningBid?.targetingInfo?["hb_bidder"], "openx")
+    }
+
+    // MARK: - Selector must not leave stale winner-marker keys in targetingInfo
+
+    func testSelectorPickingUnmarkedBid_doesNotLeakOldWinnerMarkers() {
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: nil),
+            Self.bidDictionary(id: "unmarked", price: 2.00, bidder: nil, cache: nil)
+        ])
+
+        // Selector picks the unmarked bid, which has no targetingInfo of its own.
+        let selector = StubBidSelector { bids in bids.max { $0.price < $1.price } }
+        bidResponse.applyBidSelector(selector)
+
+        XCTAssertEqual(bidResponse.winningBid?.price, 2.00)
+        // The "marked" bid is no longer the winner -- its hb_bidder/hb_pb markers must not
+        // survive into the merged targetingInfo, or the ad server would be targeted with a
+        // different bid than the one `winningBid` actually reports.
+        XCTAssertNil(bidResponse.targetingInfo?["hb_bidder"])
+        XCTAssertNil(bidResponse.targetingInfo?["hb_pb"])
+    }
+
+    func testDefaultLogic_stillReportsWinnerMarkers() {
+        // Characterization: when no selector is active, the actual winner's own markers
+        // must still flow through untouched -- the leak fix only strips markers from bids
+        // that are *not* the winner.
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: nil)
+        ])
+
+        XCTAssertEqual(bidResponse.targetingInfo?["hb_bidder"], "openx")
+        XCTAssertEqual(bidResponse.targetingInfo?["hb_pb"], "0.75")
+    }
+
+    // MARK: - Selector must not be able to hand back a bid that isn't in the provided array
+
+    func testSelectorReturningForeignBid_isRejected() {
+        // A bid from an entirely separate response -- e.g. one a publisher's selector
+        // implementation retained from a previous auction -- must never become the winner.
+        let staleResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "stale", price: 5.00, bidder: "stale_bidder", cache: nil)
+        ])
+        let staleBid = staleResponse.allBids![0]
+
+        let bidResponse = Self.makeBidResponse([
+            Self.bidDictionary(id: "marked", price: 0.75, bidder: "openx", cache: nil)
+        ])
+
+        bidResponse.applyBidSelector(StubBidSelector { _ in staleBid })
+
+        XCTAssertNil(bidResponse.winningBid)
+        XCTAssertNil(bidResponse.targetingInfo?["hb_bidder"])
+    }
+
+    // MARK: - Helpers
+
+    private static func makeBidResponse(_ bidDictionaries: [[String: Any]]) -> BidResponse {
+        BidResponse(jsonDictionary: [
+            "id": "response-id",
+            "seatbid": [
+                [
+                    "bid": bidDictionaries,
+                    "seat": "openx"
+                ]
+            ],
+            "cur": "USD"
+        ])
+    }
+
+    private static func bidDictionary(
+        id: String,
+        price: Double,
+        bidder: String?,
+        cache: [String: Any]?
+    ) -> [String: Any] {
+        var prebid: [String: Any] = ["type": "banner"]
+
+        if let bidder {
+            prebid["targeting"] = [
+                "hb_bidder": bidder,
+                "hb_pb": "\(NSString(format: "%4.2f", price))"
+            ]
+        }
+
+        if let cache {
+            prebid["cache"] = cache
+        }
+
+        return [
+            "id": "test-bid-id-\(id)",
+            "impid": "test-imp-id-\(id)",
+            "price": price,
+            "adm": "<html></html>",
+            "w": 300,
+            "h": 250,
+            "ext": ["prebid": prebid]
+        ]
+    }
+}

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/InterstitialRenderingAdUnitTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/InterstitialRenderingAdUnitTest.swift
@@ -33,4 +33,17 @@ class InterstitialRenderingAdUnitTest: XCTestCase {
         XCTAssertEqual(adUnit.adPosition, adUnitConfig.adPosition)
         XCTAssertEqual(adUnitConfig.adPosition, .footer)
     }
+
+    private final class StubBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? { bids.first }
+    }
+
+    func testBidSelectorForwardsToAdUnitConfig() {
+        let adUnit = InterstitialRenderingAdUnit(configID: "test")
+        let selector = StubBidSelector()
+
+        adUnit.bidSelector = selector
+
+        XCTAssertTrue(adUnit.adUnitConfig.bidSelector === selector)
+    }
 }

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/MediationAPI/MediationBannerAdUnitTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/MediationAPI/MediationBannerAdUnitTest.swift
@@ -64,7 +64,20 @@ class MediationBannerAdUnitTest: XCTestCase {
         bannerAdUnit.refreshInterval = refreshInterval
         XCTAssertEqual(adUnitConfig.refreshInterval, refreshInterval)
     }
-    
+
+    private final class StubBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? { bids.first }
+    }
+
+    func testBidSelectorForwardsToAdUnitConfig() {
+        let bannerAdUnit = MediationBannerAdUnit(configID: testID, size: primarySize, mediationDelegate: mediationDelegate!)
+        let selector = StubBidSelector()
+
+        bannerAdUnit.bidSelector = selector
+
+        XCTAssertTrue(bannerAdUnit.adUnitConfig.bidSelector === selector)
+    }
+
     func testAdObjectSetUpCleanUp() {
        
         //a good response with a bid

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/MediationAPI/MediationInterstitialAdUnitTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/MediationAPI/MediationInterstitialAdUnitTest.swift
@@ -118,4 +118,20 @@ class MediationInterstitialAdUnitTest: XCTestCase {
         XCTAssertEqual(adUnit.adPosition, adUnitConfig.adPosition)
         XCTAssertEqual(adUnitConfig.adPosition, .footer)
     }
+
+    private final class StubBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? { bids.first }
+    }
+
+    func testBidSelectorForwardsToAdUnitConfig() {
+        let adUnit = MediationBaseInterstitialAdUnit(
+            configId: "test",
+            mediationDelegate: MockEmptyPrebidMediationDelegate()
+        )
+        let selector = StubBidSelector()
+
+        adUnit.bidSelector = selector
+
+        XCTAssertTrue(adUnit.adUnitConfig.bidSelector === selector)
+    }
 }

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/MediationAPI/MediationNativeAdUnitTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/MediationAPI/MediationNativeAdUnitTest.swift
@@ -1,0 +1,34 @@
+/*   Copyright 2018-2026 Prebid.org, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
+import XCTest
+
+@testable import PrebidMobile
+
+class MediationNativeAdUnitTest: XCTestCase {
+
+    private final class StubBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? { bids.first }
+    }
+
+    func testBidSelectorForwardsToAdUnitConfig() {
+        let adUnit = MediationNativeAdUnit(configId: "test", mediationDelegate: MockEmptyPrebidMediationDelegate())
+        let selector = StubBidSelector()
+
+        adUnit.bidSelector = selector
+
+        XCTAssertTrue(adUnit.nativeAdUnit.adUnitConfig.bidSelector === selector)
+    }
+}

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/MediationAPI/MediationRewardedAdUnitTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/MediationAPI/MediationRewardedAdUnitTest.swift
@@ -30,4 +30,17 @@ class MediationRewardedAdUnitTest: XCTestCase {
         PBMAssertEq(adUnitConfig.adPosition, .fullScreen)
         XCTAssertTrue(adUnitConfig.adFormats.contains(.video))
     }
+
+    private final class StubBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? { bids.first }
+    }
+
+    func testBidSelectorForwardsToAdUnitConfig() {
+        let adUnit = MediationRewardedAdUnit(configId: "prebidConfigId", mediationDelegate: mediationDelegate)
+        let selector = StubBidSelector()
+
+        adUnit.bidSelector = selector
+
+        XCTAssertTrue(adUnit.adUnitConfig.bidSelector === selector)
+    }
 }

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/PBMBidRequesterTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/PBMBidRequesterTest.swift
@@ -152,6 +152,56 @@ class PBMBidRequesterTest: XCTestCase {
         waitForExpectations(timeout: 5)
     }
 
+    // MARK: - bidSelector
+
+    private final class HighestPriceBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? {
+            bids.max { $0.price < $1.price }
+        }
+    }
+
+    func testBanner_bidSelectorAppliedBeforeCacheFiltering() {
+        let configId = "b6260e2b-bc4c-4d10-bdb5-f7bdd62f5ed4"
+        let adUnitConfig = AdUnitConfig(configId: configId, size: CGSize(width: 300, height: 250))
+        adUnitConfig.bidSelector = HighestPriceBidSelector()
+
+        // Two bids, both with a successful server cache entry -- only one carries the standard
+        // hb_bidder/hb_pb/hb_cache_id markers (and would be the default winner), the other is
+        // higher-priced but unmarked. If PBMBidRequester didn't actually apply
+        // `adUnitConfiguration.bidSelector`, the marked (lower-price) bid would win instead.
+        let responseBody = """
+        {"id":"resp-id","seatbid":[{"bid":[\
+        {"id":"marked-bid","impid":"imp-1","price":0.75,"adm":"<html></html>","w":300,"h":250,\
+        "ext":{"prebid":{"targeting":{"hb_bidder":"openx","hb_pb":"0.75","hb_cache_id":"cache-id"},"type":"banner",\
+        "cache":{"bids":{"url":"https://prebid-cache/cache?uuid=cache-id","cacheId":"cache-id"}}}}},\
+        {"id":"unmarked-bid","impid":"imp-2","price":2.00,"adm":"<html></html>","w":300,"h":250,\
+        "ext":{"prebid":{"type":"banner",\
+        "cache":{"bids":{"url":"https://prebid-cache/cache?uuid=cache-id-2","cacheId":"cache-id-2"}}}}}\
+        ],"seat":"openx"}],"cur":"USD"}
+        """
+
+        let connection = MockServerConnection(onPost: [{ (url, data, timeout, callback) in
+            callback(PBMBidResponseTransformer.buildResponse(responseBody))
+        }])
+        let requester = Factory.createBidRequester(connection: connection,
+                                                   sdkConfiguration: sdkConfiguration,
+                                                   targeting: targeting,
+                                                   adUnitConfiguration: adUnitConfig)
+        sdkConfiguration.requireServerSideBidCache = true
+
+        let exp = expectation(description: "exp")
+        requester.requestBids { (bidResponse, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(bidResponse)
+            // Both bids have a successful cache entry, so cache filtering removes neither.
+            XCTAssertEqual(bidResponse?.allBids?.count, 2)
+            XCTAssertEqual(bidResponse?.winningBid?.price, 2.00)
+            exp.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+
     func testBanner_invalidAccountID_noRequest() {
         let configId = "b6260e2b-bc4c-4d10-bdb5-f7bdd62f5ed4"
         let adUnitConfig = AdUnitConfig(configId: configId, size: CGSize(width: 300, height: 250))

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/PrebidBidSelectingObjCTest.m
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/PrebidBidSelectingObjCTest.m
@@ -1,0 +1,113 @@
+/*   Copyright 2018-2026 Prebid.org, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  */
+
+#import <XCTest/XCTest.h>
+#import "SwiftImport.h"
+
+// A plain Objective-C class adopting PrebidBidSelecting, proving the @objc protocol
+// is usable from Objective-C, not just declarable there.
+@interface ObjCHighestPriceBidSelector : NSObject <PrebidBidSelecting>
+@end
+
+@implementation ObjCHighestPriceBidSelector
+
+- (Bid * _Nullable)selectBidFrom:(NSArray<Bid *> * _Nonnull)bids {
+    Bid *best = nil;
+    for (Bid *bid in bids) {
+        if (best == nil || bid.price > best.price) {
+            best = bid;
+        }
+    }
+    return best;
+}
+
+@end
+
+@interface PrebidBidSelectingObjCTest : XCTestCase
+@end
+
+@implementation PrebidBidSelectingObjCTest
+
+- (void)setUp {
+    // Hermetic regardless of what other test suites leave in the shared singleton --
+    // isWinning's marker set only includes hb_cache_id when this is true, and these
+    // fixtures deliberately don't set that marker.
+    Prebid.shared.useCacheForReportingWithRenderingAPI = NO;
+}
+
+- (void)testAdoptableAndSettableFromObjC {
+    ObjCHighestPriceBidSelector *selector = [[ObjCHighestPriceBidSelector alloc] init];
+
+    AdUnitConfig *config = [[AdUnitConfig alloc] initWithConfigId:@"test-config-id"];
+    config.bidSelector = selector;
+
+    XCTAssertEqualObjects(config.bidSelector, selector);
+}
+
+- (void)testSelectBidCallableFromObjC {
+    ObjCHighestPriceBidSelector *selector = [[ObjCHighestPriceBidSelector alloc] init];
+
+    NSDictionary *markedBid = @{
+        @"id": @"marked-bid",
+        @"impid": @"imp-1",
+        @"price": @0.75,
+        @"adm": @"<html></html>",
+        @"w": @300,
+        @"h": @250,
+        @"ext": @{
+            @"prebid": @{
+                @"targeting": @{@"hb_bidder": @"openx", @"hb_pb": @"0.75"},
+                @"type": @"banner"
+            }
+        }
+    };
+    NSDictionary *unmarkedBid = @{
+        @"id": @"unmarked-bid",
+        @"impid": @"imp-2",
+        @"price": @2.00,
+        @"adm": @"<html></html>",
+        @"w": @300,
+        @"h": @250,
+        @"ext": @{
+            @"prebid": @{
+                @"type": @"banner"
+            }
+        }
+    };
+    NSDictionary *responseDict = @{
+        @"id": @"response-id",
+        @"seatbid": @[
+            @{
+                @"bid": @[markedBid, unmarkedBid],
+                @"seat": @"openx"
+            }
+        ],
+        @"cur": @"USD"
+    };
+
+    BidResponse *bidResponse = [[BidResponse alloc] initWithJsonDictionary:responseDict];
+
+    // Default (no selector): the marker-driven bid wins.
+    XCTAssertEqualWithAccuracy(bidResponse.winningBid.price, 0.75, 0.001);
+
+    [bidResponse applyBidSelector:selector];
+
+    // Once the ObjC-adopted selector is applied, the highest-price (unmarked) bid wins instead --
+    // proving the protocol method is actually invoked, not just adoptable.
+    XCTAssertEqualObjects(bidResponse.bidSelector, selector);
+    XCTAssertEqualWithAccuracy(bidResponse.winningBid.price, 2.00, 0.001);
+}
+
+@end

--- a/PrebidMobileTests/RenderingTests/Tests/Prebid/RewardedAdUnitTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/Prebid/RewardedAdUnitTest.swift
@@ -33,4 +33,17 @@ class RewardedAdUnitTest: XCTestCase {
         XCTAssertEqual(adUnit.adPosition, adUnitConfig.adPosition)
         XCTAssertEqual(adUnitConfig.adPosition, .footer)
     }
+
+    private final class StubBidSelector: PrebidBidSelecting {
+        func selectBid(from bids: [Bid]) -> Bid? { bids.first }
+    }
+
+    func testBidSelectorForwardsToAdUnitConfig() {
+        let adUnit = RewardedAdUnit(configID: "test")
+        let selector = StubBidSelector()
+
+        adUnit.bidSelector = selector
+
+        XCTAssertTrue(adUnit.adUnitConfig.bidSelector === selector)
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `PrebidBidSelecting`, an `@objc` protocol letting publishers override the SDK's default marker-driven winning-bid selection, resolving part 2 of #950.
- `BidResponse.applyBidSelector(_:)` is called by `PBMBidRequester` right after transforming the server response, before cache filtering, and is re-consulted after `removeBidsWithoutSuccessfulCache()` so the selector's decision survives cache-based filtering.
- When a selector is active, it takes precedence over both the default `hb_pb`/`hb_bidder` marker logic and `Targeting.forceSdkToChooseWinner`. Returning `nil` is final — no bid's keywords are attached and `AdUnit.setUp` reports `.prebidDemandNoBids`, not success.
- Non-winning bids' standard winner markers (`hb_pb`/`hb_bidder`/`hb_cache_id`) are stripped from the merged `targetingInfo` when a selector is active, so the ad server is never targeted with a different bid than the one `winningBid` reports.
- Selector results are validated to be a member of the bids array the SDK provided; a stale/foreign `Bid` is logged and rejected rather than becoming the winner.

