### PR TITLE
Expose VideoParameters skippable setter to Objective-C

### DIFF
--- a/PrebidMobile/Swift/AdUnits/Parameters/VideoParameters.swift
+++ b/PrebidMobile/Swift/AdUnits/Parameters/VideoParameters.swift
@@ -105,6 +105,13 @@ public class VideoParameters: NSObject {
             return NSNumber(value: isSkippable ? 1 : 0)
         }
     }
+
+    /// Objective-C API for setting the OpenRTB video skip attribute.
+    @available(swift, unavailable, message: "Use isSkippable instead.")
+    @objc(setSkippable:)
+    public func setSkippable(_ isSkippable: Bool) {
+        self.isSkippable = isSkippable
+    }
     
     /// - Parameter mimes: supported MIME types
     public init(mimes: [String]) {

--- a/PrebidMobile/Swift/AdUnits/Parameters/VideoParameters.swift
+++ b/PrebidMobile/Swift/AdUnits/Parameters/VideoParameters.swift
@@ -107,7 +107,7 @@ public class VideoParameters: NSObject {
     }
 
     /// Objective-C API for setting the OpenRTB video skip attribute.
-    @available(swift, unavailable, message: "Use isSkippable instead.")
+    @available(swift, obsoleted: 1.0)
     @objc(setSkippable:)
     public func setSkippable(_ isSkippable: Bool) {
         self.isSkippable = isSkippable

--- a/PrebidMobileTests/AdUnitTests/AdUnitSuccessorObjCTests.m
+++ b/PrebidMobileTests/AdUnitTests/AdUnitSuccessorObjCTests.m
@@ -106,4 +106,18 @@ NSString * const configId = @"1001-1";
     XCTAssert(rewardedVideoAdUnit.videoParameters == parameters);
 }
 
+- (void)testVideoParametersSkippableIsWritable {
+    VideoParameters *parameters = [[VideoParameters alloc] initWithMimes:@[@"video/mp4"]];
+
+    XCTAssertNil(parameters.rawSkippable);
+
+    [parameters setSkippable:YES];
+
+    XCTAssertEqualObjects(parameters.rawSkippable, @1);
+
+    [parameters setSkippable:NO];
+
+    XCTAssertEqualObjects(parameters.rawSkippable, @0);
+}
+
 @end


### PR DESCRIPTION
Expose an Objective-C-only `setSkippable:` API because Swift's optional `Bool` property is not writable from Objective-C. Add an Objective-C regression test covering unset, `YES`, and `NO` values.

Test: targeted `AdUnitSuccessorObjCTests` test passes.

Closes #1309
