### PR TITLE
Improve smoke UI test reliability and diagnostics

### DIFF
--- a/.github/workflows/PR_checks.yml
+++ b/.github/workflows/PR_checks.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   build:
     name: Build PrebidMobile Frameworks
-    if: ${{ !github.event.pull_request.draft }}
+    if: ${{ !github.event.pull_request.draft && !contains(github.head_ref, 'smoke-ui-tests') }}
     runs-on: macos-15
 
     steps:
@@ -44,7 +44,7 @@ jobs:
 
   unit-test-pr:
     name: Run Quick Unit Tests for Frameworks
-    if: ${{!github.event.pull_request.draft && !(contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests'))}}
+    if: ${{ !github.event.pull_request.draft && !contains(github.head_ref, 'smoke-ui-tests') && !(contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests')) }}
     runs-on: macos-15
 
     steps:
@@ -59,7 +59,7 @@ jobs:
           ./scripts/testPrebidMobile.sh --latest --quick
   unit-test-full:
     name: Run All Unit Tests for Frameworks
-    if: ${{!github.event.pull_request.draft && (contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests'))}}
+    if: ${{ !github.event.pull_request.draft && !contains(github.head_ref, 'smoke-ui-tests') && (contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests')) }}
     runs-on: macos-15
 
     steps:
@@ -74,7 +74,7 @@ jobs:
 
   unit-test-adapters:
     name: Run Unit Tests for Adapters
-    if: ${{!github.event.pull_request.draft}}
+    if: ${{ !github.event.pull_request.draft && !contains(github.head_ref, 'smoke-ui-tests') }}
     runs-on: macos-15
 
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   run-swift-demo-ui-tests:
     name: Run Smoke UI Tests - Swift Demo App
-    if: ${{!github.event.pull_request.draft && (contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests'))}}
+    if: ${{ contains(github.head_ref, 'smoke-ui-tests') || (!github.event.pull_request.draft && (contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests'))) }}
     runs-on: macos-15
 
     steps:
@@ -123,7 +123,7 @@ jobs:
           retention-days: 3
   run-swift-demo-integration-tests:
     name: Run Integration Tests - Swift Demo App
-    if: ${{!github.event.pull_request.draft && (contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests'))}}
+    if: ${{ !github.event.pull_request.draft && !contains(github.head_ref, 'smoke-ui-tests') && (contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests')) }}
     runs-on: macos-15
     steps:
       - name: Checkout

--- a/.github/workflows/PR_checks.yml
+++ b/.github/workflows/PR_checks.yml
@@ -113,6 +113,14 @@ jobs:
           xcode-version: ${{ env.XCODE_VERSION }}
       - name: Run Smoke UI Tests - Swift Demo App
         run: ./scripts/testPrebidDemo.sh -ui -l
+      - name: Upload smoke UI test diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-ui-test-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: TestResults/**
+          if-no-files-found: warn
+          retention-days: 3
   run-swift-demo-integration-tests:
     name: Run Integration Tests - Swift Demo App
     if: ${{!github.event.pull_request.draft && (contains(github.head_ref, 'bump-to') || contains(toJson(github.event.pull_request.labels), 'run-full-tests'))}}

--- a/.github/workflows/manual_checks.yml
+++ b/.github/workflows/manual_checks.yml
@@ -68,6 +68,14 @@ jobs:
         with: 
           xcode-version: ${{ env.XCODE_VERSION }}
       - run: ./scripts/testPrebidDemo.sh -ui -l
+      - name: Upload smoke UI test diagnostics
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-ui-test-results-${{ github.run_id }}-${{ github.run_attempt }}
+          path: TestResults/**
+          if-no-files-found: warn
+          retention-days: 3
 
   integration_tests:
     name: Run Integration Tests - Swift Demo App

--- a/Example/PrebidDemo/PrebidDemoSwift/AppDelegate.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/AppDelegate.swift
@@ -34,6 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if CommandLine.arguments.contains("-uiTesting") {
             UIApplication.shared.getKeyWindow()?.layer.speed = 2
             UIView.setAnimationsEnabled(false)
+            UITestAdStatus.shared.reset()
         }
         
         // Set account id and custom Prebid server URL
@@ -81,4 +82,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {}
 }
-

--- a/Example/PrebidDemo/PrebidDemoSwift/Utils/PrebidDemoLogger.swift
+++ b/Example/PrebidDemo/PrebidDemoSwift/Utils/PrebidDemoLogger.swift
@@ -14,7 +14,65 @@
  */
 
 import OSLog
+import UIKit
 
 struct PrebidDemoLogger {
-    static let shared = Logger()
+    static let shared = PrebidDemoLogger()
+
+    private let logger = Logger()
+
+    func info(_ message: String) {
+        logger.info("\(message, privacy: .public)")
+    }
+
+    func error(_ message: String) {
+        logger.error("\(message, privacy: .public)")
+        UITestAdStatus.shared.reportFailure(message)
+    }
+}
+
+/// Makes SDK and ad-server failures observable to UI tests without affecting the demo UI.
+final class UITestAdStatus {
+    static let shared = UITestAdStatus()
+    static let accessibilityIdentifier = "prebid-demo-ad-status"
+
+    private weak var statusView: UIView?
+
+    private var isEnabled: Bool {
+        CommandLine.arguments.contains("-uiTesting")
+    }
+
+    func reset() {
+        guard isEnabled else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.updateStatus("loading")
+        }
+    }
+
+    func reportFailure(_ message: String) {
+        guard isEnabled else { return }
+
+        DispatchQueue.main.async { [weak self] in
+            self?.updateStatus("failed: \(message)")
+        }
+    }
+
+    private func updateStatus(_ status: String) {
+        guard let statusView = statusView ?? installStatusView() else { return }
+        statusView.accessibilityValue = status
+    }
+
+    private func installStatusView() -> UIView? {
+        guard let window = UIApplication.shared.getKeyWindow() else { return nil }
+
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        view.isAccessibilityElement = true
+        view.accessibilityIdentifier = Self.accessibilityIdentifier
+        view.accessibilityLabel = "Ad load status"
+        view.accessibilityValue = "loading"
+        window.addSubview(view)
+        statusView = view
+        return view
+    }
 }

--- a/Example/PrebidDemo/PrebidDemoSwiftUITests/BannerAdsTest.swift
+++ b/Example/PrebidDemo/PrebidDemoSwiftUITests/BannerAdsTest.swift
@@ -46,15 +46,17 @@ class BannerAdsTest: BaseAdsTest {
     }
     
     override func checkAd(testCase: String) {
-        XCTAssert(
-            app.webViews.element.waitForExistence(timeout: 10),
-            assertFailedMessage(testCase: testCase,reason: "Banner Web View is not displayed")
+        assertElementExists(
+            app.webViews.element,
+            testCase: testCase,
+            reason: "Banner Web View is not displayed"
         )
         
         if let labelText {
-            XCTAssert(
-                app.staticTexts[labelText].waitForExistence(timeout: 10),
-                assertFailedMessage(testCase: testCase, reason: "`\(labelText)` is not displayed")
+            assertElementExists(
+                app.staticTexts[labelText],
+                testCase: testCase,
+                reason: "`\(labelText)` is not displayed"
             )
         }
     }

--- a/Example/PrebidDemo/PrebidDemoSwiftUITests/BaseAdsTest.swift
+++ b/Example/PrebidDemo/PrebidDemoSwiftUITests/BaseAdsTest.swift
@@ -16,6 +16,13 @@
 import XCTest
 
 class BaseAdsTest: XCTestCase {
+
+    private enum Timeout {
+        static let navigation: TimeInterval = 15
+        static let adLoad: TimeInterval = 30
+    }
+
+    private static let adStatusAccessibilityIdentifier = "prebid-demo-ad-status"
     
     let app = XCUIApplication()
     let testCases = TestCases()
@@ -35,11 +42,62 @@ class BaseAdsTest: XCTestCase {
     func assertFailedMessage(testCase: String, reason: String) -> String {
         return "Ad Failed \(testCase): \(reason)"
     }
+
+    func assertElementExists(
+        _ element: XCUIElement,
+        testCase: String,
+        reason: String,
+        timeout: TimeInterval = Timeout.adLoad
+    ) {
+        let adStatus = app.otherElements[Self.adStatusAccessibilityIdentifier]
+        let outcomePredicate = NSPredicate { _, _ in
+            element.exists || Self.failureMessage(from: adStatus) != nil
+        }
+        let outcomeExpectation = XCTNSPredicateExpectation(predicate: outcomePredicate, object: nil)
+        let outcome = XCTWaiter.wait(for: [outcomeExpectation], timeout: timeout)
+
+        if let failureMessage = Self.failureMessage(from: adStatus) {
+            XCTFail(assertFailedMessage(testCase: testCase, reason: failureMessage))
+            return
+        }
+
+        XCTAssertEqual(
+            outcome,
+            .completed,
+            assertFailedMessage(testCase: testCase, reason: reason)
+        )
+        XCTAssertTrue(
+            element.exists,
+            assertFailedMessage(testCase: testCase, reason: reason)
+        )
+    }
     
     private func goToAd(testCase: String) {
         app.launch()
-        app.searchFields.element.tap()
-        app.searchFields.element.typeText(testCase)
-        app.tables.element(boundBy: 0).cells.element(boundBy: 0).tap()
+
+        let searchField = app.searchFields.element
+        XCTAssertTrue(
+            searchField.waitForExistence(timeout: Timeout.navigation),
+            "Search field is not displayed"
+        )
+        searchField.tap()
+        searchField.typeText(testCase)
+
+        let firstMatchingCase = app.tables.element(boundBy: 0).cells.element(boundBy: 0)
+        XCTAssertTrue(
+            firstMatchingCase.waitForExistence(timeout: Timeout.navigation),
+            "Integration case '\(testCase)' is not displayed"
+        )
+        firstMatchingCase.tap()
+    }
+
+    private static func failureMessage(from statusElement: XCUIElement) -> String? {
+        guard statusElement.exists,
+              let status = statusElement.value as? String,
+              status.hasPrefix("failed: ") else {
+            return nil
+        }
+
+        return String(status.dropFirst("failed: ".count))
     }
 }

--- a/Example/PrebidDemo/PrebidDemoSwiftUITests/InterstitialAdsTest.swift
+++ b/Example/PrebidDemo/PrebidDemoSwiftUITests/InterstitialAdsTest.swift
@@ -51,22 +51,25 @@ class InterstitialAdsTest: BaseAdsTest {
     }
     
     override func checkAd(testCase: String) {
-        XCTAssert(
-            app.webViews.element.waitForExistence(timeout: 10),
-            assertFailedMessage(testCase: testCase,reason: "Interstitial Web View is not displayed")
+        assertElementExists(
+            app.webViews.element,
+            testCase: testCase,
+            reason: "Interstitial Web View is not displayed"
         )
         
         if let closeButton {
-            XCTAssert(
-                app.buttons[closeButton].waitForExistence(timeout: 10),
-                assertFailedMessage(testCase: testCase, reason: "Close button is not displayed")
+            assertElementExists(
+                app.buttons[closeButton],
+                testCase: testCase,
+                reason: "Close button is not displayed"
             )
         }
         
         if let labelText {
-            XCTAssert(
-                app.staticTexts[labelText].waitForExistence(timeout: 10),
-                assertFailedMessage(testCase: testCase, reason: "`\(labelText)` is not displayed")
+            assertElementExists(
+                app.staticTexts[labelText],
+                testCase: testCase,
+                reason: "`\(labelText)` is not displayed"
             )
         }
     }

--- a/Example/PrebidDemo/PrebidDemoSwiftUITests/MultiformatAdsTest.swift
+++ b/Example/PrebidDemo/PrebidDemoSwiftUITests/MultiformatAdsTest.swift
@@ -28,23 +28,27 @@ class MultiformatAdsTest: BaseAdsTest {
     override func checkAd(testCase: String) {
         if testCase == testCases.gamOriginalMultiformatInAppNativeCase {
             let configIdElement = app.staticTexts.element(matching: .any, identifier: "configIdLabel")
-            XCTAssert(configIdElement.waitForExistence(timeout: 5.0))
+            assertElementExists(
+                configIdElement,
+                testCase: testCase,
+                reason: "Config ID is not displayed"
+            )
             
             let configId = configIdElement.label
             
             if configId.contains("banner") && !configId.contains("native") {
-                XCTAssert(app.webViews.element.waitForExistence(timeout: 10), assertFailedMessage(testCase: testCase, reason: "Banner Web View is not displayed"))
-                XCTAssert(app.staticTexts["Test mode"].waitForExistence(timeout: 10))
+                assertElementExists(app.webViews.element, testCase: testCase, reason: "Banner Web View is not displayed")
+                assertElementExists(app.staticTexts["Test mode"], testCase: testCase, reason: "Test mode is not displayed")
             } else if configId.contains("video") {
-                XCTAssert(app.buttons["Play video"].waitForExistence(timeout: 30), assertFailedMessage(testCase: testCase, reason: "Play video button is not displayed"))
+                assertElementExists(app.buttons["Play video"], testCase: testCase, reason: "Play video button is not displayed")
             } else if configId.contains("native") {
-                XCTAssert(app.staticTexts["Prebid (Title)"].waitForExistence(timeout: 10), assertFailedMessage(testCase: testCase, reason: "Prebid title is not displayed"))
+                assertElementExists(app.staticTexts["Prebid (Title)"], testCase: testCase, reason: "Prebid title is not displayed")
             } else {
                 XCTFail(assertFailedMessage(testCase: testCase, reason: "Undefined ad format. Check config id."))
             }
         } else if testCase == testCases.gamOriginalMultiformatNativeStylesCase {
-            XCTAssert(app.webViews.element.waitForExistence(timeout: 10), assertFailedMessage(testCase: testCase,reason: "Banner Web View is not displayed"))
-            XCTAssert(app.staticTexts["Test mode"].waitForExistence(timeout: 10))
+            assertElementExists(app.webViews.element, testCase: testCase, reason: "Banner Web View is not displayed")
+            assertElementExists(app.staticTexts["Test mode"], testCase: testCase, reason: "Test mode is not displayed")
         }
     }
 }

--- a/Example/PrebidDemo/PrebidDemoSwiftUITests/NativeAdsTest.swift
+++ b/Example/PrebidDemo/PrebidDemoSwiftUITests/NativeAdsTest.swift
@@ -34,6 +34,10 @@ class NativeAdsTest: BaseAdsTest {
     }
     
     override func checkAd(testCase: String) {
-        XCTAssert(app.staticTexts["Prebid (Title)"].waitForExistence(timeout: 10),assertFailedMessage(testCase: testCase, reason: "Prebid title is not displayed"))
+        assertElementExists(
+            app.staticTexts["Prebid (Title)"],
+            testCase: testCase,
+            reason: "Prebid title is not displayed"
+        )
     }
 }

--- a/Example/PrebidDemo/PrebidDemoSwiftUITests/Video/BannerVideoAdsTest.swift
+++ b/Example/PrebidDemo/PrebidDemoSwiftUITests/Video/BannerVideoAdsTest.swift
@@ -36,9 +36,9 @@ class BannerVideoAds: BaseAdsTest {
     
     override func checkAd(testCase: String) {
         if testCase == testCases.gamOriginalVideoBannerCase {
-            XCTAssert(app.buttons["Learn more"].waitForExistence(timeout: 30),assertFailedMessage(testCase: testCase, reason: "Play learn more is not displayed"))
+            assertElementExists(app.buttons["Learn more"], testCase: testCase, reason: "Learn more button is not displayed")
         } else {
-            XCTAssert(app.otherElements["PBMVideoView"].waitForExistence(timeout: 20),assertFailedMessage(testCase: testCase, reason: "Video is not displayed"))
+            assertElementExists(app.otherElements["PBMVideoView"], testCase: testCase, reason: "Video is not displayed")
         }
     }
     

--- a/Example/PrebidDemo/PrebidDemoSwiftUITests/Video/InterstitialVideoAdsTest.swift
+++ b/Example/PrebidDemo/PrebidDemoSwiftUITests/Video/InterstitialVideoAdsTest.swift
@@ -36,12 +36,12 @@ class InterstitialVideoAds: BaseAdsTest {
     
     override func checkAd(testCase: String) {
         if testCase == testCases.gamOriginalVideoInterstitialCase {
-            XCTAssert(app.webViews.element.waitForExistence(timeout: 30),assertFailedMessage(testCase: testCase, reason: "Video is not displayed"))
-            XCTAssert(app.buttons["Close Advertisement"].waitForExistence(timeout: 15),assertFailedMessage(testCase: testCase, reason: "Close Button is not displayed"))
+            assertElementExists(app.webViews.element, testCase: testCase, reason: "Video is not displayed")
+            assertElementExists(app.buttons["Close Advertisement"], testCase: testCase, reason: "Close button is not displayed")
         } else {
-            XCTAssert(app.otherElements["PBMVideoView"].waitForExistence(timeout: 20),assertFailedMessage(testCase: testCase, reason: "Video is not displayed"))
-            XCTAssert(app.buttons["Learn More"].waitForExistence(timeout: 10),assertFailedMessage(testCase: testCase, reason: "Learn more button is not displayed"))
-            XCTAssert(app.buttons["PBMCloseButton"].waitForExistence(timeout: 15),assertFailedMessage(testCase: testCase, reason: "Video close button is not displayed"))
+            assertElementExists(app.otherElements["PBMVideoView"], testCase: testCase, reason: "Video is not displayed")
+            assertElementExists(app.buttons["Learn More"], testCase: testCase, reason: "Learn more button is not displayed")
+            assertElementExists(app.buttons["PBMCloseButton"], testCase: testCase, reason: "Video close button is not displayed")
         }
     }
 }

--- a/scripts/testPrebidDemo.sh
+++ b/scripts/testPrebidDemo.sh
@@ -6,6 +6,7 @@ DEMO_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEMO_REPOSITORY_ROOT="$(cd "${DEMO_SCRIPT_DIRECTORY}/.." && pwd)"
 DEMO_SIMULATOR_NAME="iPhone-16-Pro-PrebidMobile"
 DEMO_TEST_RESULTS_DIRECTORY="${DEMO_REPOSITORY_ROOT}/TestResults"
+DEMO_COCOAPODS_VERSION="1.16.2"
 
 cd "${DEMO_REPOSITORY_ROOT}"
 
@@ -36,10 +37,15 @@ xcrun simctl bootstatus "${DEMO_SIMULATOR_UDID}" -b
 
 echo $PWD
 
-export PATH="/Users/distiller/.gem/ruby/2.7.0/bin:$PATH"
-gem install cocoapods -v 1.16.2 --no-document
+if ! gem install cocoapods -v "${DEMO_COCOAPODS_VERSION}" --no-document; then
+    echo "🔴 Failed to install CocoaPods ${DEMO_COCOAPODS_VERSION}"
+    exit 1
+fi
 
-pod install --repo-update --deployment
+if ! pod "_${DEMO_COCOAPODS_VERSION}_" install --repo-update --deployment; then
+    echo "🔴 CocoaPods dependency installation failed"
+    exit 1
+fi
 
 if [ "$1" == "-ui" ]; then
     echo -e "\n${GREEN}Running UI tests${NC} \n"

--- a/scripts/testPrebidDemo.sh
+++ b/scripts/testPrebidDemo.sh
@@ -1,6 +1,13 @@
-if [ -d "scripts" ]; then
-cd scripts/
-fi
+#!/usr/bin/env bash
+
+set -o pipefail
+
+DEMO_SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEMO_REPOSITORY_ROOT="$(cd "${DEMO_SCRIPT_DIRECTORY}/.." && pwd)"
+DEMO_SIMULATOR_NAME="iPhone-16-Pro-PrebidMobile"
+DEMO_TEST_RESULTS_DIRECTORY="${DEMO_REPOSITORY_ROOT}/TestResults"
+
+cd "${DEMO_REPOSITORY_ROOT}"
 
 GREEN='\033[0;32m'
 NC='\033[0m' # No Color
@@ -8,17 +15,31 @@ NC='\033[0m' # No Color
 echo -e "\n\n${GREEN}RUN PREBID DEMO TESTS${NC}\n\n"
 
 echo -e "\n${GREEN}Creating simulator${NC} \n"
-xcrun simctl create iPhone-16-Pro-PrebidMobile com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro
+DEMO_SIMULATOR_UDID="$(xcrun simctl create "${DEMO_SIMULATOR_NAME}" com.apple.CoreSimulator.SimDeviceType.iPhone-16-Pro)"
 
-cd ..
+cleanup_demo_simulator() {
+    xcrun simctl delete "${DEMO_SIMULATOR_UDID}" > /dev/null 2>&1 || true
+}
+
+collect_demo_simulator_logs() {
+    mkdir -p "${DEMO_TEST_RESULTS_DIRECTORY}"
+    xcrun simctl spawn "${DEMO_SIMULATOR_UDID}" log show \
+        --style compact \
+        --last 30m \
+        > "${DEMO_TEST_RESULTS_DIRECTORY}/${TEST}-simulator.log" 2>&1 || true
+}
+
+trap cleanup_demo_simulator EXIT
+
+xcrun simctl boot "${DEMO_SIMULATOR_UDID}"
+xcrun simctl bootstatus "${DEMO_SIMULATOR_UDID}" -b
+
 echo $PWD
 
 export PATH="/Users/distiller/.gem/ruby/2.7.0/bin:$PATH"
-gem install cocoapods
+gem install cocoapods -v 1.16.2 --no-document
 
-pod deintegrate
-pod install --repo-update
-pod update
+pod install --repo-update --deployment
 
 if [ "$1" == "-ui" ]; then
     echo -e "\n${GREEN}Running UI tests${NC} \n"
@@ -30,6 +51,9 @@ else
     TEST="Integration"
 fi
 
+mkdir -p "${DEMO_TEST_RESULTS_DIRECTORY}"
+DEMO_RESULT_BUNDLE="${DEMO_TEST_RESULTS_DIRECTORY}/PrebidDemo-${TEST}-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-0}-$$.xcresult"
+
 echo -e "\n\n${GREEN}Building ${SCHEME} for testing${NC}\n\n"
 
 xcodebuild \
@@ -37,9 +61,16 @@ xcodebuild \
     -scheme $SCHEME \
     -sdk iphonesimulator \
     -configuration Debug \
-    -destination 'platform=iOS Simulator,name=iPhone-16-Pro-PrebidMobile,OS=latest' \
+    -destination "platform=iOS Simulator,id=${DEMO_SIMULATOR_UDID}" \
     -destination-timeout 60 \
     build-for-testing
+
+DEMO_BUILD_EXIT_CODE=$?
+if [[ ${DEMO_BUILD_EXIT_CODE} != 0 ]]; then
+    collect_demo_simulator_logs
+    echo "🔴 ${TEST} Test Build Failed"
+    exit "${DEMO_BUILD_EXIT_CODE}"
+fi
 
 echo -e "\n\n${GREEN}Testing ${SCHEME}${NC}\n\n"
 
@@ -47,18 +78,18 @@ xcodebuild \
     -workspace PrebidMobile.xcworkspace \
     -scheme $SCHEME \
     -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=iPhone-16-Pro-PrebidMobile,OS=latest' \
+    -destination "platform=iOS Simulator,id=${DEMO_SIMULATOR_UDID}" \
     -destination-timeout 60 \
     -test-iterations 2 \
     -retry-tests-on-failure \
+    -resultBundlePath "${DEMO_RESULT_BUNDLE}" \
     test-without-building
 
-if [[ ${PIPESTATUS[0]} == 0 ]]; then
+DEMO_TEST_EXIT_CODE=$?
+if [[ ${DEMO_TEST_EXIT_CODE} == 0 ]]; then
     echo "✅ ${TEST} Tests Passed"
 else
+    collect_demo_simulator_logs
     echo "🔴 ${TEST} Tests Failed"
-    exit 1
+    exit "${DEMO_TEST_EXIT_CODE}"
 fi
-
-echo -e "\n${GREEN}Removing simulator${NC} \n"
-xcrun simctl delete iPhone-16-Pro-PrebidMobile


### PR DESCRIPTION
## Summary

- wait up to 30 seconds for either the expected ad UI or an explicit SDK failure
- expose the demo app ad failure state to UI tests so failures report the underlying error
- make smoke test setup deterministic with an isolated simulator, pinned CocoaPods, and deployment-mode installs
- preserve `.xcresult` bundles and simulator logs as CI artifacts when smoke tests fail
- run only the smoke UI job for PR branches whose name contains `smoke-ui-tests`, including draft PRs

## Why

The smoke suite currently reports only that an ad WebView did not appear. That hides the SDK failure and makes transient infrastructure problems difficult to distinguish from regressions. A focused local run with these changes surfaced the actual error: `PBMCreativeFactoryJob: Failed to complete in specified time interval`.

## Impact

Normal PR and release-PR behavior is unchanged. The smoke-only mode is activated only by the explicit `smoke-ui-tests` branch naming convention.

This PR is intentionally stacked on #1315 and targets `bump-to-3.3.4`.

## Validation

- `bash -n scripts/testPrebidDemo.sh`
- Ruby YAML parsing for both modified workflow files
- `git diff --check`
- `xcodebuild ... build-for-testing` succeeded locally with Xcode 26.5
- focused `BannerAdsTest.testInAppBannerAd` run confirmed the underlying SDK timeout is now reported