### PR TITLE
Surface winning-bid economics on the original (GAM) API

### DIFF
--- a/PrebidMobile/Swift/AdUnits/AdUnit.swift
+++ b/PrebidMobile/Swift/AdUnits/AdUnit.swift
@@ -132,7 +132,26 @@ public class AdUnit: NSObject, DispatcherDelegate {
             }
         }
     }
-    
+
+    /// Makes a bid request for a specific ad object and provides the full `BidInfo`. Like
+    /// `fetchDemand(adObject:completion:)` it sets up the Prebid targeting keywords into `adObject`
+    /// for ad serving, but returns the full `BidInfo` (including the winning-bid economics) instead
+    /// of only the result code.
+    ///
+    /// - Parameters:
+    ///   - adObject: The ad object for which demand is being fetched.
+    ///   - completionBidInfo: A closure called with a `BidInfo` object representing the fetched demand.
+    dynamic public func fetchDemand(
+        adObject: AnyObject,
+        completionBidInfo: @escaping (_ bidInfo: BidInfo) -> Void
+    ) {
+        baseFetchDemand(adObject: adObject) { bidInfo in
+            DispatchQueue.main.async {
+                completionBidInfo(bidInfo)
+            }
+        }
+    }
+
     // SDK internal
     func baseFetchDemand(
         adObject: AnyObject? = nil,

--- a/PrebidMobile/Swift/AdUnits/MultiformatAdUnit/BidInfo.swift
+++ b/PrebidMobile/Swift/AdUnits/MultiformatAdUnit/BidInfo.swift
@@ -40,7 +40,27 @@ public class BidInfo: NSObject {
     
     /// Events related to the bid
     public private(set) var events: [String: String]
-    
+
+    // MARK: - Winning-bid economics
+    // Exact economics of the winning bid, surfaced on the original (GAM) API. Prebid normally
+    // exposes only the bucketed `hb_pb` keyword; these read the winning bid's real values off the
+    // (module-internal) ORTB response inside `create(...)`.
+
+    /// Winning bid net price (exact CPM), if any.
+    public private(set) var cpm: Double?
+
+    /// Bid currency (ISO-4217), from the ORTB bid response.
+    public private(set) var currency: String?
+
+    /// Winning creative id (`crid`).
+    public private(set) var creativeId: String?
+
+    /// Auction id — the ORTB response id (falls back to the bidder response id `bidid`).
+    public private(set) var auctionId: String?
+
+    /// Winning ad id (`adid`).
+    public private(set) var adId: String?
+
     /// Initializes a new `BidInfo` instance with the specified parameters.
     /// - Parameters:
     ///   - resultCode: The result code of the bid request.
@@ -86,7 +106,17 @@ public class BidInfo: NSObject {
         if let impURL = bidResponse.winningBid?.events?.win {
             bidInfo.addEvent(key: BidInfo.EVENT_IMP, value: impURL)
         }
-        
+
+        // Surface exact economics of the winning bid (original-API analytics). These read the
+        // module-internal ORTB objects, which are only reachable here inside PrebidMobile.
+        if let winningBid = bidResponse.winningBid {
+            bidInfo.cpm = Double(winningBid.price)
+            bidInfo.creativeId = winningBid.bid.crid
+            bidInfo.adId = winningBid.bid.adid
+        }
+        bidInfo.currency = bidResponse.rawResponse?.cur
+        bidInfo.auctionId = bidResponse.rawResponse?.requestID ?? bidResponse.rawResponse?.bidid
+
         return bidInfo
     }
     

--- a/PrebidMobileTests/ResponseParsingTests.swift
+++ b/PrebidMobileTests/ResponseParsingTests.swift
@@ -513,4 +513,38 @@ class ResponseParsingTests: XCTestCase {
         XCTAssertTrue(passthrough.sdkConfiguration is CustomSDKConfiguration)
         XCTAssertTrue(bidExt.skadn!.fidelities![0] is CustomSkadnFidelity)
     }
+
+    // MARK: - BidInfo winning-bid economics (original/GAM API)
+
+    // `BidInfo.create` should surface the winning bid's exact economics (cpm/currency/creativeId/
+    // adId/auctionId) alongside the targeting keywords, so integrators on the original API can read
+    // them without switching to the Rendering API or issuing a second auction.
+    func testBidInfoSurfacesWinningBidEconomics() {
+        let bidResponse = WinningBidResponseFabricator.makeWinningBidResponse(bidPrice: 3.14)
+        guard let winningBid = bidResponse.winningBid else {
+            return XCTFail("Fabricated response should have a winning bid")
+        }
+
+        let bidInfo = BidInfo.create(resultCode: .prebidDemandFetchSuccess, bidResponse: bidResponse)
+
+        XCTAssertEqual(bidInfo.resultCode, .prebidDemandFetchSuccess)
+        XCTAssertEqual(bidInfo.cpm, Double(winningBid.price))
+        XCTAssertEqual(bidInfo.currency, bidResponse.rawResponse?.cur)
+        XCTAssertEqual(bidInfo.creativeId, winningBid.bid.crid)
+        XCTAssertEqual(bidInfo.adId, winningBid.bid.adid)
+        XCTAssertEqual(bidInfo.auctionId,
+                       bidResponse.rawResponse?.requestID ?? bidResponse.rawResponse?.bidid)
+    }
+
+    // With no winning bid the economics must stay nil (e.g. a no-bid response).
+    func testBidInfoEconomicsAreNilWithoutWinningBid() {
+        let bidResponse = BidResponse(jsonDictionary: [:])
+        XCTAssertNil(bidResponse.winningBid)
+
+        let bidInfo = BidInfo.create(resultCode: .prebidDemandNoBids, bidResponse: bidResponse)
+
+        XCTAssertNil(bidInfo.cpm)
+        XCTAssertNil(bidInfo.creativeId)
+        XCTAssertNil(bidInfo.adId)
+    }
 }


### PR DESCRIPTION
## Surface winning-bid economics on the original (GAM) API

On the original (GAM) API, Prebid today exposes only the bucketed `hb_pb` keyword. This adds a way to read the winning bid's **exact** economics, without switching to the Rendering API or issuing a second auction.

### What's added (purely additive — no existing public API changed)

**`BidInfo`** — new public read-only properties, populated in `create()` from the winning bid's ORTB values:

- `cpm: NSNumber?` — exact net price. `NSNumber?` (not `Double?`) so it's visible from Objective-C and carries the price exactly as Prebid Server sent it (reading it as a `Float` first would round most decimals, e.g. `3.14` → `3.1400001…`).
- `currency: String?` — ISO-4217 for `cpm`; defaults to the ORTB default `"USD"` when the response omits `cur`.
- `creativeId: String?` — the creative id (`crid`).
- `adId: String?` — the ad id (`adid`).
- `requestId: String?` — the ORTB `BidResponse.id` (a per-request UUID the SDK generates); identifies the request, response-level.

`cpm`/`currency`/`creativeId`/`adId` describe the bid whose targeting was attached to the ad object, and are `nil` unless a bid was designated — a nil `cpm` is not a zero-price win. When `topBidFiltered` is `true` they describe the promoted cached runner-up.

**`AdUnit`** — new `fetchDemandBidInfo(adObject:completion:)`: attaches the Prebid targeting keywords into `adObject` for ad serving (like `fetchDemand(adObject:completion:)`) but returns the full `BidInfo`. `baseFetchDemand` already produced the `BidInfo`; the result-code variant now forwards to this method. A distinct method name (not a `fetchDemand` overload) avoids the trailing-closure ambiguity that would break existing call sites.

### Tests

`ResponseParsingTests` asserts, from a JSON-text fixture: an exact `3.14` `cpm` (no `Float` rounding), the `"USD"` default and an explicit `"EUR"`, distinct `crid`/`adid`/`id`, and that a parsed response with `cur` and bids but no designated winner leaves the winning-bid fields `nil` while `requestId` still reports the response id.