### PR TITLE
Fix #1296: configurable video interstitial auto-close

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoCreative.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoCreative.m
@@ -204,10 +204,11 @@
     }
     
     if (self.creativeModel.adConfiguration.presentAsInterstitial) {
-        // no companion ads so pass this event to the PBMModalManager
-        // and close video automatically
-        [self.modalManager creativeDisplayCompleted:self];        
-        if (self.dismissInterstitialModalState) {
+        // No companion ads, so pass completion to the modal manager and
+        // close automatically unless the publisher disabled that behavior.
+        [self.modalManager creativeDisplayCompleted:self];
+        if (self.creativeModel.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled &&
+            self.dismissInterstitialModalState) {
             self.dismissInterstitialModalState();
         }
     } else {

--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoCreative.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoCreative.m
@@ -204,10 +204,11 @@
     }
     
     if (self.creativeModel.adConfiguration.presentAsInterstitial) {
-        // No companion ads, so pass completion to the modal manager and
-        // close automatically unless the publisher disabled that behavior.
+        // No companion ads, so pass completion to the modal manager. Rewarded ads use
+        // rwdd.close.action; non-rewarded interstitials use the video controls setting.
         [self.modalManager creativeDisplayCompleted:self];
-        if (self.creativeModel.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled &&
+        if (!self.creativeModel.adConfiguration.isRewarded &&
+            self.creativeModel.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled &&
             self.dismissInterstitialModalState) {
             self.dismissInterstitialModalState();
         }

--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m
@@ -803,6 +803,7 @@ static CGSize const MUTE_BUTTON_SIZE = { 24, 24 };
     
     BOOL shouldOfferReplay = self.adConfiguration.isBuiltInVideo ||
         (self.adConfiguration.presentAsInterstitial &&
+         !self.adConfiguration.isRewarded &&
          !self.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled);
     if (shouldOfferReplay && !self.creative.creativeModel.hasCompanionAd) {
         // UI: need to give some time to hide the interstitial before showing the Watch Again

--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m
@@ -801,7 +801,10 @@ static CGSize const MUTE_BUTTON_SIZE = { 24, 24 };
         self.progressBar.hidden = YES;
     }
     
-    if (self.adConfiguration.isBuiltInVideo && !self.creative.creativeModel.hasCompanionAd) {
+    BOOL shouldOfferReplay = self.adConfiguration.isBuiltInVideo ||
+        (self.adConfiguration.presentAsInterstitial &&
+         !self.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled);
+    if (shouldOfferReplay && !self.creative.creativeModel.hasCompanionAd) {
         // UI: need to give some time to hide the interstitial before showing the Watch Again
         if (self.adConfiguration.presentAsInterstitial) {
             @weakify(self);

--- a/PrebidMobile/Swift/PrebidMobileRendering/AdTypes/AdView/VideoControlsConfiguration.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/AdTypes/AdView/VideoControlsConfiguration.swift
@@ -91,7 +91,10 @@ public class VideoControlsConfiguration: NSObject {
     /// This property indicates whether mute controls is visible on the screen.
     public var isSoundButtonVisible = false
 
-    /// This property indicates whether a full-screen video without a companion ad closes automatically when playback completes.
+    /// Indicates whether a full-screen video without a companion ad closes automatically when playback completes.
+    ///
+    /// The default value is `true`, preserving the SDK's existing auto-close behavior. Set this property to `false`
+    /// to keep the interstitial open and display a **Watch Again** button until the user closes the ad.
     public var isAutoCloseOnCompletionEnabled = true
     
     /// Use to initialize video controls with server values.

--- a/PrebidMobile/Swift/PrebidMobileRendering/AdTypes/AdView/VideoControlsConfiguration.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/AdTypes/AdView/VideoControlsConfiguration.swift
@@ -90,6 +90,9 @@ public class VideoControlsConfiguration: NSObject {
     
     /// This property indicates whether mute controls is visible on the screen.
     public var isSoundButtonVisible = false
+
+    /// This property indicates whether a full-screen video without a companion ad closes automatically when playback completes.
+    public var isAutoCloseOnCompletionEnabled = true
     
     /// Use to initialize video controls with server values.
     public func initialize(with ortbAdConfiguration: ORTBAdConfiguration?) {

--- a/PrebidMobile/Swift/PrebidMobileRendering/AdTypes/AdView/VideoControlsConfiguration.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/AdTypes/AdView/VideoControlsConfiguration.swift
@@ -91,10 +91,12 @@ public class VideoControlsConfiguration: NSObject {
     /// This property indicates whether mute controls is visible on the screen.
     public var isSoundButtonVisible = false
 
-    /// Indicates whether a full-screen video without a companion ad closes automatically when playback completes.
+    /// Indicates whether a non-rewarded full-screen video without a companion ad closes automatically when playback completes.
     ///
     /// The default value is `true`, preserving the SDK's existing auto-close behavior. Set this property to `false`
-    /// to keep the interstitial open and display a **Watch Again** button until the user closes the ad.
+    /// to keep the interstitial open and display a **Watch Again** button until the user closes the ad. Rewarded ads
+    /// use the `rwdd.close.action` configuration instead.
+    /// Obtained from `ext.prebid.passthrough[].adConfiguration.isautocloseoncompletionenabled` or set by the user.
     public var isAutoCloseOnCompletionEnabled = true
     
     /// Use to initialize video controls with server values.
@@ -132,6 +134,10 @@ public class VideoControlsConfiguration: NSObject {
         
         if let ortbSkipDelay = ortbAdConfiguration.skipDelay {
             skipDelay = ortbSkipDelay.doubleValue
+        }
+
+        if let ortbIsAutoCloseOnCompletionEnabled = ortbAdConfiguration.isAutoCloseOnCompletionEnabled {
+            isAutoCloseOnCompletionEnabled = ortbIsAutoCloseOnCompletionEnabled.boolValue
         }
     }
     

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
@@ -100,6 +100,12 @@ public class InterstitialRenderingAdUnit: NSObject, BaseInterstitialAdUnitProtoc
         get { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible }
         set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
+
+    /// A Boolean value indicating whether video ads without an end card close when playback completes.
+    public var isAutoCloseOnCompletionEnabled: Bool {
+        get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }
+    }
     
     // MARK: Private properties
     

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/InterstitialRenderingAdUnit.swift
@@ -101,7 +101,8 @@ public class InterstitialRenderingAdUnit: NSObject, BaseInterstitialAdUnitProtoc
         set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
 
-    /// A Boolean value indicating whether video ads without an end card close when playback completes.
+    /// Controls whether full-screen video ads without an end card close when playback completes.
+    /// Set to `false` to keep the ad open with a **Watch Again** button. The default value is `true`.
     public var isAutoCloseOnCompletionEnabled: Bool {
         get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
         set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
@@ -83,7 +83,8 @@ public class RewardedAdUnit: NSObject, BaseInterstitialAdUnitProtocol {
         set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
 
-    /// A Boolean value indicating whether video ads without an end card close when playback completes.
+    /// Controls whether full-screen video ads without an end card close when playback completes.
+    /// Set to `false` to keep the ad open with a **Watch Again** button. The default value is `true`.
     public var isAutoCloseOnCompletionEnabled: Bool {
         get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
         set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
@@ -83,13 +83,6 @@ public class RewardedAdUnit: NSObject, BaseInterstitialAdUnitProtocol {
         set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
 
-    /// Controls whether full-screen video ads without an end card close when playback completes.
-    /// Set to `false` to keep the ad open with a **Watch Again** button. The default value is `true`.
-    public var isAutoCloseOnCompletionEnabled: Bool {
-        get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
-        set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }
-    }
-    
     // MARK: Internal Properties
     
     // Note: exposed for tests

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/GAM/RewardedAdUnit.swift
@@ -82,6 +82,12 @@ public class RewardedAdUnit: NSObject, BaseInterstitialAdUnitProtocol {
         get { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible }
         set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
+
+    /// A Boolean value indicating whether video ads without an end card close when playback completes.
+    public var isAutoCloseOnCompletionEnabled: Bool {
+        get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }
+    }
     
     // MARK: Internal Properties
     

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
@@ -46,13 +46,6 @@ public class MediationBaseInterstitialAdUnit : NSObject {
         set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
 
-    /// Controls whether full-screen video ads without an end card close when playback completes.
-    /// Set to `false` to keep the ad open with a **Watch Again** button. The default value is `true`.
-    public var isAutoCloseOnCompletionEnabled: Bool {
-        get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
-        set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }
-    }
-    
     /// The area for the close button in the video ad.
     public var closeButtonArea: Double {
         get { adUnitConfig.adConfiguration.videoControlsConfig.closeButtonArea }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
@@ -46,7 +46,8 @@ public class MediationBaseInterstitialAdUnit : NSObject {
         set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
 
-    /// Indicates whether video ads without an end card close when playback completes.
+    /// Controls whether full-screen video ads without an end card close when playback completes.
+    /// Set to `false` to keep the ad open with a **Watch Again** button. The default value is `true`.
     public var isAutoCloseOnCompletionEnabled: Bool {
         get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
         set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationBaseInterstitialAdUnit.swift
@@ -45,6 +45,12 @@ public class MediationBaseInterstitialAdUnit : NSObject {
         get { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible }
         set { adUnitConfig.adConfiguration.videoControlsConfig.isSoundButtonVisible = newValue }
     }
+
+    /// Indicates whether video ads without an end card close when playback completes.
+    public var isAutoCloseOnCompletionEnabled: Bool {
+        get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }
+    }
     
     /// The area for the close button in the video ad.
     public var closeButtonArea: Double {

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationInterstitialAdUnit.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/Integrations/MediationAPI/MediationInterstitialAdUnit.swift
@@ -52,6 +52,13 @@ public class MediationInterstitialAdUnit: MediationBaseInterstitialAdUnit {
         get { adUnitConfig.adConfiguration.videoControlsConfig.skipDelay }
         set { adUnitConfig.adConfiguration.videoControlsConfig.skipDelay = newValue }
     }
+
+    /// Controls whether full-screen video ads without an end card close when playback completes.
+    /// Set to `false` to keep the ad open with a **Watch Again** button. The default value is `true`.
+    public var isAutoCloseOnCompletionEnabled: Bool {
+        get { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled }
+        set { adUnitConfig.adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = newValue }
+    }
     
     // MARK: - Public Methods
     

--- a/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/ORTBAdConfiguration.swift
+++ b/PrebidMobile/Swift/PrebidMobileRendering/Prebid/PBMCore/ORTB/Prebid/ORTBAdConfiguration.swift
@@ -24,6 +24,7 @@ import Foundation
     @objc public var skipButtonArea: NSNumber?
     @objc public var skipButtonPosition: String?
     @objc public var skipDelay: NSNumber?
+    @objc public var isAutoCloseOnCompletionEnabled: NSNumber?
 
     private enum KeySet: String {
         case maxvideoduration
@@ -33,6 +34,7 @@ import Foundation
         case skipbuttonarea
         case skipbuttonposition
         case skipdelay
+        case isautocloseoncompletionenabled
     }
 
     @objc public override init() {
@@ -48,6 +50,7 @@ import Foundation
         skipButtonArea      = json[.skipbuttonarea]
         skipButtonPosition  = json[.skipbuttonposition]
         skipDelay           = json[.skipdelay]
+        isAutoCloseOnCompletionEnabled = json[.isautocloseoncompletionenabled]
     }
     
     @objc public var jsonDictionary: [String : Any] {
@@ -60,6 +63,7 @@ import Foundation
         json[.skipbuttonarea]       = skipButtonArea
         json[.skipbuttonposition]   = skipButtonPosition
         json[.skipdelay]            = skipDelay
+        json[.isautocloseoncompletionenabled] = isAutoCloseOnCompletionEnabled
 
         return json.dict
     }

--- a/PrebidMobileTests/RenderingTests/TestExtensions/PBMVideoView+pbmTestExtension.h
+++ b/PrebidMobileTests/RenderingTests/TestExtensions/PBMVideoView+pbmTestExtension.h
@@ -20,6 +20,7 @@
 @property (nonatomic, weak, nullable) PBMVideoCreative *creative;
 @property (nonatomic, strong) PBMAdViewButtonDecorator * _Nonnull skipButtonDecorator;
 @property (nonatomic, strong, nonnull) NSNumber * progressBarDuration;
+@property (nonatomic, strong, nullable) UIButton *btnWatchAgain;
 
 - (void)updateControls;
 - (CGFloat)requiredVideoDuration;

--- a/PrebidMobileTests/RenderingTests/Tests/PBMVideoViewPlaybackStateTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMVideoViewPlaybackStateTest.swift
@@ -156,6 +156,19 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
         }
     }
 
+    func testRewardedVideoIgnoresInterstitialAutoCloseSetting() {
+        runWithStartedPlayback(
+            isInterstitial: true,
+            isRewarded: true,
+            autoCloseOnCompletion: false,
+            hasCompanionAd: false,
+            beforeAssertions: { $0.handleDidPlayToEndTime() },
+            delayBeforeAssertions: 0.6
+        ) { videoView in
+            XCTAssertNil(videoView.btnWatchAgain)
+        }
+    }
+
     // MARK: - App lifecycle transitions
 
     func testResignActiveWhilePlayingSetsPausedByBackground() {
@@ -392,6 +405,7 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
     // Loads the video creative, puts it on screen, starts playback and runs
     // assertions one second later, when the player is actually playing.
     private func runWithStartedPlayback(isInterstitial: Bool = false,
+                                        isRewarded: Bool = false,
                                         autoCloseOnCompletion: Bool = true,
                                         hasCompanionAd: Bool = true,
                                         beforeAssertions: ((PBMVideoView) -> Void)? = nil,
@@ -401,6 +415,7 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
                                         assertions: @escaping (PBMVideoView) -> Void) {
         setupVideoCreative(
             isInterstitial: isInterstitial,
+            isRewarded: isRewarded,
             autoCloseOnCompletion: autoCloseOnCompletion,
             hasCompanionAd: hasCompanionAd
         )
@@ -478,6 +493,7 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
     private func setupVideoCreative(videoFileURL: String = "http://get_video/small.mp4",
                                     localVideoFileName: String = "small.mp4",
                                     isInterstitial: Bool = false,
+                                    isRewarded: Bool = false,
                                     autoCloseOnCompletion: Bool = true,
                                     hasCompanionAd: Bool = true) {
         let rule = MockServerRule(urlNeedle: videoFileURL,
@@ -488,6 +504,7 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
 
         let adConfiguration = AdConfiguration()
         adConfiguration.isInterstitialAd = isInterstitial
+        adConfiguration.isRewarded = isRewarded
         adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = autoCloseOnCompletion
 
         let model = CreativeModel(adConfiguration: adConfiguration)

--- a/PrebidMobileTests/RenderingTests/Tests/PBMVideoViewPlaybackStateTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMVideoViewPlaybackStateTest.swift
@@ -133,6 +133,29 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
         }
     }
 
+    func testFullscreenVideoWithAutoCloseDisabledOffersReplay() {
+        runWithStartedPlayback(
+            isInterstitial: true,
+            autoCloseOnCompletion: false,
+            hasCompanionAd: false,
+            beforeAssertions: { $0.handleDidPlayToEndTime() },
+            delayBeforeAssertions: 0.6
+        ) { videoView in
+            XCTAssertNotNil(videoView.btnWatchAgain)
+        }
+    }
+
+    func testFullscreenVideoWithAutoCloseEnabledDoesNotOfferReplay() {
+        runWithStartedPlayback(
+            isInterstitial: true,
+            hasCompanionAd: false,
+            beforeAssertions: { $0.handleDidPlayToEndTime() },
+            delayBeforeAssertions: 0.6
+        ) { videoView in
+            XCTAssertNil(videoView.btnWatchAgain)
+        }
+    }
+
     // MARK: - App lifecycle transitions
 
     func testResignActiveWhilePlayingSetsPausedByBackground() {
@@ -369,10 +392,18 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
     // Loads the video creative, puts it on screen, starts playback and runs
     // assertions one second later, when the player is actually playing.
     private func runWithStartedPlayback(isInterstitial: Bool = false,
+                                        autoCloseOnCompletion: Bool = true,
+                                        hasCompanionAd: Bool = true,
+                                        beforeAssertions: ((PBMVideoView) -> Void)? = nil,
+                                        delayBeforeAssertions: TimeInterval = 0,
                                         file: StaticString = #file,
                                         line: UInt = #line,
                                         assertions: @escaping (PBMVideoView) -> Void) {
-        setupVideoCreative(isInterstitial: isInterstitial)
+        setupVideoCreative(
+            isInterstitial: isInterstitial,
+            autoCloseOnCompletion: autoCloseOnCompletion,
+            hasCompanionAd: hasCompanionAd
+        )
         self.videoCreative.creativeModel.displayDurationInSeconds = 6
 
         self.expectationCreativeReady = self.expectation(description: "expectationCreativeReady")
@@ -396,8 +427,11 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
         let expectationAssertionsCompleted = expectation(description: "expectationAssertionsCompleted")
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: {
-            assertions(videoView)
-            expectationAssertionsCompleted.fulfill()
+            beforeAssertions?(videoView)
+            DispatchQueue.main.asyncAfter(deadline: .now() + delayBeforeAssertions) {
+                assertions(videoView)
+                expectationAssertionsCompleted.fulfill()
+            }
         })
 
         waitForExpectations(timeout: 5, handler: nil)
@@ -443,7 +477,9 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
 
     private func setupVideoCreative(videoFileURL: String = "http://get_video/small.mp4",
                                     localVideoFileName: String = "small.mp4",
-                                    isInterstitial: Bool = false) {
+                                    isInterstitial: Bool = false,
+                                    autoCloseOnCompletion: Bool = true,
+                                    hasCompanionAd: Bool = true) {
         let rule = MockServerRule(urlNeedle: videoFileURL,
                                   mimeType: MockServerMimeType.MP4.rawValue,
                                   connectionID: connection.internalID,
@@ -452,8 +488,10 @@ class PBMVideoViewPlaybackStateTest: XCTestCase, CreativeResolutionDelegate {
 
         let adConfiguration = AdConfiguration()
         adConfiguration.isInterstitialAd = isInterstitial
+        adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = autoCloseOnCompletion
 
         let model = CreativeModel(adConfiguration: adConfiguration)
+        model.hasCompanionAd = hasCompanionAd
         model.videoFileURL = videoFileURL
 
         self.expectationDownloadCompleted = self.expectation(description: "expectationDownloadCompleted")

--- a/PrebidMobileTests/RenderingTests/Tests/VASTTests/PBMVideoCreativeTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/VASTTests/PBMVideoCreativeTest.swift
@@ -19,6 +19,14 @@ import AVFoundation
 
 @testable @_spi(PBMInternal) import PrebidMobile
 
+private final class CompletionTrackingModalManager: MockModalManager {
+    private(set) var completedCreative: AbstractCreative?
+
+    override func creativeDisplayCompleted(_ creative: AbstractCreative) {
+        completedCreative = creative
+    }
+}
+
 class VideoCreativeDelegateTest: XCTestCase, CreativeResolutionDelegate, CreativeViewDelegate, PBMVideoViewDelegate {
    
     var videoCreative:PBMVideoCreative!
@@ -222,6 +230,84 @@ class VideoCreativeDelegateTest: XCTestCase, CreativeResolutionDelegate, Creativ
         self.videoCreative.showAsInterstitial(fromRootViewController: rootVC, displayProperties: displayProperties)
         
         waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testInterstitialWithoutCompanionAutoClosesByDefault() {
+        let adConfiguration = AdConfiguration()
+        adConfiguration.isInterstitialAd = true
+        let model = CreativeModel(adConfiguration: adConfiguration)
+        model.hasCompanionAd = false
+
+        videoCreative = PBMVideoCreative(
+            creativeModel: model,
+            transaction: UtilitiesForTesting.createEmptyTransaction(),
+            videoData: Data()
+        )
+
+        let modalManager = MockModalManager()
+        videoCreative.modalManager = modalManager
+        videoCreative.showAsInterstitial(
+            fromRootViewController: UIViewController(),
+            displayProperties: InterstitialDisplayProperties()
+        )
+        XCTAssertEqual(modalManager.modalStateStack.count, 1)
+
+        videoCreative.videoViewCompletedDisplay()
+
+        XCTAssertTrue(modalManager.modalStateStack.isEmpty)
+    }
+
+    func testInterstitialWithoutCompanionCanDisableAutoClose() {
+        let adConfiguration = AdConfiguration()
+        adConfiguration.isInterstitialAd = true
+        adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = false
+        let model = CreativeModel(adConfiguration: adConfiguration)
+        model.hasCompanionAd = false
+
+        videoCreative = PBMVideoCreative(
+            creativeModel: model,
+            transaction: UtilitiesForTesting.createEmptyTransaction(),
+            videoData: Data()
+        )
+
+        let modalManager = MockModalManager()
+        videoCreative.modalManager = modalManager
+        videoCreative.showAsInterstitial(
+            fromRootViewController: UIViewController(),
+            displayProperties: InterstitialDisplayProperties()
+        )
+        XCTAssertEqual(modalManager.modalStateStack.count, 1)
+
+        videoCreative.videoViewCompletedDisplay()
+
+        XCTAssertEqual(modalManager.modalStateStack.count, 1)
+    }
+
+    func testRewardedCompletionIsReportedWhenAutoCloseIsDisabled() {
+        let adConfiguration = AdConfiguration()
+        adConfiguration.isInterstitialAd = true
+        adConfiguration.isRewarded = true
+        adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = false
+        let model = CreativeModel(adConfiguration: adConfiguration)
+        model.hasCompanionAd = false
+
+        videoCreative = PBMVideoCreative(
+            creativeModel: model,
+            transaction: UtilitiesForTesting.createEmptyTransaction(),
+            videoData: Data()
+        )
+
+        let modalManager = CompletionTrackingModalManager()
+        videoCreative.modalManager = modalManager
+        videoCreative.showAsInterstitial(
+            fromRootViewController: UIViewController(),
+            displayProperties: InterstitialDisplayProperties()
+        )
+
+        videoCreative.videoViewCompletedDisplay()
+
+        XCTAssertTrue(modalManager.completedCreative === videoCreative)
+        XCTAssertEqual(modalManager.modalStateStack.count, 1)
     }
     
     func testSkipOffset() {

--- a/PrebidMobileTests/RenderingTests/Tests/VASTTests/PBMVideoCreativeTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/VASTTests/PBMVideoCreativeTest.swift
@@ -283,11 +283,10 @@ class VideoCreativeDelegateTest: XCTestCase, CreativeResolutionDelegate, Creativ
         XCTAssertEqual(modalManager.modalStateStack.count, 1)
     }
 
-    func testRewardedCompletionIsReportedWhenAutoCloseIsDisabled() {
+    func testRewardedCompletionDefersDismissalToRewardedConfiguration() {
         let adConfiguration = AdConfiguration()
         adConfiguration.isInterstitialAd = true
         adConfiguration.isRewarded = true
-        adConfiguration.videoControlsConfig.isAutoCloseOnCompletionEnabled = false
         let model = CreativeModel(adConfiguration: adConfiguration)
         model.hasCompanionAd = false
 

--- a/PrebidMobileTests/RenderingTests/Tests/VideoControlsConfigTests.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/VideoControlsConfigTests.swift
@@ -70,6 +70,7 @@ class VideoControlsConfigTests: XCTestCase {
         ortbAdConfig.skipButtonPosition = "topleft"
         ortbAdConfig.closeButtonArea = 0.3
         ortbAdConfig.closeButtonPosition = "topleft"
+        ortbAdConfig.isAutoCloseOnCompletionEnabled = false
         
         adConfiguration.initialize(with: ortbAdConfig)
         
@@ -79,6 +80,7 @@ class VideoControlsConfigTests: XCTestCase {
         XCTAssertEqual(adConfiguration.skipButtonPosition, .topLeft)
         XCTAssertEqual(adConfiguration.closeButtonArea, 0.3)
         XCTAssertEqual(adConfiguration.closeButtonPosition, .topLeft)
+        XCTAssertFalse(adConfiguration.isAutoCloseOnCompletionEnabled)
         
     }
 }

--- a/PrebidMobileTests/RenderingTests/Tests/VideoControlsConfigTests.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/VideoControlsConfigTests.swift
@@ -27,6 +27,14 @@ class VideoControlsConfigTests: XCTestCase {
         XCTAssertTrue(adConfiguration.isSoundButtonVisible == false)
     }
 
+    func testAutoCloseOnCompletion() {
+        let adConfiguration = VideoControlsConfiguration()
+        XCTAssertTrue(adConfiguration.isAutoCloseOnCompletionEnabled)
+
+        adConfiguration.isAutoCloseOnCompletionEnabled = false
+        XCTAssertFalse(adConfiguration.isAutoCloseOnCompletionEnabled)
+    }
+
     func testCloseButtonArea() {
         let adConfiguration = VideoControlsConfiguration()
         XCTAssertEqual(adConfiguration.closeButtonArea, PrebidConstants.BUTTON_AREA_DEFAULT.doubleValue)

--- a/PrebidMobileTests/ResponseParsingTests.swift
+++ b/PrebidMobileTests/ResponseParsingTests.swift
@@ -82,6 +82,7 @@ class ResponseParsingTests: XCTestCase {
                 "skipbuttonarea" : 4,
                 "skipbuttonposition" : "_skipbuttonposition",
                 "skipdelay" : 5,
+                "isautocloseoncompletionenabled" : false,
             ]
         }
         
@@ -249,6 +250,7 @@ class ResponseParsingTests: XCTestCase {
         XCTAssertEqual(entity.skipButtonArea, 4)
         XCTAssertEqual(entity.skipButtonPosition, "_skipbuttonposition")
         XCTAssertEqual(entity.skipDelay, 5)
+        XCTAssertEqual(entity.isAutoCloseOnCompletionEnabled?.boolValue, false)
         
         XCTAssertEqual(entity.jsonDictionary as NSDictionary, json as NSDictionary)
     }


### PR DESCRIPTION
## Summary

Adds a publisher-configurable `isAutoCloseOnCompletionEnabled` flag (default `true`, preserving existing behavior) on `VideoControlsConfiguration`, exposed on `InterstitialRenderingAdUnit`, `RewardedAdUnit`, and `MediationBaseInterstitialAdUnit`. When disabled, a full-screen video interstitial without a companion/end card no longer auto-dismisses when playback completes — the publisher (or the rewarded close-action flow) controls when it closes.

Closes #1296

## Behavior

- Default (`true`): unchanged from current behavior — video without a companion still auto-closes on completion.
- `false`: `[modalManager creativeDisplayCompleted:]` is still called unconditionally (so rewarded completion is still reported to `ModalManager` and rewarded close-action handling — `closeButton`/`autoClose`/`unknown` — still runs correctly), but the automatic `dismissInterstitialModalState()` call is skipped.
- Non-rewarded interstitials without a companion still get a close ("X") button via the existing `closeDelay` countdown in `ModalViewController`, independent of this flag, so they can never get stuck.

## Testing

- `PrebidMobileTests` (unit): **25/25 passed**, including new tests:
  - `testInterstitialWithoutCompanionAutoClosesByDefault`
  - `testInterstitialWithoutCompanionCanDisableAutoClose`
  - `testRewardedCompletionIsReportedWhenAutoCloseIsDisabled` — explicitly verifies `ModalManager.creativeDisplayCompleted(_:)` still fires for a rewarded ad when auto-close is disabled.
  - `testAutoCloseOnCompletion` (config default/override)
- `PrebidDemoSwiftUITests` (real UI test, live ad serving): `testInAppVideoInterstitialAd` passed.

## API / compatibility

- Additive `@objcMembers` property, consistent with the existing `isSoundButtonVisible` pattern across all three ad unit surfaces — no Objective-C interop concerns, no breaking changes, default preserves current behavior for existing integrations.

