### PR TITLE
Fix: memory leak in AdUnit.baseFetchDemand timeout DispatchWorkItem

### DIFF
--- a/PrebidMobile/Swift/AdUnits/AdUnit.swift
+++ b/PrebidMobile/Swift/AdUnits/AdUnit.swift
@@ -169,7 +169,8 @@ public class AdUnit: NSObject, DispatcherDelegate {
         lastFetchDemandCompletion = completion
         adServerObject = adObject
         
-        let timeoutHandler = DispatchWorkItem {
+        let timeoutHandler = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
             if (!self.didReceiveResponse) {
                 self.timeOutSignalSent = true
                 completion(BidInfo(resultCode: .prebidDemandTimedOut))


### PR DESCRIPTION
Closes #1311

The timeout `DispatchWorkItem` in `AdUnit.baseFetchDemand` captured `self` strongly. Cancelling it on a successful bid response doesn't release its captured references until GCD reaches the scheduled deadline, keeping the `AdUnit` (and its owner chain) alive for up to `timeoutMillis` after the response completes.

Fix: capture `self` weakly in the timeout handler, consistent with the `bidRequester.requestBids` completion closure nearby.