### PR TITLE
Fix #1299: interstitial orientation lock by creative size

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/PBMInterstitialLayoutConfigurator.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/PBMInterstitialLayoutConfigurator.m
@@ -29,8 +29,15 @@
     displayProperties.interstitialLayout = [self calculateLayoutFromSize:adConfiguration.size];
 }
 
-//FIXME: - Need to figure out how to determine orientation properly. Autorotate is enabled for now.
 + (PBMInterstitialLayout)calculateLayoutFromSize:(CGSize)size {
+    if ([self isPortrait:size]) {
+        return PBMInterstitialLayoutPortrait;
+    }
+
+    if ([self isLandscape:size]) {
+        return PBMInterstitialLayoutLandscape;
+    }
+
     return PBMInterstitialLayoutAspectRatio;
 }
 

--- a/PrebidMobileTests/RenderingTests/Tests/PBMInterstitialLayoutConfiguratorTest.swift
+++ b/PrebidMobileTests/RenderingTests/Tests/PBMInterstitialLayoutConfiguratorTest.swift
@@ -85,27 +85,26 @@ class PBMInterstitialLayoutConfiguratorTest: XCTestCase {
         XCTAssertTrue(displayProperties.isRotationEnabled)
     }
     
-    // FIXME: - Auto rotation is enabled by default for now. 
-//    func testAdConfigurationNoLayoutWithSize() {
-//        let displayProperties = InterstitialDisplayProperties()
-//        let adConfig = AdConfiguration()
-//
-//        //test portrait size
-//        adConfig.size = CGSize(width: 360, height: 480)
-//        PBMInterstitialLayoutConfigurator.configureProperties(with: adConfig, displayProperties: displayProperties)
-//        XCTAssertEqual(displayProperties.interstitialLayout, .portrait)
-//        XCTAssertFalse(displayProperties.isRotationEnabled)
-//
-//        //test landscape size
-//        adConfig.size = CGSize(width: 1024, height: 768)
-//        PBMInterstitialLayoutConfigurator.configureProperties(with: adConfig, displayProperties: displayProperties)
-//        XCTAssertEqual(displayProperties.interstitialLayout, .landscape)
-//        XCTAssertFalse(displayProperties.isRotationEnabled)
-//
-//        //test aspectRatio size
-//        adConfig.size = CGSize(width: 400, height: 300)
-//        PBMInterstitialLayoutConfigurator.configureProperties(with: adConfig, displayProperties: displayProperties)
-//        XCTAssertEqual(displayProperties.interstitialLayout, .aspectRatio)
-//        XCTAssertTrue(displayProperties.isRotationEnabled)
-//    }
+    func testAdConfigurationNoLayoutWithSize() {
+        let displayProperties = InterstitialDisplayProperties()
+        let adConfig = AdConfiguration()
+
+        // test portrait size
+        adConfig.size = CGSize(width: 360, height: 480)
+        PBMInterstitialLayoutConfigurator.configureProperties(with: adConfig, displayProperties: displayProperties)
+        XCTAssertEqual(displayProperties.interstitialLayout, .portrait)
+        XCTAssertFalse(displayProperties.isRotationEnabled)
+
+        // test landscape size
+        adConfig.size = CGSize(width: 1024, height: 768)
+        PBMInterstitialLayoutConfigurator.configureProperties(with: adConfig, displayProperties: displayProperties)
+        XCTAssertEqual(displayProperties.interstitialLayout, .landscape)
+        XCTAssertFalse(displayProperties.isRotationEnabled)
+
+        // test unknown size
+        adConfig.size = CGSize(width: 400, height: 300)
+        PBMInterstitialLayoutConfigurator.configureProperties(with: adConfig, displayProperties: displayProperties)
+        XCTAssertEqual(displayProperties.interstitialLayout, .aspectRatio)
+        XCTAssertTrue(displayProperties.isRotationEnabled)
+    }
 }


### PR DESCRIPTION
## Summary

Wires up the previously dead `PBMInterstitialLayoutConfigurator.calculateLayoutFromSize:` to the existing (already-tested) `isPortrait:`/`isLandscape:` size-lookup helpers instead of unconditionally returning `.aspectRatio`. Interstitials whose creative size matches a known portrait or landscape IAB size now get their orientation locked; unrecognized/zero sizes keep the previous auto-rotate (`.aspectRatio`) fallback unchanged.

Closes #1299

## Behavior

- Portrait/landscape size lookup uses the existing hard-coded size tables (`portraitSizes`/`landscapeSizes`), unchanged by this PR.
- Zero-size and any unrecognized size fall through to `.aspectRatio`, identical to current behavior — no regression for existing integrations that don't hit a known portrait/landscape size.
- Orientation restoration on push/pop and stacked-modal interaction traced end-to-end: `ModalManager.popModal()` → `display(state:)` → `ModalViewController.setupState(_:)` recomputes `isRotationEnabled`/`interstitialLayout` from the new top-of-stack state on every push and pop. A video interstitial and its own companion/end card share the same `InterstitialDisplayProperties` instance, so the lock can't desync between them within a single ad.
- One pre-existing (not introduced by this PR) robustness note for the maintainer: neither `ModalViewController` nor `ModalManager` calls `setNeedsUpdateOfSupportedInterfaceOrientations()` after `isRotationEnabled`/`interstitialLayout` change on an already-presented `ModalViewController` instance, which iOS 16+ recommends for orientation-mask changes to reliably propagate without a fresh present/dismiss. This was rarely exercised before (auto-detected layout was always `.aspectRatio`), and is now exercised much more often since this PR locks common ad sizes by default. Recommend a device QA pass on iOS 16+ for: locked interstitial → stacked/deferred modal (e.g. in-app click-through browser) → dismiss → confirm the lock is re-enforced. Not blocking this PR — flagging for awareness/follow-up.

## Testing

- `PrebidMobileTests` (unit): **4/4 passed** in `PBMInterstitialLayoutConfiguratorTest`, including the re-enabled `testAdConfigurationNoLayoutWithSize` (portrait/landscape/unknown-size assertions) and pre-existing `testAdSizeConstants`/`testDefaultAdConfiguration`.
- **Live verification**: built and ran the demo app (`PrebidDemoSwift`, In-App Video Interstitial Landscape 320x480) in the iOS Simulator against a real bid — the landscape-sized creative renders correctly under the new size-based layout classification. (A live device-rotation test to visually confirm the lock itself wasn't completed in this pass — see robustness note above.)

## API / compatibility

- `PBMInterstitialLayoutConfigurator` is Objective-C-internal only (private header), no public API surface, no interop concerns.

