### PR TITLE
Fix #1329: avoid AVAudioSession setActive when only observing volume

### DIFF
--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m
@@ -251,7 +251,10 @@ static CGSize const MUTE_BUTTON_SIZE = { 24, 24 };
                                                name:AVPlayerItemDidPlayToEndTimeNotification
                                              object:playerItem];
     
-    [AVAudioSession.sharedInstance setActive:YES error:nil];
+    // Note: intentionally not calling `setActive:YES` here. Activating the shared audio session
+    // is a synchronous call that can block the main thread and interrupts audio already playing
+    // in other apps, even though this is only needed to observe `outputVolume` via KVO, which
+    // works without activating the session.
     [AVAudioSession.sharedInstance addObserver:self forKeyPath:PBMAudioSessionObserverKeyVoulume options:NSKeyValueObservingOptionNew context:nil];
 }
 

--- a/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMWebView.m
+++ b/PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMWebView.m
@@ -616,7 +616,10 @@ static PBMError *extracted(NSString *errorMessage) {
 - (void)setupVolumeObserver {
     if (!self.isVolumeObserverSetup) {
         self.isVolumeObserverSetup = YES;
-        [[AVAudioSession sharedInstance] setActive:YES error:nil];
+        // Note: intentionally not calling `setActive:YES` here. Activating the shared audio session
+        // is a synchronous call that can block the main thread and interrupts audio already playing
+        // in other apps, even though this is only needed to observe `outputVolume` via KVO, which
+        // works without activating the session.
         [[AVAudioSession sharedInstance] addObserver:self
                                           forKeyPath:KeyPathOutputVolume
                                              options:NSKeyValueObservingOptionNew


### PR DESCRIPTION
## Summary

Fixes #1329.

`PBMVideoView` and `PBMWebView` both called `[AVAudioSession.sharedInstance setActive:YES error:nil]` immediately before attaching a KVO observer on `outputVolume`, purely to observe device volume — not to play audio.

This causes two problems:
1. **Main-thread stall.** `setActive:` is a synchronous XPC round-trip to `mediaserverd` and can block the main thread during ad setup.
2. **Unsolicited interruption of other apps' audio.** Activating the session interrupts audio already playing in other apps, even though these creatives default to muted autoplay and never produce sound.

`outputVolume` is readable and KVO-observable without calling `setActive:`, so this removes the `setActive:YES` call in both places while keeping the observer registration (and the interruption-notification observer in `PBMWebView`) intact. The audio session still activates normally once the ad actually begins audible playback (standard `AVPlayer`/`WKWebView` behavior), so audible video/MRAID ads are unaffected.

## Changes

- `PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMVideoView.m` — removed `setActive:YES` in `setupObserversWithPlayerItem:`
- `PrebidMobile/Objc/PrebidMobileRendering/AdTypes/AdView/PBMWebView.m` — removed `setActive:YES` in `setupVolumeObserver`

## Test plan

- [x] `xcodebuild build-for-testing` succeeds for `PrebidMobileTests`
- [x] Ran `PBMWebViewTest`, `PBMVideoViewTest`, `PBMVideoViewPlaybackStateTest` — no new failures introduced (one pre-existing, unrelated failure in `testAudioVolumeChange` reproduces identically on unmodified `master`)
- [x] Confirmed via `grep` that these were the only two `setActive` call sites in the SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)